### PR TITLE
feat: add pacto_schema MCP tool and server instructions

### DIFF
--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -53,6 +53,7 @@ An AI assistant sends MCP tool calls to the `pacto mcp` server. Pacto executes t
 | `pacto_explain` | Return a human-readable summary of a contract |
 | `pacto_generate_contract` | Generate a new contract YAML from structured inputs |
 | `pacto_suggest_dependencies` | Suggest likely dependencies based on service characteristics |
+| `pacto_schema` | Return the Pacto format explanation and full JSON Schema (call first before writing contracts) |
 
 All tools accept both local directory paths and `oci://` references.
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -14,7 +14,12 @@ import (
 func NewServer(svc *app.Service, version string) *mcpsdk.Server {
 	server := mcpsdk.NewServer(
 		&mcpsdk.Implementation{Name: "pacto", Version: version},
-		nil,
+		&mcpsdk.ServerOptions{
+			Instructions: "Pacto is an operational contract format for cloud-native services. " +
+				"Before creating or editing pacto.yaml files, call the pacto_schema tool to get " +
+				"the JSON Schema and documentation link. This ensures you use the correct syntax " +
+				"and avoid validation errors.",
+		},
 	)
 
 	registerTools(server, svc)
@@ -31,6 +36,7 @@ func registerTools(server *mcpsdk.Server, svc *app.Service) {
 	server.AddTool(explainTool(), explainHandler(svc))
 	server.AddTool(generateContractTool(), generateContractHandler())
 	server.AddTool(suggestDependenciesTool(), suggestDependenciesHandler(svc))
+	server.AddTool(schemaTool(), schemaHandler())
 }
 
 // jsonResult marshals v to JSON and returns it as a CallToolResult with text content.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -7,6 +7,7 @@ import (
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/trianalab/pacto/internal/app"
+	"github.com/trianalab/pacto/internal/validation"
 	"github.com/trianalab/pacto/pkg/contract"
 )
 
@@ -391,6 +392,38 @@ func suggestFromRuntime(rt app.ExplainRuntime, add func(string)) {
 
 	if rt.WorkloadType == "service" {
 		add("prometheus")
+	}
+}
+
+// --- pacto_schema ---
+
+func schemaTool() *mcpsdk.Tool {
+	return &mcpsdk.Tool{
+		Name: "pacto_schema",
+		Description: "Returns the Pacto contract JSON Schema and links to the full documentation. " +
+			"Call this tool FIRST before creating or editing pacto.yaml files to understand the format and avoid syntax errors.",
+		InputSchema: inputSchema(map[string]property{}, nil),
+	}
+}
+
+const docsURL = "https://trianalab.github.io/pacto"
+
+type schemaResult struct {
+	Description string `json:"description"`
+	Docs        string `json:"docs"`
+	JSONSchema  string `json:"jsonSchema"`
+}
+
+func schemaHandler() mcpsdk.ToolHandler {
+	return func(_ context.Context, _ *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+		result := schemaResult{
+			Description: "Pacto is an operational contract format for cloud-native services. " +
+				"A pacto.yaml file describes the service itself — interfaces, dependencies, runtime semantics, " +
+				"configuration, and scaling. Refer to the documentation link for the full specification.",
+			Docs:       docsURL,
+			JSONSchema: string(validation.SchemaBytes()),
+		}
+		return jsonResult(result)
 	}
 }
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -231,6 +231,31 @@ func TestSuggestDependenciesTool(t *testing.T) {
 	}
 }
 
+func TestSchemaTool(t *testing.T) {
+	svc := app.NewService(nil, nil)
+
+	result := callTool(t, svc, "pacto_schema", map[string]any{})
+	if result.IsError {
+		t.Fatal("expected no error from pacto_schema")
+	}
+
+	text := resultText(t, result)
+
+	var parsed schemaResult
+	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+		t.Fatalf("expected valid JSON: %v", err)
+	}
+	if !strings.Contains(parsed.Description, "operational contract format") {
+		t.Errorf("expected description to mention Pacto, got: %s", parsed.Description)
+	}
+	if parsed.Docs == "" {
+		t.Error("expected non-empty docs URL")
+	}
+	if !strings.Contains(parsed.JSONSchema, `"pactoVersion"`) {
+		t.Errorf("expected pactoVersion in JSON schema, got: %.100s...", parsed.JSONSchema)
+	}
+}
+
 func TestBuildExplainSummary(t *testing.T) {
 	port := 8080
 	r := &app.ExplainResult{
@@ -463,6 +488,7 @@ func TestToolDefinitions(t *testing.T) {
 		{"pacto_explain", explainTool},
 		{"pacto_generate_contract", generateContractTool},
 		{"pacto_suggest_dependencies", suggestDependenciesTool},
+		{"pacto_schema", schemaTool},
 	}
 
 	for _, tt := range tools {


### PR DESCRIPTION
## Summary

- Add `pacto_schema` MCP tool that returns the contract JSON Schema (from the embedded validation schema) and a link to the documentation, so agents can write valid `pacto.yaml` files without syntax errors
- Add MCP server instructions that guide agents to call `pacto_schema` first before creating or editing contracts
- Update the MCP integration docs to list the new tool

## Test plan

- [x] `TestSchemaTool` verifies the tool returns valid JSON with description, docs URL, and JSON Schema content
- [x] `TestToolDefinitions` updated to include `pacto_schema`
- [x] Full test suite passes