### PR TITLE
fix: flatten nested $ref properties in configuration schema

### DIFF
--- a/internal/doc/schema.go
+++ b/internal/doc/schema.go
@@ -42,18 +42,21 @@ func readSchemaProperties(fsys fs.FS, path string) ([]Property, error) {
 		return nil, fmt.Errorf("compiling schema %s: %w", path, err)
 	}
 
-	// Follow $ref if the root schema is a reference.
-	resolved := sch
-	for resolved.Ref != nil {
-		resolved = resolved.Ref
-	}
-
-	return extractProperties(resolved), nil
+	return flattenProperties("", resolveRef(sch)), nil
 }
 
-// extractProperties converts a compiled JSON Schema's properties into a sorted
-// slice of Property values.
-func extractProperties(sch *jsonschema.Schema) []Property {
+// resolveRef follows $ref pointers to reach the underlying schema.
+func resolveRef(s *jsonschema.Schema) *jsonschema.Schema {
+	for s.Ref != nil {
+		s = s.Ref
+	}
+	return s
+}
+
+// flattenProperties recursively collects properties from a schema, prefixing
+// nested property names with their parent path using dot notation
+// (e.g. "postgres.host").
+func flattenProperties(prefix string, sch *jsonschema.Schema) []Property {
 	if len(sch.Properties) == 0 {
 		return nil
 	}
@@ -69,11 +72,19 @@ func extractProperties(sch *jsonschema.Schema) []Property {
 	}
 	sort.Strings(names)
 
-	props := make([]Property, 0, len(names))
+	var props []Property
 	for _, name := range names {
-		p := sch.Properties[name]
+		p := resolveRef(sch.Properties[name])
+		fullName := prefix + name
+
+		// If the property is an object with its own properties, recurse.
+		if len(p.Properties) > 0 {
+			props = append(props, flattenProperties(fullName+".", p)...)
+			continue
+		}
+
 		prop := Property{
-			Name:        name,
+			Name:        fullName,
 			Required:    requiredSet[name],
 			Description: p.Description,
 		}

--- a/internal/doc/schema_test.go
+++ b/internal/doc/schema_test.go
@@ -224,6 +224,126 @@ func TestReadSchemaProperties_RefDefinition(t *testing.T) {
 	}
 }
 
+func TestReadSchemaProperties_NestedRefProperties(t *testing.T) {
+	schema := `{
+  "$ref": "#/definitions/Config",
+  "definitions": {
+    "Config": {
+      "type": "object",
+      "properties": {
+        "log_level": {
+          "type": "string",
+          "description": "Logging level"
+        },
+        "postgres": {
+          "$ref": "#/definitions/Postgres"
+        }
+      },
+      "required": ["postgres"]
+    },
+    "Postgres": {
+      "type": "object",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Database host"
+        },
+        "port": {
+          "type": "integer",
+          "description": "Database port",
+          "default": 5432
+        }
+      },
+      "required": ["host"]
+    }
+  }
+}`
+	fsys := fstest.MapFS{
+		"schema.json": &fstest.MapFile{Data: []byte(schema)},
+	}
+
+	props, err := readSchemaProperties(fsys, "schema.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(props) != 3 {
+		t.Fatalf("expected 3 properties, got %d", len(props))
+	}
+
+	// Sorted: log_level, postgres.host, postgres.port
+	want := []Property{
+		{Name: "log_level", Type: "string", Description: "Logging level", Required: false},
+		{Name: "postgres.host", Type: "string", Description: "Database host", Required: true},
+		{Name: "postgres.port", Type: "integer", Description: "Database port", Default: "5432", Required: false},
+	}
+	for i, w := range want {
+		if props[i] != w {
+			t.Errorf("property %d: got %+v, want %+v", i, props[i], w)
+		}
+	}
+}
+
+func TestReadSchemaProperties_DeeplyNestedRefProperties(t *testing.T) {
+	schema := `{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string", "description": "Service name" },
+    "database": { "$ref": "#/definitions/Database" }
+  },
+  "required": ["name", "database"],
+  "definitions": {
+    "Database": {
+      "type": "object",
+      "properties": {
+        "primary": { "$ref": "#/definitions/Connection" },
+        "pool_size": { "type": "integer", "default": 10 }
+      },
+      "required": ["primary"]
+    },
+    "Connection": {
+      "type": "object",
+      "properties": {
+        "host": { "type": "string", "description": "Hostname" },
+        "tls": { "$ref": "#/definitions/TLS" }
+      },
+      "required": ["host", "tls"]
+    },
+    "TLS": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "cert_path": { "type": "string" }
+      },
+      "required": ["enabled"]
+    }
+  }
+}`
+	fsys := fstest.MapFS{
+		"schema.json": &fstest.MapFile{Data: []byte(schema)},
+	}
+
+	props, err := readSchemaProperties(fsys, "schema.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []Property{
+		{Name: "database.pool_size", Type: "integer", Default: "10"},
+		{Name: "database.primary.host", Type: "string", Description: "Hostname", Required: true},
+		{Name: "database.primary.tls.cert_path", Type: "string"},
+		{Name: "database.primary.tls.enabled", Type: "boolean", Default: "true", Required: true},
+		{Name: "name", Type: "string", Description: "Service name", Required: true},
+	}
+	if len(props) != len(want) {
+		t.Fatalf("expected %d properties, got %d: %+v", len(want), len(props), props)
+	}
+	for i, w := range want {
+		if props[i] != w {
+			t.Errorf("property %d: got %+v, want %+v", i, props[i], w)
+		}
+	}
+}
+
 func TestReadSchemaProperties_RefMissingDefinition(t *testing.T) {
 	schema := `{
   "$ref": "#/definitions/Missing",


### PR DESCRIPTION
## Summary
- Recursively resolve `$ref` properties that point to nested objects and flatten them using dot notation (e.g. `postgres.host`, `cors.enabled`)
- This fixes `pacto doc` not displaying nested configuration items for schemas that use `$ref` to define sub-objects (like em-runtime-assets)

## Test plan
- [x] `TestReadSchemaProperties_NestedRefProperties` — flattens `postgres.host` and `postgres.port` from `$ref` to `#/definitions/Postgres`
- [x] All existing tests pass
- [x] 100% test coverage on `internal/doc`
- [x] e2e tests pass
- [x] gofmt, go vet, gocyclo, golangci-lint clean