### PR TITLE
perf: cache ListTags results in memory to avoid redundant registry calls

### DIFF
--- a/docs/contract-reference.md
+++ b/docs/contract-reference.md
@@ -219,7 +219,19 @@ Declares dependencies on other services via their Pacto contracts.
 | `file://` | `file://../shared-db` | Local filesystem path |
 | *(bare path)* | `../shared-db` | Local filesystem path (shorthand for `file://`) |
 
-When an `oci://` reference omits the tag, pacto queries the registry for available tags and selects the highest semver version that satisfies the `compatibility` constraint. For example, with `compatibility: "^2.0.0"` and available tags `1.0.0`, `2.0.0`, `2.3.0`, `3.0.0`, pacto resolves to `2.3.0`.
+When an `oci://` reference omits the tag, pacto queries the registry for available tags and selects the highest semver version that satisfies the `compatibility` constraint. For example, with `compatibility: "^2.0.0"` and available tags `1.0.0`, `2.0.0`, `2.3.0`, `3.0.0`, pacto resolves to `2.3.0`. Tag listings are cached in memory for the duration of the command, so multiple dependencies pointing to the same repository only trigger a single registry query.
+
+#### Compatibility constraint examples
+
+Pacto uses [Masterminds/semver](https://github.com/Masterminds/semver#checking-version-constraints) constraint syntax:
+
+| Constraint | Matches | Use case |
+|------------|---------|----------|
+| `^2.0.0` | `>= 2.0.0`, `< 3.0.0` | Accept patches and minors within a major version |
+| `~2.1.0` | `>= 2.1.0`, `< 2.2.0` | Accept only patches within a minor version |
+| `>= 2.0.0` | `2.0.0` and above (including `3.x`, `4.x`, …) | Track the latest version above a floor |
+| `>= 2.0.0, < 4.0.0` | `2.x` and `3.x` only | Constrain to a range of major versions |
+| `*` | Any version | Always resolve to the absolute latest |
 
 {: .warning }
 Local dependency references (`file://` and bare paths) are only allowed during development. `pacto push` rejects contracts with local dependencies — all refs must use `oci://` before publishing.

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -263,5 +263,5 @@ Using GitHub Actions? Check out the official [Pacto CLI action]({{ site.baseurl 
 - **Keep interface contracts up to date.** OpenAPI specs and protobuf definitions in the bundle should match what your service actually serves.
 - **Use `pacto explain` to review.** It produces a human-readable summary of your contract.
 - **Use `pacto doc` for rich documentation.** It generates Markdown with architecture diagrams and interface tables. Use `--serve` to view it in the browser.
-- **Leverage caching.** OCI bundles are cached locally in `~/.cache/pacto/oci/`, so repeated `graph`, `doc`, and `diff` commands resolve instantly. Use `--no-cache` to force a fresh pull.
+- **Leverage caching.** OCI bundles are cached locally in `~/.cache/pacto/oci/` and tag listings are cached in memory per command, so repeated `graph`, `doc`, and `diff` commands resolve instantly. Use `--no-cache` to force a fresh pull.
 - **Use metadata for organizational context.** Team ownership, on-call channels, and service tiers go in `metadata`.

--- a/internal/oci/cache.go
+++ b/internal/oci/cache.go
@@ -6,15 +6,20 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/trianalab/pacto/pkg/contract"
 )
 
-// CachedStore wraps a BundleStore with local disk caching for Pull operations.
-// Bundles are cached by OCI reference under ~/.cache/pacto/oci/.
+// CachedStore wraps a BundleStore with local disk caching for Pull operations
+// and in-memory caching for ListTags. Bundles are cached by OCI reference
+// under ~/.cache/pacto/oci/.
 type CachedStore struct {
 	inner    BundleStore
 	cacheDir string
+
+	tagsMu    sync.Mutex
+	tagsCache map[string][]string
 }
 
 // NewCachedStore creates a BundleStore that caches pulled bundles on disk.
@@ -24,7 +29,7 @@ func NewCachedStore(inner BundleStore) *CachedStore {
 	if err != nil {
 		dir = ""
 	}
-	return &CachedStore{inner: inner, cacheDir: dir}
+	return &CachedStore{inner: inner, cacheDir: dir, tagsCache: map[string][]string{}}
 }
 
 // DisableCache turns off caching so all operations go directly to the registry.
@@ -53,7 +58,23 @@ func (c *CachedStore) Resolve(ctx context.Context, ref string) (string, error) {
 }
 
 func (c *CachedStore) ListTags(ctx context.Context, repo string) ([]string, error) {
-	return c.inner.ListTags(ctx, repo)
+	c.tagsMu.Lock()
+	if cached, ok := c.tagsCache[repo]; ok {
+		c.tagsMu.Unlock()
+		return cached, nil
+	}
+	c.tagsMu.Unlock()
+
+	tags, err := c.inner.ListTags(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	c.tagsMu.Lock()
+	c.tagsCache[repo] = tags
+	c.tagsMu.Unlock()
+
+	return tags, nil
 }
 
 func (c *CachedStore) Pull(ctx context.Context, ref string) (*contract.Bundle, error) {

--- a/internal/oci/cache_test.go
+++ b/internal/oci/cache_test.go
@@ -17,9 +17,12 @@ import (
 )
 
 type countingStore struct {
-	pullCount atomic.Int32
-	pullErr   error
-	bundle    *contract.Bundle
+	pullCount      atomic.Int32
+	listTagsCount  atomic.Int32
+	pullErr        error
+	listTagsErr    error
+	listTagsResult []string
+	bundle         *contract.Bundle
 }
 
 func (s *countingStore) Push(context.Context, string, *contract.Bundle) (string, error) {
@@ -39,7 +42,11 @@ func (s *countingStore) Pull(_ context.Context, _ string) (*contract.Bundle, err
 }
 
 func (s *countingStore) ListTags(_ context.Context, _ string) ([]string, error) {
-	return nil, nil
+	s.listTagsCount.Add(1)
+	if s.listTagsErr != nil {
+		return nil, s.listTagsErr
+	}
+	return s.listTagsResult, nil
 }
 
 func newCachedStoreWithTempDir(t *testing.T) (*oci.CachedStore, *countingStore) {
@@ -368,6 +375,85 @@ func TestCachedStore_Pull_ReadOnlyCacheDirIgnored(t *testing.T) {
 	}
 	if b.Contract.Service.Name != "test-svc" {
 		t.Errorf("got name %q, want test-svc", b.Contract.Service.Name)
+	}
+}
+
+func TestCachedStore_ListTags_CachesInMemory(t *testing.T) {
+	inner := &countingStore{
+		bundle:         newTestBundle(),
+		listTagsResult: []string{"1.0.0", "1.1.0", "2.0.0"},
+	}
+	store := oci.NewCachedStore(inner)
+	ctx := context.Background()
+	repo := "ghcr.io/test/repo"
+
+	tags1, err := store.ListTags(ctx, repo)
+	if err != nil {
+		t.Fatalf("first ListTags() error: %v", err)
+	}
+	if len(tags1) != 3 {
+		t.Fatalf("expected 3 tags, got %d", len(tags1))
+	}
+
+	tags2, err := store.ListTags(ctx, repo)
+	if err != nil {
+		t.Fatalf("second ListTags() error: %v", err)
+	}
+	if len(tags2) != 3 {
+		t.Fatalf("expected 3 tags, got %d", len(tags2))
+	}
+
+	if inner.listTagsCount.Load() != 1 {
+		t.Errorf("expected 1 inner ListTags call, got %d", inner.listTagsCount.Load())
+	}
+}
+
+func TestCachedStore_ListTags_DifferentReposMissCache(t *testing.T) {
+	inner := &countingStore{
+		bundle:         newTestBundle(),
+		listTagsResult: []string{"1.0.0"},
+	}
+	store := oci.NewCachedStore(inner)
+	ctx := context.Background()
+
+	if _, err := store.ListTags(ctx, "ghcr.io/test/a"); err != nil {
+		t.Fatalf("ListTags(a) error: %v", err)
+	}
+	if _, err := store.ListTags(ctx, "ghcr.io/test/b"); err != nil {
+		t.Fatalf("ListTags(b) error: %v", err)
+	}
+
+	if inner.listTagsCount.Load() != 2 {
+		t.Errorf("expected 2 inner ListTags calls for different repos, got %d", inner.listTagsCount.Load())
+	}
+}
+
+func TestCachedStore_ListTags_ErrorNotCached(t *testing.T) {
+	inner := &countingStore{
+		bundle:      newTestBundle(),
+		listTagsErr: errors.New("registry error"),
+	}
+	store := oci.NewCachedStore(inner)
+	ctx := context.Background()
+	repo := "ghcr.io/test/repo"
+
+	if _, err := store.ListTags(ctx, repo); err == nil {
+		t.Fatal("expected error from ListTags")
+	}
+
+	// Clear error so second call succeeds.
+	inner.listTagsErr = nil
+	inner.listTagsResult = []string{"1.0.0"}
+
+	tags, err := store.ListTags(ctx, repo)
+	if err != nil {
+		t.Fatalf("second ListTags() error: %v", err)
+	}
+	if len(tags) != 1 {
+		t.Errorf("expected 1 tag, got %d", len(tags))
+	}
+	if inner.listTagsCount.Load() != 2 {
+		t.Errorf("expected 2 inner calls (error not cached), got %d", inner.listTagsCount.Load())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Cache `ListTags` results in memory per repository within `CachedStore`, so tagless OCI dependency resolution only queries the registry once per repo per command invocation
- Errors are not cached, allowing retries on transient failures
- Document compatibility constraint syntax with examples table in contract-reference docs

## Test plan
- [x] `TestCachedStore_ListTags_CachesInMemory` — same repo hits registry only once
- [x] `TestCachedStore_ListTags_DifferentReposMissCache` — different repos each get their own call
- [x] `TestCachedStore_ListTags_ErrorNotCached` — failed calls are retried
- [x] 100% test coverage on `internal/oci`
- [x] `gofmt`, `go vet`, `golangci-lint`, `gocyclo` — all clean
- [x] Full test suite + e2e tests pass