### PR TITLE
docs: simplify GitHub Actions documentation

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -252,7 +252,7 @@ Changes (2):
 Integrate `pacto diff` into your CI pipeline to block merges that introduce breaking changes.
 
 {: .tip }
-Using GitHub Actions? The official [Pacto CLI action]({{ site.baseurl }}{% link github-actions.md %}) wraps `setup`, `diff`, and `push` into a single reusable action.
+Using GitHub Actions? Check out the official [Pacto CLI action]({{ site.baseurl }}{% link github-actions.md %}).
 
 ---
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -11,19 +11,6 @@ Automate contract validation, breaking-change detection, and publishing in your 
 
 ---
 
-## Overview
+## Getting Started
 
-The [TrianaLab/pacto-actions](https://github.com/TrianaLab/pacto-actions) action provides three commands through a single reusable action:
-
-| Command | Purpose |
-|---------|---------|
-| `setup` | Install the Pacto CLI binary |
-| `diff` | Compare two contracts and detect breaking changes |
-| `push` | Push contracts to an OCI registry |
-
-After `setup`, the `pacto` binary is available for subsequent steps — so you can call any CLI command (like `pacto validate`) directly.
-
-For usage examples, inputs, outputs, and advanced configuration see:
-
-- [Pacto CLI on GitHub Marketplace](https://github.com/marketplace/actions/pacto-cli)
-- [pacto-actions README](https://github.com/TrianaLab/pacto-actions)
+For usage examples, available commands, inputs, outputs, and advanced configuration see the [pacto-actions](https://github.com/TrianaLab/pacto-actions) repository.

--- a/docs/platform-engineers.md
+++ b/docs/platform-engineers.md
@@ -193,7 +193,7 @@ steps:
 ```
 
 {: .tip }
-Using GitHub Actions? The official [Pacto CLI action]({{ site.baseurl }}{% link github-actions.md %}) wraps `setup`, `diff`, and `push` into a single reusable action.
+Using GitHub Actions? Check out the official [Pacto CLI action]({{ site.baseurl }}{% link github-actions.md %}).
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove implementation details (commands table, usage specifics) from GitHub Actions docs to avoid maintaining them in both this repo and [pacto-actions](https://github.com/TrianaLab/pacto-actions)
- Simplify references in developers and platform-engineers docs to just link to the GitHub Actions page without listing specific commands