### PR TITLE
docs: fix field paths, missing entries, and validation rules

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -507,6 +507,7 @@ The server exposes the following tools:
 | `pacto_explain` | Return a human-readable summary of a contract |
 | `pacto_generate_contract` | Generate a new contract YAML from structured inputs |
 | `pacto_suggest_dependencies` | Suggest likely dependencies based on service characteristics |
+| `pacto_schema` | Return the Pacto JSON Schema and documentation link |
 
 All tools accept both local directory paths and `oci://` references.
 

--- a/docs/contract-reference.md
+++ b/docs/contract-reference.md
@@ -470,13 +470,17 @@ Validates semantic references and consistency:
 | `service.version` is valid semver | `INVALID_SEMVER` |
 | Interface names are unique | `DUPLICATE_INTERFACE_NAME` |
 | `http`/`grpc` interfaces have `port` | `PORT_REQUIRED` |
+| `event` interfaces with `port` set | `PORT_IGNORED` (warning) |
 | `grpc`/`event` interfaces have `contract` | `CONTRACT_REQUIRED` |
 | `health.interface` matches a declared interface | `HEALTH_INTERFACE_NOT_FOUND` |
 | Health interface is not `event` type | `HEALTH_INTERFACE_INVALID` |
 | `health.path` required for `http` health interface | `HEALTH_PATH_REQUIRED` |
+| `health.path` on `grpc` health interface is ignored | `HEALTH_PATH_IGNORED` (warning) |
 | Referenced files exist in the bundle | `FILE_NOT_FOUND` |
 | OCI dependency refs (`oci://`) are valid OCI references | `INVALID_OCI_REF` |
 | Compatibility ranges are valid semver constraints | `INVALID_COMPATIBILITY` |
+| Compatibility range is empty | `EMPTY_COMPATIBILITY` |
+| OCI dependency uses tag instead of digest | `TAG_NOT_DIGEST` (warning) |
 | `image.ref` is a valid OCI reference | `INVALID_IMAGE_REF` |
 | `scaling.min` <= `scaling.max` | `SCALING_MIN_EXCEEDS_MAX` |
 | Job workloads cannot have scaling | `JOB_SCALING_NOT_ALLOWED` |
@@ -486,9 +490,9 @@ Validates semantic references and consistency:
 
 Validates cross-concern consistency:
 
-| Rule | Type |
-|---|---|
-| `ordered` upgrade strategy with `stateless` state | Warning |
+| Rule | Code | Type |
+|---|---|---|
+| `ordered` upgrade strategy with `stateless` state | `UPGRADE_STRATEGY_STATE_MISMATCH` | Warning |
 
 ---
 

--- a/docs/platform-engineers.md
+++ b/docs/platform-engineers.md
@@ -27,19 +27,21 @@ Every question you'd normally have to ask the dev team — or discover in produc
 
 | Contract Field | Platform Decision |
 |---|---|
-| `workload: service` | Deploy as a long-running process (Deployment/StatefulSet) |
-| `workload: job` | Deploy as a one-shot task (Job/CronJob) |
-| `state.type: stateful` | Needs stable identity and storage (StatefulSet + PVC) |
-| `state.type: stateless` | Horizontally scalable, no persistent storage needed |
-| `state.persistence.durability: persistent` | Provision durable storage |
-| `state.dataCriticality: high` | Enable backups, stricter disruption budgets |
+| `runtime.workload: service` | Deploy as a long-running process (Deployment/StatefulSet) |
+| `runtime.workload: job` | Deploy as a one-shot task (Job/CronJob) |
+| `runtime.state.type: stateful` | Needs stable identity and storage (StatefulSet + PVC) |
+| `runtime.state.type: stateless` | Horizontally scalable, no persistent storage needed |
+| `runtime.state.persistence.durability: persistent` | Provision durable storage |
+| `runtime.state.dataCriticality: high` | Enable backups, stricter disruption budgets |
 | `interfaces[].port` | Configure Service, Ingress |
 | `interfaces[].visibility: public` | Create external Ingress or load balancer |
-| `health.interface` + `health.path` | Configure liveness/readiness probes |
-| `lifecycle.upgradeStrategy: ordered` | Use ordered pod management |
-| `lifecycle.gracefulShutdownSeconds` | Set termination grace period |
+| `runtime.health.interface` + `runtime.health.path` | Configure liveness/readiness probes |
+| `runtime.lifecycle.upgradeStrategy: ordered` | Use ordered pod management |
+| `runtime.lifecycle.gracefulShutdownSeconds` | Set termination grace period |
 | `scaling.min` / `scaling.max` | Configure auto-scaling bounds |
+| `configuration.schema` | Validate required configuration, generate config templates |
 | `dependencies[].ref` | Validate dependency graph, check compatibility |
+| `docs/` *(optional)* | Access service documentation, runbooks, integration guides |
 | `sbom/` *(optional)* | Audit third-party packages, track license compliance |
 
 ---
@@ -123,9 +125,9 @@ This invokes the `pacto-plugin-helm` plugin to produce Helm charts, Kubernetes m
 
 ### Workload type
 
-| `workload` | Kubernetes resource | Notes |
+| `runtime.workload` | Kubernetes resource | Notes |
 |---|---|---|
-| `service` | Deployment or StatefulSet | Based on `state.type` |
+| `service` | Deployment or StatefulSet | Based on `runtime.state.type` |
 | `job` | Job | No scaling, runs to completion |
 | `scheduled` | CronJob | Schedule defined externally |
 
@@ -133,7 +135,7 @@ This invokes the `pacto-plugin-helm` plugin to produce Helm charts, Kubernetes m
 
 The state model tells you exactly what storage and scheduling strategy a service needs:
 
-| `state.type` | `persistence` | Infrastructure |
+| `runtime.state.type` | `runtime.state.persistence` | Infrastructure |
 |---|---|---|
 | `stateless` | `local/ephemeral` | Deployment, no PVC, free to scale horizontally |
 | `stateful` | `local/persistent` | StatefulSet + PVC, stable identity per replica |
@@ -144,7 +146,7 @@ The state model tells you exactly what storage and scheduling strategy a service
 
 ### Upgrade strategy
 
-| `upgradeStrategy` | Kubernetes strategy |
+| `runtime.lifecycle.upgradeStrategy` | Kubernetes strategy |
 |---|---|
 | `rolling` | `RollingUpdate` |
 | `recreate` | `Recreate` |


### PR DESCRIPTION
## Summary

- **platform-engineers.md**: Add `runtime.` prefix to all runtime field paths in the "What a contract tells you", "State model", "Workload type", and "Upgrade strategy" tables. Add missing `configuration.schema` and `docs/` rows.
- **cli-reference.md**: Add missing `pacto_schema` MCP tool to the tools table.
- **contract-reference.md**: Add 4 missing Layer 2 validation rules (`PORT_IGNORED`, `HEALTH_PATH_IGNORED`, `EMPTY_COMPATIBILITY`, `TAG_NOT_DIGEST`) and add error code column to Layer 3 table (`UPGRADE_STRATEGY_STATE_MISMATCH`).

## Test plan

- [x] Verified all documented field paths match `pkg/contract` struct YAML tags
- [x] Cross-referenced validation rules against `internal/validation/crossfield.go` and `semantic.go`
- [x] Confirmed `pacto_schema` tool exists in `internal/mcp/server.go`
- [x] All tests pass