### PR TITLE
fix: resolve $ref in config schemas and support JSON OpenAPI specs

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CP
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
+golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -85,6 +87,8 @@ golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=
 golang.org/x/term v0.40.0/go.mod h1:w2P8uVp06p2iyKKuvXIm7N/y0UCRt3UfJTfZ7oOpglM=
 golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
 golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
+golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=
+golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/doc/openapi.go
+++ b/internal/doc/openapi.go
@@ -1,9 +1,11 @@
 package doc
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"sort"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -27,16 +29,16 @@ var httpMethodOrder = map[string]int{
 	"trace":   7,
 }
 
-// readOpenAPIEndpoints parses an OpenAPI YAML file and returns its endpoints
-// sorted by path (alphabetically) then by HTTP method order.
+// readOpenAPIEndpoints parses an OpenAPI spec (YAML or JSON) and returns its
+// endpoints sorted by path (alphabetically) then by HTTP method order.
 func readOpenAPIEndpoints(fsys fs.FS, path string) ([]Endpoint, error) {
 	data, err := fs.ReadFile(fsys, path)
 	if err != nil {
 		return nil, fmt.Errorf("reading OpenAPI spec %s: %w", path, err)
 	}
 
-	var spec map[string]any
-	if err := yaml.Unmarshal(data, &spec); err != nil {
+	spec, err := unmarshalSpec(data, path)
+	if err != nil {
 		return nil, fmt.Errorf("parsing OpenAPI spec %s: %w", path, err)
 	}
 
@@ -59,40 +61,50 @@ func readOpenAPIEndpoints(fsys fs.FS, path string) ([]Endpoint, error) {
 
 	var endpoints []Endpoint
 	for _, p := range pathKeys {
-		methods, ok := paths[p].(map[string]any)
-		if !ok {
-			continue
-		}
-
-		// Collect HTTP methods for this path, sorted by standard order.
-		var methodKeys []string
-		for m := range methods {
-			if _, isHTTP := httpMethodOrder[m]; isHTTP {
-				methodKeys = append(methodKeys, m)
-			}
-		}
-		sort.Slice(methodKeys, func(i, j int) bool {
-			return httpMethodOrder[methodKeys[i]] < httpMethodOrder[methodKeys[j]]
-		})
-
-		for _, m := range methodKeys {
-			op, ok := methods[m].(map[string]any)
-			if !ok {
-				continue
-			}
-
-			ep := Endpoint{
-				Method: m,
-				Path:   p,
-			}
-
-			if summary, ok := op["summary"].(string); ok {
-				ep.Summary = summary
-			}
-
-			endpoints = append(endpoints, ep)
-		}
+		endpoints = append(endpoints, extractPathEndpoints(p, paths[p])...)
 	}
 
 	return endpoints, nil
+}
+
+// extractPathEndpoints returns the endpoints for a single OpenAPI path entry,
+// sorted by standard HTTP method order.
+func extractPathEndpoints(path string, raw any) []Endpoint {
+	methods, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	var methodKeys []string
+	for m := range methods {
+		if _, isHTTP := httpMethodOrder[m]; isHTTP {
+			methodKeys = append(methodKeys, m)
+		}
+	}
+	sort.Slice(methodKeys, func(i, j int) bool {
+		return httpMethodOrder[methodKeys[i]] < httpMethodOrder[methodKeys[j]]
+	})
+
+	var endpoints []Endpoint
+	for _, m := range methodKeys {
+		op, ok := methods[m].(map[string]any)
+		if !ok {
+			continue
+		}
+		ep := Endpoint{Method: m, Path: path}
+		if summary, ok := op["summary"].(string); ok {
+			ep.Summary = summary
+		}
+		endpoints = append(endpoints, ep)
+	}
+	return endpoints
+}
+
+// unmarshalSpec parses an OpenAPI spec as JSON (for .json files) or YAML.
+func unmarshalSpec(data []byte, path string) (map[string]any, error) {
+	var spec map[string]any
+	if strings.HasSuffix(path, ".json") {
+		return spec, json.Unmarshal(data, &spec)
+	}
+	return spec, yaml.Unmarshal(data, &spec)
 }

--- a/internal/doc/openapi_test.go
+++ b/internal/doc/openapi_test.go
@@ -193,6 +193,50 @@ func TestReadOpenAPIEndpoints_InvalidYAML(t *testing.T) {
 	}
 }
 
+func TestReadOpenAPIEndpoints_JSONFormat(t *testing.T) {
+	spec := `{
+  "openapi": "3.0.0",
+  "paths": {
+    "/health": {
+      "get": { "summary": "Health check" }
+    },
+    "/items": {
+      "get": { "summary": "List items" },
+      "post": { "summary": "Create item" }
+    }
+  }
+}`
+	fsys := fstest.MapFS{
+		"openapi.json": &fstest.MapFile{Data: []byte(spec)},
+	}
+
+	endpoints, err := readOpenAPIEndpoints(fsys, "openapi.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(endpoints) != 3 {
+		t.Fatalf("expected 3 endpoints, got %d", len(endpoints))
+	}
+	if endpoints[0].Path != "/health" || endpoints[0].Method != "get" {
+		t.Errorf("expected GET /health first, got %s %s", endpoints[0].Method, endpoints[0].Path)
+	}
+	if endpoints[1].Path != "/items" || endpoints[1].Method != "get" {
+		t.Errorf("expected GET /items second, got %s %s", endpoints[1].Method, endpoints[1].Path)
+	}
+}
+
+func TestReadOpenAPIEndpoints_InvalidJSON(t *testing.T) {
+	fsys := fstest.MapFS{
+		"bad.json": &fstest.MapFile{Data: []byte("{invalid json")},
+	}
+
+	_, err := readOpenAPIEndpoints(fsys, "bad.json")
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
 func TestReadOpenAPIEndpoints_MethodOrder(t *testing.T) {
 	spec := `
 openapi: "3.0.0"

--- a/internal/doc/schema.go
+++ b/internal/doc/schema.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"io/fs"
 	"sort"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 // Property represents a configuration property extracted from a JSON Schema.
@@ -16,55 +19,72 @@ type Property struct {
 	Required    bool
 }
 
-// readSchemaProperties parses a JSON Schema file and returns its top-level properties.
+// readSchemaProperties compiles a JSON Schema file using the jsonschema library
+// and extracts its top-level properties. All $ref pointers ($ref, $defs,
+// definitions, nested chains, etc.) are resolved automatically by the compiler.
 func readSchemaProperties(fsys fs.FS, path string) ([]Property, error) {
 	data, err := fs.ReadFile(fsys, path)
 	if err != nil {
 		return nil, fmt.Errorf("reading schema %s: %w", path, err)
 	}
 
-	var schema struct {
-		Properties map[string]struct {
-			Type        string `json:"type"`
-			Description string `json:"description"`
-			Default     any    `json:"default"`
-		} `json:"properties"`
-		Required []string `json:"required"`
-	}
-
-	if err := json.Unmarshal(data, &schema); err != nil {
+	var doc any
+	if err := json.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("parsing schema %s: %w", path, err)
 	}
 
-	if len(schema.Properties) == 0 {
-		return nil, nil
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource(path, doc); err != nil {
+		return nil, fmt.Errorf("compiling schema %s: %w", path, err)
+	}
+	sch, err := c.Compile(path)
+	if err != nil {
+		return nil, fmt.Errorf("compiling schema %s: %w", path, err)
 	}
 
-	requiredSet := make(map[string]bool, len(schema.Required))
-	for _, r := range schema.Required {
+	// Follow $ref if the root schema is a reference.
+	resolved := sch
+	for resolved.Ref != nil {
+		resolved = resolved.Ref
+	}
+
+	return extractProperties(resolved), nil
+}
+
+// extractProperties converts a compiled JSON Schema's properties into a sorted
+// slice of Property values.
+func extractProperties(sch *jsonschema.Schema) []Property {
+	if len(sch.Properties) == 0 {
+		return nil
+	}
+
+	requiredSet := make(map[string]bool, len(sch.Required))
+	for _, r := range sch.Required {
 		requiredSet[r] = true
 	}
 
-	names := make([]string, 0, len(schema.Properties))
-	for name := range schema.Properties {
+	names := make([]string, 0, len(sch.Properties))
+	for name := range sch.Properties {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 
 	props := make([]Property, 0, len(names))
 	for _, name := range names {
-		p := schema.Properties[name]
+		p := sch.Properties[name]
 		prop := Property{
 			Name:        name,
-			Type:        p.Type,
-			Description: p.Description,
 			Required:    requiredSet[name],
+			Description: p.Description,
+		}
+		if p.Types != nil {
+			prop.Type = strings.Join(p.Types.ToStrings(), ", ")
 		}
 		if p.Default != nil {
-			prop.Default = fmt.Sprintf("%v", p.Default)
+			prop.Default = fmt.Sprintf("%v", *p.Default)
 		}
 		props = append(props, prop)
 	}
 
-	return props, nil
+	return props
 }

--- a/internal/doc/schema_test.go
+++ b/internal/doc/schema_test.go
@@ -1,8 +1,11 @@
 package doc
 
 import (
+	"io"
+	"io/fs"
 	"testing"
 	"testing/fstest"
+	"time"
 )
 
 func TestReadSchemaProperties_Basic(t *testing.T) {
@@ -124,5 +127,128 @@ func TestReadSchemaProperties_InvalidJSON(t *testing.T) {
 	_, err := readSchemaProperties(fsys, "bad.json")
 	if err == nil {
 		t.Error("expected error for invalid JSON")
+	}
+}
+
+// staticFS serves the same content for any path, bypassing fs.ValidPath checks.
+type staticFS struct{ data []byte }
+
+func (f staticFS) Open(name string) (fs.File, error) {
+	return &staticFile{data: f.data}, nil
+}
+
+type staticFile struct {
+	data   []byte
+	offset int
+}
+
+func (f *staticFile) Stat() (fs.FileInfo, error) {
+	return staticFileInfo{size: int64(len(f.data))}, nil
+}
+func (f *staticFile) Read(b []byte) (int, error) {
+	if f.offset >= len(f.data) {
+		return 0, io.EOF
+	}
+	n := copy(b, f.data[f.offset:])
+	f.offset += n
+	return n, nil
+}
+func (f *staticFile) Close() error { return nil }
+
+type staticFileInfo struct{ size int64 }
+
+func (fi staticFileInfo) Name() string       { return "schema.json" }
+func (fi staticFileInfo) Size() int64        { return fi.size }
+func (fi staticFileInfo) Mode() fs.FileMode  { return 0o444 }
+func (fi staticFileInfo) ModTime() time.Time { return time.Time{} }
+func (fi staticFileInfo) IsDir() bool        { return false }
+func (fi staticFileInfo) Sys() any           { return nil }
+
+func TestReadSchemaProperties_InvalidResourceURL(t *testing.T) {
+	fsys := staticFS{data: []byte(`{"type": "object"}`)}
+
+	_, err := readSchemaProperties(fsys, "://invalid")
+	if err == nil {
+		t.Error("expected error for invalid resource URL")
+	}
+}
+
+func TestReadSchemaProperties_RefDefinition(t *testing.T) {
+	schema := `{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$ref": "#/definitions/Config",
+  "definitions": {
+    "Config": {
+      "type": "object",
+      "properties": {
+        "log_level": {
+          "type": "string",
+          "description": "Logging level"
+        },
+        "port": {
+          "type": "integer",
+          "description": "Server port",
+          "default": 8080
+        }
+      },
+      "required": ["port"]
+    }
+  }
+}`
+	fsys := fstest.MapFS{
+		"schema.json": &fstest.MapFile{Data: []byte(schema)},
+	}
+
+	props, err := readSchemaProperties(fsys, "schema.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(props) != 2 {
+		t.Fatalf("expected 2 properties, got %d", len(props))
+	}
+	// Sorted: log_level, port
+	if props[0].Name != "log_level" {
+		t.Errorf("expected log_level, got %s", props[0].Name)
+	}
+	if props[0].Required {
+		t.Error("log_level should not be required")
+	}
+	if props[1].Name != "port" {
+		t.Errorf("expected port, got %s", props[1].Name)
+	}
+	if !props[1].Required {
+		t.Error("port should be required")
+	}
+	if props[1].Default != "8080" {
+		t.Errorf("expected default 8080, got %s", props[1].Default)
+	}
+}
+
+func TestReadSchemaProperties_RefMissingDefinition(t *testing.T) {
+	schema := `{
+  "$ref": "#/definitions/Missing",
+  "definitions": {}
+}`
+	fsys := fstest.MapFS{
+		"schema.json": &fstest.MapFile{Data: []byte(schema)},
+	}
+
+	_, err := readSchemaProperties(fsys, "schema.json")
+	if err == nil {
+		t.Error("expected error for missing $ref definition")
+	}
+}
+
+func TestReadSchemaProperties_RefNonLocalIgnored(t *testing.T) {
+	schema := `{
+  "$ref": "https://example.com/schema.json"
+}`
+	fsys := fstest.MapFS{
+		"schema.json": &fstest.MapFile{Data: []byte(schema)},
+	}
+
+	_, err := readSchemaProperties(fsys, "schema.json")
+	if err == nil {
+		t.Error("expected error for unresolvable external $ref")
 	}
 }


### PR DESCRIPTION
## Summary
- **$ref resolution in configuration schemas**: Use the `santhosh-tekuri/jsonschema` compiler to resolve all `$ref` patterns (`#/definitions/X`, `#/$defs/X`, nested chains, etc.) instead of only reading root-level properties. This fixes `pacto doc` not displaying the configuration section for schemas that use `$ref` indirection.
- **JSON OpenAPI support**: `readOpenAPIEndpoints` now explicitly handles `.json` OpenAPI specs using `encoding/json`, alongside existing YAML support.

## Test plan
- [x] `TestReadSchemaProperties_RefDefinition` — resolves `$ref` to `#/definitions/Config`
- [x] `TestReadSchemaProperties_RefMissingDefinition` — rejects unresolvable `$ref`
- [x] `TestReadSchemaProperties_RefNonLocalIgnored` — rejects external `$ref` URLs
- [x] `TestReadSchemaProperties_InvalidResourceURL` — rejects invalid resource URLs
- [x] `TestReadOpenAPIEndpoints_JSONFormat` — parses JSON OpenAPI spec
- [x] `TestReadOpenAPIEndpoints_InvalidJSON` — rejects malformed JSON
- [x] 100% test coverage on `internal/doc`
- [x] All tests pass (`go test ./...` and `go test -tags=e2e ./tests/e2e/`)
- [x] gofmt, go vet, gocyclo, golangci-lint clean