### PR TITLE
fix: eliminate phantom diff changes from shared dependency resolution order

### DIFF
--- a/internal/graph/diff.go
+++ b/internal/graph/diff.go
@@ -55,7 +55,13 @@ func DiffGraphs(old, new *Result) *GraphDiff {
 		return &GraphDiff{Root: root, Changes: changes}
 	}
 
-	root := diffTrees(old.Root, new.Root, map[string]bool{})
+	// Build a full-node index for the old graph so that diffTrees can
+	// look up the fully-resolved version of shared (shallow) nodes.
+	// Without this, non-deterministic concurrent resolution order causes
+	// phantom added/removed changes when a node is shared in the old
+	// graph but fully resolved in the new graph at the same tree position.
+	oldFull := fullNodeIndex(old.Root)
+	root := diffTrees(old.Root, new.Root, oldFull, map[string]bool{})
 	changes := collectTreeChanges(root)
 	sortChanges(changes)
 	return &GraphDiff{Root: root, Changes: changes}
@@ -63,7 +69,9 @@ func DiffGraphs(old, new *Result) *GraphDiff {
 
 // diffTrees recursively compares two graph nodes and builds a DiffNode tree
 // annotating added, removed, and version-changed children at each level.
-func diffTrees(oldNode, newNode *Node, visited map[string]bool) DiffNode {
+// oldFull maps node names to their fully-resolved versions from the old
+// graph, used to replace shared (shallow) copies before recursion.
+func diffTrees(oldNode, newNode *Node, oldFull map[string]*Node, visited map[string]bool) DiffNode {
 	dn := DiffNode{Name: newNode.Name, Version: newNode.Version}
 
 	oldByName := childMap(oldNode)
@@ -88,7 +96,13 @@ func diffTrees(oldNode, newNode *Node, visited map[string]bool) DiffNode {
 			}
 			if !edge.Shared && !visited[name] {
 				visited[name] = true
-				sub := diffTrees(oldChild, edge.Node, visited)
+				// Use the fully-resolved old node for recursion.
+				// Shared (shallow) copies lack Dependencies, which
+				// would cause phantom added/removed changes.
+				if full, ok := oldFull[name]; ok {
+					oldChild = full
+				}
+				sub := diffTrees(oldChild, edge.Node, oldFull, visited)
 				child.Children = sub.Children
 			}
 			dn.Children = append(dn.Children, child)
@@ -154,6 +168,29 @@ func markAll(node *Node, ct ChangeType, visited map[string]bool) DiffNode {
 		dn.Children = append(dn.Children, child)
 	}
 	return dn
+}
+
+// fullNodeIndex collects all fully-resolved nodes from a dependency
+// graph, indexed by name. When a node appears both as a fully-resolved
+// edge and as a shared (shallow) edge, the full version is kept.
+func fullNodeIndex(root *Node) map[string]*Node {
+	idx := map[string]*Node{}
+	fullNodeIndexRec(root, idx)
+	return idx
+}
+
+func fullNodeIndexRec(node *Node, idx map[string]*Node) {
+	if node == nil {
+		return
+	}
+	prev, seen := idx[node.Name]
+	if seen && len(prev.Dependencies) > 0 {
+		return
+	}
+	idx[node.Name] = node
+	for _, edge := range node.Dependencies {
+		fullNodeIndexRec(edge.Node, idx)
+	}
 }
 
 // childMap indexes a node's direct dependency children by name.

--- a/internal/graph/diff_test.go
+++ b/internal/graph/diff_test.go
@@ -434,3 +434,108 @@ func TestChildMap_NilNode(t *testing.T) {
 		t.Errorf("expected empty map for nil node, got %v", m)
 	}
 }
+
+// TestDiffGraphs_SharedOldNodeNoPhantomChanges reproduces a bug where
+// non-deterministic concurrent resolution causes phantom dependency
+// additions. When the old graph resolves a node (e.g. keycloak) fully
+// under one parent but as shared (shallow, no Dependencies) under
+// another, and the new graph resolves it fully under the second parent,
+// diffTrees would recurse into the shallow old copy and see all its
+// children as "added" because childMap returns empty for shallow nodes.
+func TestDiffGraphs_SharedOldNodeNoPhantomChanges(t *testing.T) {
+	// Old graph: keycloak fully resolved under svc-a, shared (shallow)
+	// under svc-b. This simulates svc-a winning the concurrent fetch.
+	old := &Result{
+		Root: &Node{
+			Name:    "runtime",
+			Version: "1.0.0",
+			Dependencies: []Edge{
+				{
+					Ref: "reg/svc-a:1.0.0",
+					Node: &Node{
+						Name:    "svc-a",
+						Version: "1.0.0",
+						Dependencies: []Edge{
+							{
+								Ref: "reg/keycloak:26.0.0",
+								Node: &Node{
+									Name:    "keycloak",
+									Version: "26.0.0",
+									Dependencies: []Edge{
+										{Ref: "reg/postgres:17.0.0", Node: &Node{Name: "postgres", Version: "17.0.0"}},
+									},
+								},
+							},
+							{Ref: "reg/postgres:17.0.0", Shared: true, Node: &Node{Name: "postgres", Version: "17.0.0"}},
+						},
+					},
+				},
+				{
+					Ref: "reg/svc-b:1.0.0",
+					Node: &Node{
+						Name:    "svc-b",
+						Version: "1.0.0",
+						Dependencies: []Edge{
+							// Shared: keycloak was already resolved under svc-a.
+							// Shallow copy — no Dependencies.
+							{Ref: "reg/keycloak:26.0.0", Shared: true, Node: &Node{Name: "keycloak", Version: "26.0.0"}},
+							{Ref: "reg/postgres:17.0.0", Shared: true, Node: &Node{Name: "postgres", Version: "17.0.0"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// New graph: keycloak fully resolved under svc-b (different
+	// goroutine won), shared under svc-a. Identical dependency
+	// structure — only the resolution order differs.
+	new := &Result{
+		Root: &Node{
+			Name:    "runtime",
+			Version: "1.0.0",
+			Dependencies: []Edge{
+				{
+					Ref: "reg/svc-a:1.0.0",
+					Node: &Node{
+						Name:    "svc-a",
+						Version: "1.0.0",
+						Dependencies: []Edge{
+							// Shared: keycloak resolved under svc-b this time.
+							{Ref: "reg/keycloak:26.0.0", Shared: true, Node: &Node{Name: "keycloak", Version: "26.0.0"}},
+							{Ref: "reg/postgres:17.0.0", Shared: true, Node: &Node{Name: "postgres", Version: "17.0.0"}},
+						},
+					},
+				},
+				{
+					Ref: "reg/svc-b:1.0.0",
+					Node: &Node{
+						Name:    "svc-b",
+						Version: "1.0.0",
+						Dependencies: []Edge{
+							{
+								Ref: "reg/keycloak:26.0.0",
+								Node: &Node{
+									Name:    "keycloak",
+									Version: "26.0.0",
+									Dependencies: []Edge{
+										{Ref: "reg/postgres:17.0.0", Node: &Node{Name: "postgres", Version: "17.0.0"}},
+									},
+								},
+							},
+							{Ref: "reg/postgres:17.0.0", Shared: true, Node: &Node{Name: "postgres", Version: "17.0.0"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	d := DiffGraphs(old, new)
+
+	if len(d.Changes) != 0 {
+		t.Errorf("expected no changes (identical graphs with different resolution order), got %d: %+v",
+			len(d.Changes), d.Changes)
+		t.Logf("rendered diff tree:\n%s", RenderDiffTree(d))
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes a bug where `pacto diff` reports phantom added/removed dependencies when the old and new graphs resolve shared nodes in different order due to concurrent goroutine scheduling
- For example, if service A and service B both depend on service C, and C depends on D, the diff could falsely report `D +x.y.z` when nothing actually changed — just because the old graph resolved C fully under A (leaving a shallow copy under B) while the new graph resolved C fully under B
- Adds `fullNodeIndex` to collect fully-resolved nodes from the old graph, used to replace shallow shared copies before recursing into subtree comparison

## Test plan

- [x] New test `TestDiffGraphs_SharedOldNodeNoPhantomChanges` reproduces the exact scenario (fails without the fix, passes with it)
- [x] All existing diff tests pass unchanged
- [x] Full test suite passes (`go test ./...`)
- [x] 100% line coverage on `diff.go`