### PR TITLE
fix: fail install script on download errors

### DIFF
--- a/scripts/get-pacto.sh
+++ b/scripts/get-pacto.sh
@@ -91,7 +91,7 @@ downloadFile() {
   tmp="$(mktemp -d)"
   target="$tmp/$filename"
   if [ "$HAS_CURL" = "true" ]; then
-    curl -sSL "$url" -o "$target"
+    curl -fsSL "$url" -o "$target"
   else
     wget -qO "$target" "$url"
   fi


### PR DESCRIPTION
## Summary
- Add `-f` flag to curl in the download step so HTTP errors (e.g. 404 when release assets haven't finished uploading) cause the script to abort instead of silently saving the error page as the binary

## Root cause
When installing right after a release is created, the GitHub Actions workflow may not have finished uploading assets yet. `curl -sSL` follows the redirect to a 404 page and saves its content as the "binary", resulting in a broken install (`/usr/local/bin/pacto: line 1: Not: command not found`).