### PR TITLE
fix: resolve duplicate nodes and improve mermaid diagram layout

### DIFF
--- a/internal/doc/generate.go
+++ b/internal/doc/generate.go
@@ -257,7 +257,7 @@ func writeMermaidDiagram(b *strings.Builder, c *contract.Contract, gr *graph.Res
 	fmt.Fprintln(b, "## Architecture")
 	fmt.Fprintln(b)
 	fmt.Fprintln(b, "```mermaid")
-	fmt.Fprintln(b, "graph LR")
+	fmt.Fprintln(b, "graph TB")
 
 	allContracts := collectAllContracts(c, gr)
 
@@ -278,12 +278,26 @@ func writeMermaidDiagram(b *strings.Builder, c *contract.Contract, gr *graph.Res
 }
 
 func collectAllContracts(c *contract.Contract, gr *graph.Result) []*contract.Contract {
-	all := []*contract.Contract{c}
-	if gr != nil && gr.Root != nil {
-		for _, node := range collectUniqueNodes(gr.Root) {
-			if node.Contract != nil {
-				all = append(all, node.Contract)
+	if gr == nil || gr.Root == nil {
+		return []*contract.Contract{c}
+	}
+	// BFS by depth so Mermaid renders services in natural layers (root → leaves).
+	var all []*contract.Contract
+	seen := map[string]bool{}
+	queue := []*graph.Node{gr.Root}
+	seen[gr.Root.Name] = true
+	for len(queue) > 0 {
+		node := queue[0]
+		queue = queue[1:]
+		if node.Contract != nil {
+			all = append(all, node.Contract)
+		}
+		for _, edge := range node.Dependencies {
+			if edge.Node == nil || edge.Shared || seen[edge.Node.Name] {
+				continue
 			}
+			seen[edge.Node.Name] = true
+			queue = append(queue, edge.Node)
 		}
 	}
 	return all
@@ -364,27 +378,6 @@ func writeServiceSubgraph(b *strings.Builder, c *contract.Contract, hasExternal 
 	}
 }
 
-func collectUniqueNodes(root *graph.Node) []*graph.Node {
-	var nodes []*graph.Node
-	seen := map[string]bool{}
-	walkCollectNodes(root, seen, &nodes)
-	return nodes
-}
-
-func walkCollectNodes(node *graph.Node, seen map[string]bool, nodes *[]*graph.Node) {
-	if node == nil {
-		return
-	}
-	for _, edge := range node.Dependencies {
-		if edge.Node == nil || edge.Shared || seen[edge.Node.Name] {
-			continue
-		}
-		seen[edge.Node.Name] = true
-		*nodes = append(*nodes, edge.Node)
-		walkCollectNodes(edge.Node, seen, nodes)
-	}
-}
-
 func writeMermaidEdges(b *strings.Builder, node *graph.Node) {
 	seen := map[string]bool{}
 	walkMermaidEdges(b, node, seen)
@@ -398,12 +391,14 @@ func walkMermaidEdges(b *strings.Builder, node *graph.Node, seen map[string]bool
 		if edge.Node == nil {
 			continue
 		}
-		key := node.Name + "-->" + edge.Node.Name
+		fromID := sanitizeMermaidID(node.Name)
+		toID := sanitizeMermaidID(edge.Node.Name)
+		key := fromID + "-->" + toID
 		if seen[key] {
 			continue
 		}
 		seen[key] = true
-		fmt.Fprintf(b, "  %s --> %s\n", node.Name, edge.Node.Name)
+		fmt.Fprintf(b, "  %s --> %s\n", fromID, toID)
 		if !edge.Shared {
 			walkMermaidEdges(b, edge.Node, seen)
 		}

--- a/internal/doc/generate_test.go
+++ b/internal/doc/generate_test.go
@@ -729,7 +729,7 @@ func TestWriteMermaidDiagram_WithGraphResult(t *testing.T) {
 
 	mustContain := []string{
 		"```mermaid",
-		"graph LR",
+		"graph TB",
 		// Root subgraph
 		`subgraph frontend["frontend v1.0.0"]`,
 		`external(["External User"])`,
@@ -835,10 +835,12 @@ func TestWalkMermaidEdges_NilNode(t *testing.T) {
 	}
 }
 
-func TestWalkCollectNodes_NilNode(t *testing.T) {
-	var nodes []*graph.Node
-	walkCollectNodes(nil, map[string]bool{}, &nodes)
-	if len(nodes) != 0 {
-		t.Errorf("expected no nodes for nil input, got %d", len(nodes))
+func TestCollectAllContracts_NilGraph(t *testing.T) {
+	c := &contract.Contract{
+		Service: contract.ServiceIdentity{Name: "svc", Version: "1.0.0"},
+	}
+	all := collectAllContracts(c, nil)
+	if len(all) != 1 || all[0].Service.Name != "svc" {
+		t.Errorf("expected single contract for nil graph, got %d", len(all))
 	}
 }


### PR DESCRIPTION
## Summary
- **Fix duplicate nodes**: Edge IDs in `walkMermaidEdges` now use `sanitizeMermaidID` to match subgraph IDs, preventing Mermaid from creating implicit duplicate nodes for hyphenated service names (e.g., `em-runtime-governance`)
- **Improve layout**: Switched diagram direction from `graph LR` to `graph TB` for cleaner top-down layered rendering of dependency trees
- **BFS collection**: Replaced DFS node collection with BFS so subgraphs are emitted in natural depth layers (root → direct deps → transitive deps → leaves)

## Test plan
- [x] `go test ./...` — all pass
- [x] `go test ./internal/doc/... -cover` — 100% statement coverage
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [x] Verified visually with a 9-service dependency graph (em-runtime)