### PR TITLE
fix: resolve four reliability bugs found during code audit

### DIFF
--- a/internal/app/generate.go
+++ b/internal/app/generate.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/trianalab/pacto/internal/plugin"
 )
@@ -77,8 +78,15 @@ func (s *Service) Generate(ctx context.Context, opts GenerateOptions) (*Generate
 		return nil, err
 	}
 
+	absOutput, err := absPathFn(outputDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve output directory: %w", err)
+	}
 	for _, f := range resp.Files {
-		outPath := filepath.Join(outputDir, f.Path)
+		outPath := filepath.Join(absOutput, f.Path)
+		if rel, relErr := filepath.Rel(absOutput, outPath); relErr != nil || strings.HasPrefix(rel, "..") {
+			return nil, fmt.Errorf("plugin file path %q escapes output directory", f.Path)
+		}
 		if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
 			return nil, fmt.Errorf("failed to create directory for %s: %w", f.Path, err)
 		}

--- a/internal/app/generate_test.go
+++ b/internal/app/generate_test.go
@@ -227,6 +227,56 @@ func TestGenerate_WriteFileError_FlatPath(t *testing.T) {
 	}
 }
 
+func TestGenerate_PathTraversalBlocked(t *testing.T) {
+	bundleDir := writeTestBundle(t)
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "gen-output")
+
+	runner := &mockPluginRunner{
+		RunFn: func(_ context.Context, _ string, _ plugin.GenerateRequest) (*plugin.GenerateResponse, error) {
+			return &plugin.GenerateResponse{
+				Files: []plugin.GeneratedFile{{Path: "../../escape.txt", Content: "pwned"}},
+			}, nil
+		},
+	}
+
+	svc := NewService(nil, runner)
+	_, err := svc.Generate(context.Background(), GenerateOptions{
+		Path:      bundleDir,
+		OutputDir: outputDir,
+		Plugin:    "bad-plugin",
+	})
+	if err == nil {
+		t.Fatal("expected error for path traversal attempt")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "escape.txt")); statErr == nil {
+		t.Error("file was written outside output directory")
+	}
+}
+
+func TestGenerate_AbsPathError(t *testing.T) {
+	bundleDir := writeTestBundle(t)
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "gen-output")
+
+	old := absPathFn
+	absPathFn = func(string) (string, error) {
+		return "", fmt.Errorf("getwd failed")
+	}
+	defer func() { absPathFn = old }()
+
+	runner := &mockPluginRunner{}
+	svc := NewService(nil, runner)
+	_, err := svc.Generate(context.Background(), GenerateOptions{
+		Path:      bundleDir,
+		OutputDir: outputDir,
+		Plugin:    "test-plugin",
+	})
+	if err == nil {
+		t.Error("expected error when filepath.Abs fails")
+	}
+}
+
 func TestGenerate_MkdirTempError(t *testing.T) {
 	old := mkdirTempFn
 	mkdirTempFn = func(string, string) (string, error) {

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/trianalab/pacto/internal/oci"
 )
@@ -12,6 +13,7 @@ import (
 var (
 	writeFileFn = os.WriteFile
 	mkdirTempFn = os.MkdirTemp
+	absPathFn   = filepath.Abs
 )
 
 // Service is the application service container. It holds injected dependencies

--- a/internal/diff/runtime.go
+++ b/internal/diff/runtime.go
@@ -79,17 +79,13 @@ func diffLifecycle(old, new *contract.Lifecycle) []Change {
 	if old == nil && new == nil {
 		return nil
 	}
+
+	// Normalise nil to empty so every field is compared uniformly.
 	if old == nil {
-		if new.UpgradeStrategy != "" {
-			changes = append(changes, newChange("runtime.lifecycle.upgradeStrategy", Added, nil, new.UpgradeStrategy))
-		}
-		return changes
+		old = &contract.Lifecycle{}
 	}
 	if new == nil {
-		if old.UpgradeStrategy != "" {
-			changes = append(changes, newChange("runtime.lifecycle.upgradeStrategy", Removed, old.UpgradeStrategy, nil))
-		}
-		return changes
+		new = &contract.Lifecycle{}
 	}
 
 	if old.UpgradeStrategy != new.UpgradeStrategy {
@@ -102,7 +98,13 @@ func diffLifecycle(old, new *contract.Lifecycle) []Change {
 		changes = append(changes, newChange("runtime.lifecycle.upgradeStrategy", ct, old.UpgradeStrategy, new.UpgradeStrategy))
 	}
 	if intPtrChanged(old.GracefulShutdownSeconds, new.GracefulShutdownSeconds) {
-		changes = append(changes, newChange("runtime.lifecycle.gracefulShutdownSeconds", Modified,
+		ct := Modified
+		if old.GracefulShutdownSeconds == nil {
+			ct = Added
+		} else if new.GracefulShutdownSeconds == nil {
+			ct = Removed
+		}
+		changes = append(changes, newChange("runtime.lifecycle.gracefulShutdownSeconds", ct,
 			intPtrVal(old.GracefulShutdownSeconds), intPtrVal(new.GracefulShutdownSeconds)))
 	}
 

--- a/internal/diff/runtime_test.go
+++ b/internal/diff/runtime_test.go
@@ -32,6 +32,36 @@ func TestDiffLifecycle_OldNil_EmptyStrategy(t *testing.T) {
 	}
 }
 
+func TestDiffLifecycle_OldNil_GracefulShutdownAdded(t *testing.T) {
+	v := 30
+	newLC := &contract.Lifecycle{GracefulShutdownSeconds: &v}
+	changes := diffLifecycle(nil, newLC)
+	found := false
+	for _, c := range changes {
+		if c.Path == "runtime.lifecycle.gracefulShutdownSeconds" && c.Type == Added {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected gracefulShutdownSeconds Added change when lifecycle is added")
+	}
+}
+
+func TestDiffLifecycle_NewNil_GracefulShutdownRemoved(t *testing.T) {
+	v := 30
+	oldLC := &contract.Lifecycle{GracefulShutdownSeconds: &v}
+	changes := diffLifecycle(oldLC, nil)
+	found := false
+	for _, c := range changes {
+		if c.Path == "runtime.lifecycle.gracefulShutdownSeconds" && c.Type == Removed {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected gracefulShutdownSeconds Removed change when lifecycle is removed")
+	}
+}
+
 func TestDiffLifecycle_NewNil(t *testing.T) {
 	oldLC := &contract.Lifecycle{UpgradeStrategy: "rolling"}
 	changes := diffLifecycle(oldLC, nil)

--- a/internal/graph/resolver.go
+++ b/internal/graph/resolver.go
@@ -53,6 +53,7 @@ type resolver struct {
 	fetcher ContractFetcher
 	mu      sync.Mutex
 	visited map[string]*Node
+	errors  map[string]string
 	pending map[string]chan struct{}
 	cycles  [][]string
 }
@@ -73,6 +74,7 @@ func Resolve(ctx context.Context, c *contract.Contract, fetcher ContractFetcher)
 	r := &resolver{
 		fetcher: fetcher,
 		visited: map[string]*Node{},
+		errors:  map[string]string{},
 		pending: map[string]chan struct{}{},
 	}
 
@@ -149,10 +151,13 @@ func (r *resolver) resolveEdge(ctx context.Context, dep contract.Dependency, pat
 		<-ch
 		r.mu.Lock()
 		prev := r.visited[dep.Ref]
+		prevErr := r.errors[dep.Ref]
 		r.mu.Unlock()
 		edge.Shared = true
 		if prev != nil {
 			edge.Node = &Node{Name: prev.Name, Version: prev.Version, Ref: prev.Ref, Local: prev.Local}
+		} else if prevErr != "" {
+			edge.Error = prevErr
 		}
 		return edge
 	}
@@ -165,6 +170,7 @@ func (r *resolver) resolveEdge(ctx context.Context, dep contract.Dependency, pat
 	if err != nil {
 		slog.Debug("dependency fetch failed", "ref", dep.Ref, "error", err)
 		r.mu.Lock()
+		r.errors[dep.Ref] = err.Error()
 		delete(r.pending, dep.Ref)
 		r.mu.Unlock()
 		close(ch)

--- a/internal/graph/resolver_test.go
+++ b/internal/graph/resolver_test.go
@@ -697,21 +697,12 @@ func TestResolve_PendingFetchError(t *testing.T) {
 	if len(result.Root.Dependencies) != 2 {
 		t.Fatalf("expected 2 deps, got %d", len(result.Root.Dependencies))
 	}
-	// With concurrent resolution of the same failing ref, either:
-	// - One goroutine fetches and fails, the other sees it as shared with nil node
-	// - Both goroutines independently fail (scheduler may not interleave as expected)
-	// Both outcomes are valid; we verify all edges surface an error or shared-nil.
-	var errCount, sharedNilCount int
-	for _, e := range result.Root.Dependencies {
-		if e.Error != "" {
-			errCount++
+	// With concurrent resolution of the same failing ref, every edge must
+	// carry an error — including the one that waited on the pending channel.
+	for i, e := range result.Root.Dependencies {
+		if e.Error == "" {
+			t.Errorf("edge %d: expected error, got empty string (shared=%v)", i, e.Shared)
 		}
-		if e.Shared && e.Node == nil {
-			sharedNilCount++
-		}
-	}
-	if errCount+sharedNilCount != 2 {
-		t.Errorf("expected 2 error or shared-nil edges, got err=%d shared-nil=%d", errCount, sharedNilCount)
 	}
 }
 
@@ -757,22 +748,46 @@ func TestResolve_PendingFetchError_Deterministic(t *testing.T) {
 		t.Fatal("expected B and C to be resolved")
 	}
 
-	// Both B and C have 1 dep on "missing". At least one should have an error.
+	// Both B and C have 1 dep on "missing". All edges must carry an error,
+	// including the one that waited on the pending channel.
 	allMissingEdges := append(bNode.Dependencies, cNode.Dependencies...)
-	var errEdges, sharedEdges int
-	for _, e := range allMissingEdges {
-		if e.Error != "" {
-			errEdges++
-		}
-		if e.Shared {
-			sharedEdges++
+	for i, e := range allMissingEdges {
+		if e.Error == "" {
+			t.Errorf("edge %d for missing dep: expected error, got empty string (shared=%v)", i, e.Shared)
 		}
 	}
-	if errEdges == 0 {
-		t.Error("expected at least 1 error edge for missing dep")
+}
+
+func TestResolveEdge_PendingWaitGetsError(t *testing.T) {
+	// Directly exercise the pending-wait error path by pre-populating
+	// the resolver with a closed pending channel and a stored error.
+	// A single call to resolveEdge sees the pending entry, receives
+	// from the already-closed channel, finds nil in visited, and
+	// reads the error from the errors map.
+	r := &resolver{
+		fetcher: &mockFetcher{},
+		visited: map[string]*Node{},
+		errors:  map[string]string{},
+		pending: map[string]chan struct{}{},
 	}
-	if errEdges+sharedEdges != 2 {
-		t.Errorf("expected 2 total edges for missing dep, got err=%d shared=%d", errEdges, sharedEdges)
+
+	ref := "oci://registry.io/fail:1.0.0"
+	ch := make(chan struct{})
+	close(ch) // pre-close so <-ch returns immediately
+	r.pending[ref] = ch
+	r.errors[ref] = "upstream failure"
+
+	dep := contract.Dependency{Ref: ref, Required: true, Compatibility: "^1.0.0"}
+	edge := r.resolveEdge(context.Background(), dep, []string{"root"})
+
+	if !edge.Shared {
+		t.Error("expected edge to be marked as shared")
+	}
+	if edge.Node != nil {
+		t.Error("expected nil node for failed fetch")
+	}
+	if edge.Error != "upstream failure" {
+		t.Errorf("expected error 'upstream failure', got %q", edge.Error)
 	}
 }
 

--- a/internal/oci/cache.go
+++ b/internal/oci/cache.go
@@ -134,7 +134,12 @@ func (c *CachedStore) storePull(ref string, bundle *contract.Bundle) {
 
 func (c *CachedStore) cachePath(ref string) string {
 	safe := strings.ReplaceAll(ref, ":", "/")
-	return filepath.Join(c.cacheDir, safe, "bundle.tar.gz")
+	joined := filepath.Join(c.cacheDir, safe, "bundle.tar.gz")
+	// Ensure the resolved path stays inside the cache directory.
+	if rel, err := filepath.Rel(c.cacheDir, joined); err != nil || strings.HasPrefix(rel, "..") {
+		return filepath.Join(c.cacheDir, "_invalid", "bundle.tar.gz")
+	}
+	return joined
 }
 
 func (c *CachedStore) loadFromCache(path string) (*contract.Bundle, error) {

--- a/internal/oci/cache_internal_test.go
+++ b/internal/oci/cache_internal_test.go
@@ -1,0 +1,42 @@
+package oci
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCachePath_TraversalBlocked(t *testing.T) {
+	cacheDir := t.TempDir()
+	store := &CachedStore{cacheDir: cacheDir}
+
+	ref := "ghcr.io/../../../etc/passwd"
+	got := store.cachePath(ref)
+
+	rel, err := filepath.Rel(cacheDir, got)
+	if err != nil {
+		t.Fatalf("filepath.Rel error: %v", err)
+	}
+	if strings.HasPrefix(rel, "..") {
+		t.Errorf("cachePath escaped cache directory: %s (rel=%s)", got, rel)
+	}
+}
+
+func TestCachePath_NormalRef(t *testing.T) {
+	cacheDir := t.TempDir()
+	store := &CachedStore{cacheDir: cacheDir}
+
+	ref := "ghcr.io/acme/svc:1.0.0"
+	got := store.cachePath(ref)
+
+	rel, err := filepath.Rel(cacheDir, got)
+	if err != nil {
+		t.Fatalf("filepath.Rel error: %v", err)
+	}
+	if strings.HasPrefix(rel, "..") {
+		t.Errorf("normal ref should stay inside cache: %s (rel=%s)", got, rel)
+	}
+	if !strings.HasSuffix(got, "bundle.tar.gz") {
+		t.Errorf("expected bundle.tar.gz suffix, got %s", got)
+	}
+}


### PR DESCRIPTION
## Summary

- **diffLifecycle missed GracefulShutdownSeconds** — when lifecycle was added or removed, only `upgradeStrategy` was reported; `gracefulShutdownSeconds` changes were silently dropped. Fixed by normalising nil to empty struct (same pattern as `diffHealth`).
- **Resolver lost fetch errors for concurrent waiters** — when two siblings depended on the same failing ref, only the fetching goroutine got the error; the waiting goroutine received `Shared=true` with no error and no node. Fixed by storing errors in a dedicated map alongside `visited`.
- **Path traversal in plugin output** — plugin-provided file paths were joined with the output directory without sanitisation, allowing `../../` escapes. Fixed with `filepath.Rel` containment check.
- **Cache path traversal** — OCI refs containing `..` segments could escape the cache directory. Fixed with `filepath.Rel` guard.

## Test plan

- [x] All four affected packages at 100% statement coverage
- [x] New tests: `TestDiffLifecycle_OldNil_GracefulShutdownAdded`, `TestDiffLifecycle_NewNil_GracefulShutdownRemoved`
- [x] New test: `TestResolveEdge_PendingWaitGetsError` (deterministic pending-wait error path)
- [x] Updated tests: `TestResolve_PendingFetchError`, `TestResolve_PendingFetchError_Deterministic` (now assert all edges carry errors)
- [x] New test: `TestGenerate_PathTraversalBlocked` (verifies `../../` rejected, no file written)
- [x] New test: `TestGenerate_AbsPathError`
- [x] New tests: `TestCachePath_TraversalBlocked`, `TestCachePath_NormalRef`
- [x] Full test suite passes (`go test ./...`)