### PR TITLE
feat: recursive dependency diff for transitive contract changes

### DIFF
--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -15,13 +15,21 @@ type DiffOptions struct {
 	NewPath string
 }
 
+// DependencyDiff holds the diff result for a single dependency.
+type DependencyDiff struct {
+	Name           string        `json:"name"`
+	Classification string        `json:"classification"`
+	Changes        []diff.Change `json:"changes"`
+}
+
 // DiffResult holds the result of the diff command.
 type DiffResult struct {
-	OldPath        string           `json:"oldPath"`
-	NewPath        string           `json:"newPath"`
-	Classification string           `json:"classification"`
-	Changes        []diff.Change    `json:"changes"`
-	GraphDiff      *graph.GraphDiff `json:"graphDiff,omitempty"`
+	OldPath         string           `json:"oldPath"`
+	NewPath         string           `json:"newPath"`
+	Classification  string           `json:"classification"`
+	Changes         []diff.Change    `json:"changes"`
+	DependencyDiffs []DependencyDiff `json:"dependencyDiffs,omitempty"`
+	GraphDiff       *graph.GraphDiff `json:"graphDiff,omitempty"`
 }
 
 // Diff compares two contracts and produces a classified change set.
@@ -48,13 +56,63 @@ func (s *Service) Diff(ctx context.Context, opts DiffOptions) (*DiffResult, erro
 	oldGraph := graph.Resolve(ctx, oldBundle.Contract, oldFetcher)
 	newGraph := graph.Resolve(ctx, newBundle.Contract, newFetcher)
 	gd := graph.DiffGraphs(oldGraph, newGraph)
-	slog.Debug("diff complete", "classification", result.Classification.String(), "changes", len(result.Changes))
+
+	// Recursively diff dependency contracts (skip root, already diffed above).
+	rootName := oldBundle.Contract.Service.Name
+	oldNodes := collectNodes(oldGraph.Root)
+	newNodes := collectNodes(newGraph.Root)
+	overall := result.Classification
+	var depDiffs []DependencyDiff
+	for name, newNode := range newNodes {
+		if name == rootName {
+			continue
+		}
+		oldNode, exists := oldNodes[name]
+		if !exists || oldNode.Contract == nil || newNode.Contract == nil {
+			continue
+		}
+		depResult := diff.Compare(oldNode.Contract, newNode.Contract, oldNode.FS, newNode.FS)
+		if len(depResult.Changes) == 0 {
+			continue
+		}
+		if depResult.Classification > overall {
+			overall = depResult.Classification
+		}
+		depDiffs = append(depDiffs, DependencyDiff{
+			Name:           name,
+			Classification: depResult.Classification.String(),
+			Changes:        depResult.Changes,
+		})
+	}
+
+	slog.Debug("diff complete", "classification", overall.String(), "changes", len(result.Changes), "dependencyDiffs", len(depDiffs))
 
 	return &DiffResult{
-		OldPath:        opts.OldPath,
-		NewPath:        opts.NewPath,
-		Classification: result.Classification.String(),
-		Changes:        result.Changes,
-		GraphDiff:      gd,
+		OldPath:         opts.OldPath,
+		NewPath:         opts.NewPath,
+		Classification:  overall.String(),
+		Changes:         result.Changes,
+		DependencyDiffs: depDiffs,
+		GraphDiff:       gd,
 	}, nil
+}
+
+// collectNodes walks the dependency graph and returns all nodes indexed by name.
+func collectNodes(node *graph.Node) map[string]*graph.Node {
+	nodes := make(map[string]*graph.Node)
+	collectNodesRec(node, nodes)
+	return nodes
+}
+
+func collectNodesRec(node *graph.Node, nodes map[string]*graph.Node) {
+	if node == nil {
+		return
+	}
+	if _, seen := nodes[node.Name]; seen {
+		return
+	}
+	nodes[node.Name] = node
+	for _, edge := range node.Dependencies {
+		collectNodesRec(edge.Node, nodes)
+	}
 }

--- a/internal/app/diff_test.go
+++ b/internal/app/diff_test.go
@@ -2,7 +2,11 @@ package app
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/trianalab/pacto/internal/graph"
 )
 
 func TestDiff_LocalFiles(t *testing.T) {
@@ -54,5 +58,207 @@ func TestDiff_OCIRef(t *testing.T) {
 	}
 	if result.Classification == "" {
 		t.Error("expected non-empty classification")
+	}
+}
+
+// writeBundleWithDep creates a parent bundle dir with a local dependency child.
+// Returns the parent dir path.
+func writeBundleWithDep(t *testing.T, parentVersion, childVersion string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	parentYAML := []byte(`pactoVersion: "1.0"
+service:
+  name: parent-svc
+  version: "` + parentVersion + `"
+dependencies:
+  - ref: ./child
+    required: true
+    compatibility: "^1.0.0"
+`)
+	childYAML := []byte(`pactoVersion: "1.0"
+service:
+  name: child-svc
+  version: "` + childVersion + `"
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+`)
+
+	if err := os.WriteFile(filepath.Join(dir, "pacto.yaml"), parentYAML, 0644); err != nil {
+		t.Fatal(err)
+	}
+	childDir := filepath.Join(dir, "child")
+	if err := os.MkdirAll(childDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(childDir, "pacto.yaml"), childYAML, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestDiff_DependencyChanges(t *testing.T) {
+	oldDir := writeBundleWithDep(t, "1.0.0", "1.0.0")
+	newDir := writeBundleWithDep(t, "1.0.0", "2.0.0")
+	svc := NewService(nil, nil)
+	result, err := svc.Diff(context.Background(), DiffOptions{OldPath: oldDir, NewPath: newDir})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.DependencyDiffs) == 0 {
+		t.Fatal("expected dependency diffs for child version change")
+	}
+	dd := result.DependencyDiffs[0]
+	if dd.Name != "child-svc" {
+		t.Errorf("expected dep name 'child-svc', got %q", dd.Name)
+	}
+	if dd.Classification == "" {
+		t.Error("expected non-empty classification on dependency diff")
+	}
+}
+
+func TestDiff_DependencyNoChanges(t *testing.T) {
+	oldDir := writeBundleWithDep(t, "1.0.0", "1.0.0")
+	newDir := writeBundleWithDep(t, "1.0.0", "1.0.0")
+	svc := NewService(nil, nil)
+	result, err := svc.Diff(context.Background(), DiffOptions{OldPath: oldDir, NewPath: newDir})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.DependencyDiffs) != 0 {
+		t.Errorf("expected no dependency diffs for identical children, got %d", len(result.DependencyDiffs))
+	}
+}
+
+func TestDiff_DependencyClassificationElevation(t *testing.T) {
+	// Old child has an extra interface; new child removes it → BREAKING in child.
+	// Parent is identical → NON_BREAKING at root.
+	// Overall should be elevated to BREAKING.
+	oldDir := writeBundleWithDep(t, "1.0.0", "1.0.0")
+
+	// Add a second interface to old child so removing it in new is BREAKING.
+	oldChildYAML := []byte(`pactoVersion: "1.0"
+service:
+  name: child-svc
+  version: "1.0.0"
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+  - name: grpc
+    type: grpc
+    port: 9090
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+`)
+	if err := os.WriteFile(filepath.Join(oldDir, "child", "pacto.yaml"), oldChildYAML, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	newDir := writeBundleWithDep(t, "1.0.0", "1.0.0")
+	svc := NewService(nil, nil)
+	result, err := svc.Diff(context.Background(), DiffOptions{OldPath: oldDir, NewPath: newDir})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Classification != "BREAKING" {
+		t.Errorf("expected BREAKING overall, got %s", result.Classification)
+	}
+}
+
+func TestDiff_DependencyOnlyInNew(t *testing.T) {
+	// Old has no dependencies, new has one → the dep exists only in newNodes.
+	// This tests the !exists branch at line 71.
+	oldDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(oldDir, "pacto.yaml"), []byte(`pactoVersion: "1.0"
+service:
+  name: parent-svc
+  version: "1.0.0"
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	newDir := writeBundleWithDep(t, "1.0.0", "1.0.0")
+	svc := NewService(nil, nil)
+	result, err := svc.Diff(context.Background(), DiffOptions{OldPath: oldDir, NewPath: newDir})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// child-svc only in new, so it should be skipped (no old to compare against).
+	for _, dd := range result.DependencyDiffs {
+		if dd.Name == "child-svc" {
+			t.Error("did not expect child-svc in dependency diffs when it only exists in new")
+		}
+	}
+}
+
+func TestCollectNodes_NilRoot(t *testing.T) {
+	nodes := collectNodes(nil)
+	if len(nodes) != 0 {
+		t.Errorf("expected empty map, got %d entries", len(nodes))
+	}
+}
+
+func TestCollectNodes_WithDependencies(t *testing.T) {
+	root := &graph.Node{
+		Name:    "root",
+		Version: "1.0.0",
+		Dependencies: []graph.Edge{
+			{Node: &graph.Node{
+				Name:    "child-a",
+				Version: "2.0.0",
+				Dependencies: []graph.Edge{
+					{Node: &graph.Node{Name: "grandchild", Version: "3.0.0"}},
+				},
+			}},
+			{Node: &graph.Node{Name: "child-b", Version: "4.0.0"}},
+		},
+	}
+	nodes := collectNodes(root)
+	if len(nodes) != 4 {
+		t.Errorf("expected 4 nodes, got %d", len(nodes))
+	}
+	for _, name := range []string{"root", "child-a", "child-b", "grandchild"} {
+		if _, ok := nodes[name]; !ok {
+			t.Errorf("expected node %q in map", name)
+		}
+	}
+}
+
+func TestCollectNodes_CycleHandling(t *testing.T) {
+	child := &graph.Node{Name: "child", Version: "1.0.0"}
+	root := &graph.Node{
+		Name:         "root",
+		Version:      "1.0.0",
+		Dependencies: []graph.Edge{{Node: child}},
+	}
+	// Create a cycle: child -> root
+	child.Dependencies = []graph.Edge{{Node: root}}
+
+	nodes := collectNodes(root)
+	if len(nodes) != 2 {
+		t.Errorf("expected 2 nodes (cycle should be handled), got %d", len(nodes))
 	}
 }

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -72,19 +72,29 @@ func printPullResult(cmd *cobra.Command, result *app.PullResult, format string) 
 
 func printDiffResult(cmd *cobra.Command, result *app.DiffResult, format string) error {
 	return formatResult(cmd, format, result, func() error {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Classification: %s\n", result.Classification)
-		if len(result.Changes) == 0 {
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No changes detected.")
+		w := cmd.OutOrStdout()
+		_, _ = fmt.Fprintf(w, "Classification: %s\n", result.Classification)
+		if len(result.Changes) == 0 && len(result.DependencyDiffs) == 0 {
+			_, _ = fmt.Fprintln(w, "No changes detected.")
 		} else {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Changes (%d):\n", len(result.Changes))
-			for _, c := range result.Changes {
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  [%s] %s (%s): %s\n",
-					c.Classification, c.Path, c.Type, c.Reason)
+			if len(result.Changes) > 0 {
+				_, _ = fmt.Fprintf(w, "Changes (%d):\n", len(result.Changes))
+				for _, c := range result.Changes {
+					_, _ = fmt.Fprintf(w, "  [%s] %s (%s): %s\n",
+						c.Classification, c.Path, c.Type, c.Reason)
+				}
+			}
+			for _, dd := range result.DependencyDiffs {
+				_, _ = fmt.Fprintf(w, "\nDependency %s [%s] (%d):\n", dd.Name, dd.Classification, len(dd.Changes))
+				for _, c := range dd.Changes {
+					_, _ = fmt.Fprintf(w, "  [%s] %s (%s): %s\n",
+						c.Classification, c.Path, c.Type, c.Reason)
+				}
 			}
 		}
 
 		if rendered := graph.RenderDiffTree(result.GraphDiff); rendered != "" {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nDependency graph changes:\n%s", rendered)
+			_, _ = fmt.Fprintf(w, "\nDependency graph changes:\n%s", rendered)
 		}
 
 		return nil

--- a/internal/cli/output_internal_test.go
+++ b/internal/cli/output_internal_test.go
@@ -152,6 +152,65 @@ func TestPrintDiffResult_NoChanges(t *testing.T) {
 	}
 }
 
+func TestPrintDiffResult_WithDependencyDiffs(t *testing.T) {
+	cmd, buf := testCmd()
+	result := &app.DiffResult{
+		OldPath:        "a.yaml",
+		NewPath:        "b.yaml",
+		Classification: "BREAKING",
+		DependencyDiffs: []app.DependencyDiff{
+			{
+				Name:           "my-dep",
+				Classification: "BREAKING",
+				Changes: []diff.Change{
+					{Path: "openapi.paths[/users]", Type: diff.Removed, Classification: diff.Breaking, Reason: "API path /users removed"},
+				},
+			},
+		},
+	}
+	if err := printDiffResult(cmd, result, "text"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Dependency my-dep [BREAKING] (1):") {
+		t.Errorf("expected dependency diff header, got %q", out)
+	}
+	if !strings.Contains(out, "openapi.paths[/users]") {
+		t.Errorf("expected change path in output, got %q", out)
+	}
+	if strings.Contains(out, "No changes detected") {
+		t.Errorf("should not show 'No changes detected' when dependency diffs exist, got %q", out)
+	}
+}
+
+func TestPrintDiffResult_OnlyDependencyDiffs(t *testing.T) {
+	cmd, buf := testCmd()
+	result := &app.DiffResult{
+		OldPath:        "a.yaml",
+		NewPath:        "b.yaml",
+		Classification: "NON_BREAKING",
+		DependencyDiffs: []app.DependencyDiff{
+			{
+				Name:           "governance",
+				Classification: "NON_BREAKING",
+				Changes: []diff.Change{
+					{Path: "service.version", Type: diff.Modified, Classification: diff.NonBreaking, Reason: "version changed"},
+				},
+			},
+		},
+	}
+	if err := printDiffResult(cmd, result, "text"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "No changes detected") {
+		t.Errorf("should not show 'No changes detected' when dependency diffs exist, got %q", out)
+	}
+	if !strings.Contains(out, "Dependency governance") {
+		t.Errorf("expected dependency diff section, got %q", out)
+	}
+}
+
 func TestPrintDiffResult_WithChanges(t *testing.T) {
 	cmd, buf := testCmd()
 	result := &app.DiffResult{


### PR DESCRIPTION
## Summary
- The `diff` command now recursively compares contracts of all resolved dependencies, not just the root contract
- Surfaces OpenAPI, schema, and contract-level changes in transitive dependencies that were previously invisible when diffing a parent wrapper contract
- Overall classification is elevated when a dependency has a higher severity (e.g., if a dep has `BREAKING` changes, the root result becomes `BREAKING`)

## Changes
- **`internal/app/diff.go`** — Walk resolved graph nodes after diffing root, match by name, run `diff.Compare()` on each dependency pair, aggregate classification
- **`internal/cli/output.go`** — Render dependency diffs with `Dependency <name> [<classification>] (<count>):` headers
- **`internal/app/diff_test.go`** — Tests for dependency changes, no changes, classification elevation, and dep-only-in-new skip
- **`internal/cli/output_internal_test.go`** — Tests for dependency diff text rendering

## Test plan
- [x] All existing unit tests pass
- [x] All e2e tests pass
- [x] 100% coverage on changed packages
- [x] `make ci` passes (fmt, vet, cyclo, lint, test, e2e)