### PR TITLE
fix: populate RawYAML and preserve all bundle files through pull and cache

### DIFF
--- a/internal/app/pull_test.go
+++ b/internal/app/pull_test.go
@@ -31,9 +31,18 @@ func TestPull_Success(t *testing.T) {
 	if result.Version != "1.0.0" {
 		t.Errorf("expected Version=1.0.0, got %s", result.Version)
 	}
-	// Verify extracted file
-	if _, err := os.Stat(filepath.Join(output, "pacto.yaml")); err != nil {
-		t.Fatalf("expected pacto.yaml in output: %v", err)
+	// Verify ALL bundle files are extracted, not just pacto.yaml.
+	wantFiles := []string{
+		"pacto.yaml",
+		"openapi.yaml",
+		"docs/README.md",
+		"docs/runbook.md",
+	}
+	for _, f := range wantFiles {
+		p := filepath.Join(output, f)
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("expected %s in output: %v", f, err)
+		}
 	}
 }
 

--- a/internal/app/validate_test.go
+++ b/internal/app/validate_test.go
@@ -74,6 +74,7 @@ func TestValidate_OCIRef_MissingPactoYAML(t *testing.T) {
 		PullFn: func(_ context.Context, _ string) (*contract.Bundle, error) {
 			b := testBundle()
 			b.FS = fstest.MapFS{} // empty FS, no pacto.yaml
+			b.RawYAML = nil
 			return b, nil
 		},
 	}

--- a/internal/oci/bundle.go
+++ b/internal/oci/bundle.go
@@ -142,19 +142,18 @@ func imageToBundle(img v1.Image) (*contract.Bundle, error) {
 		return nil, fmt.Errorf("failed to extract layer: %w", err)
 	}
 
-	// Parse the contract from the extracted FS.
-	f, err := fsys.Open("pacto.yaml")
+	// Read raw YAML bytes and parse the contract from the extracted FS.
+	rawYAML, err := fs.ReadFile(fsys, "pacto.yaml")
 	if err != nil {
 		return nil, fmt.Errorf("bundle missing pacto.yaml: %w", err)
 	}
-	defer func() { _ = f.Close() }()
 
-	c, err := contract.Parse(f)
+	c, err := contract.Parse(bytes.NewReader(rawYAML))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse contract from bundle: %w", err)
 	}
 
-	return &contract.Bundle{Contract: c, FS: fsys}, nil
+	return &contract.Bundle{Contract: c, RawYAML: rawYAML, FS: fsys}, nil
 }
 
 const (

--- a/internal/oci/bundle_test.go
+++ b/internal/oci/bundle_test.go
@@ -31,23 +31,7 @@ func (tarErrWriter) Write([]byte) (int, error) { return 0, fmt.Errorf("write err
 
 func testBundle() *contract.Bundle {
 	port := 8080
-	return &contract.Bundle{
-		Contract: &contract.Contract{
-			PactoVersion: "1.0",
-			Service:      contract.ServiceIdentity{Name: "test-svc", Version: "1.0.0"},
-			Interfaces:   []contract.Interface{{Name: "api", Type: "http", Port: &port}},
-			Runtime: &contract.Runtime{
-				Workload: "service",
-				State: contract.State{
-					Type:            "stateless",
-					Persistence:     contract.Persistence{Scope: "local", Durability: "ephemeral"},
-					DataCriticality: "low",
-				},
-				Health: &contract.Health{Interface: "api", Path: "/health"},
-			},
-		},
-		FS: fstest.MapFS{
-			"pacto.yaml": &fstest.MapFile{Data: []byte(`pactoVersion: "1.0"
+	pactoYAML := []byte(`pactoVersion: "1.0"
 service:
   name: test-svc
   version: "1.0.0"
@@ -55,6 +39,7 @@ interfaces:
   - name: api
     type: http
     port: 8080
+    contract: openapi.yaml
 runtime:
   workload: service
   state:
@@ -66,7 +51,29 @@ runtime:
   health:
     interface: api
     path: /health
-`)},
+`)
+	return &contract.Bundle{
+		Contract: &contract.Contract{
+			PactoVersion: "1.0",
+			Service:      contract.ServiceIdentity{Name: "test-svc", Version: "1.0.0"},
+			Interfaces:   []contract.Interface{{Name: "api", Type: "http", Port: &port, Contract: "openapi.yaml"}},
+			Runtime: &contract.Runtime{
+				Workload: "service",
+				State: contract.State{
+					Type:            "stateless",
+					Persistence:     contract.Persistence{Scope: "local", Durability: "ephemeral"},
+					DataCriticality: "low",
+				},
+				Health: &contract.Health{Interface: "api", Path: "/health"},
+			},
+		},
+		RawYAML: pactoYAML,
+		FS: fstest.MapFS{
+			"pacto.yaml":      &fstest.MapFile{Data: pactoYAML},
+			"openapi.yaml":    &fstest.MapFile{Data: []byte("openapi: '3.0.0'\ninfo:\n  title: Test\n  version: '1.0.0'\npaths: {}\n")},
+			"docs":            &fstest.MapFile{Mode: fs.ModeDir | 0755},
+			"docs/README.md":  &fstest.MapFile{Data: []byte("# Test Service\n")},
+			"docs/runbook.md": &fstest.MapFile{Data: []byte("# Runbook\n")},
 		},
 	}
 }

--- a/internal/oci/cache.go
+++ b/internal/oci/cache.go
@@ -1,8 +1,10 @@
 package oci
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -160,18 +162,17 @@ func (c *CachedStore) loadFromCache(path string) (*contract.Bundle, error) {
 		return nil, err
 	}
 
-	pf, err := fsys.Open("pacto.yaml")
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = pf.Close() }()
-
-	ct, err := contract.Parse(pf)
+	rawYAML, err := fs.ReadFile(fsys, "pacto.yaml")
 	if err != nil {
 		return nil, err
 	}
 
-	return &contract.Bundle{Contract: ct, FS: fsys}, nil
+	ct, err := contract.Parse(bytes.NewReader(rawYAML))
+	if err != nil {
+		return nil, err
+	}
+
+	return &contract.Bundle{Contract: ct, RawYAML: rawYAML, FS: fsys}, nil
 }
 
 func (c *CachedStore) saveToCache(path string, bundle *contract.Bundle) error {

--- a/internal/oci/cache_test.go
+++ b/internal/oci/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -569,5 +570,55 @@ func TestCachedStore_XDGCacheHome(t *testing.T) {
 	}
 	if inner.pullCount.Load() != 1 {
 		t.Errorf("expected 1 inner pull with XDG cache, got %d", inner.pullCount.Load())
+	}
+}
+
+func TestCachedStore_Pull_AllFilesSurviveDiskCache(t *testing.T) {
+	cacheDir := t.TempDir()
+	old := oci.SetUserHomeDirFn(func() (string, error) { return cacheDir, nil })
+	t.Cleanup(func() { oci.SetUserHomeDirFn(old) })
+
+	ref := "ghcr.io/test/multifile:1.0.0"
+	ctx := context.Background()
+
+	// Store 1: populate disk cache with multi-file bundle.
+	inner1 := &countingStore{bundle: newTestBundle()}
+	store1 := oci.NewCachedStore(inner1)
+	if _, err := store1.Pull(ctx, ref); err != nil {
+		t.Fatalf("store1 Pull() error: %v", err)
+	}
+
+	// Store 2 (simulates new process): fresh in-memory cache, reads from disk.
+	inner2 := &countingStore{bundle: newTestBundle()}
+	store2 := oci.NewCachedStore(inner2)
+	b, err := store2.Pull(ctx, ref)
+	if err != nil {
+		t.Fatalf("store2 Pull() error: %v", err)
+	}
+	if inner2.pullCount.Load() != 0 {
+		t.Errorf("expected 0 inner pulls on store2 (disk hit), got %d", inner2.pullCount.Load())
+	}
+
+	// Verify RawYAML is populated from cache.
+	if b.RawYAML == nil {
+		t.Fatal("expected RawYAML to be populated from disk cache")
+	}
+
+	// Verify ALL files survived the disk cache round-trip.
+	wantFiles := map[string]string{
+		"pacto.yaml":      "test-svc",
+		"openapi.yaml":    "openapi:",
+		"docs/README.md":  "# Test Service",
+		"docs/runbook.md": "# Runbook",
+	}
+	for path, wantSubstr := range wantFiles {
+		data, err := fs.ReadFile(b.FS, path)
+		if err != nil {
+			t.Errorf("ReadFile(%s) error: %v — file not preserved in disk cache", path, err)
+			continue
+		}
+		if !strings.Contains(string(data), wantSubstr) {
+			t.Errorf("%s content = %q, want it to contain %q", path, string(data), wantSubstr)
+		}
 	}
 }

--- a/internal/oci/client_test.go
+++ b/internal/oci/client_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -35,23 +36,7 @@ func newTestClient(t *testing.T) (*oci.Client, string) {
 
 func newTestBundle() *contract.Bundle {
 	port := 8080
-	return &contract.Bundle{
-		Contract: &contract.Contract{
-			PactoVersion: "1.0",
-			Service:      contract.ServiceIdentity{Name: "test-svc", Version: "1.0.0"},
-			Interfaces:   []contract.Interface{{Name: "api", Type: "http", Port: &port}},
-			Runtime: &contract.Runtime{
-				Workload: "service",
-				State: contract.State{
-					Type:            "stateless",
-					Persistence:     contract.Persistence{Scope: "local", Durability: "ephemeral"},
-					DataCriticality: "low",
-				},
-				Health: &contract.Health{Interface: "api", Path: "/health"},
-			},
-		},
-		FS: fstest.MapFS{
-			"pacto.yaml": &fstest.MapFile{Data: []byte(`pactoVersion: "1.0"
+	pactoYAML := []byte(`pactoVersion: "1.0"
 service:
   name: test-svc
   version: "1.0.0"
@@ -59,6 +44,7 @@ interfaces:
   - name: api
     type: http
     port: 8080
+    contract: openapi.yaml
 runtime:
   workload: service
   state:
@@ -70,7 +56,29 @@ runtime:
   health:
     interface: api
     path: /health
-`)},
+`)
+	return &contract.Bundle{
+		Contract: &contract.Contract{
+			PactoVersion: "1.0",
+			Service:      contract.ServiceIdentity{Name: "test-svc", Version: "1.0.0"},
+			Interfaces:   []contract.Interface{{Name: "api", Type: "http", Port: &port, Contract: "openapi.yaml"}},
+			Runtime: &contract.Runtime{
+				Workload: "service",
+				State: contract.State{
+					Type:            "stateless",
+					Persistence:     contract.Persistence{Scope: "local", Durability: "ephemeral"},
+					DataCriticality: "low",
+				},
+				Health: &contract.Health{Interface: "api", Path: "/health"},
+			},
+		},
+		RawYAML: pactoYAML,
+		FS: fstest.MapFS{
+			"pacto.yaml":      &fstest.MapFile{Data: pactoYAML},
+			"openapi.yaml":    &fstest.MapFile{Data: []byte("openapi: '3.0.0'\ninfo:\n  title: Test\n  version: '1.0.0'\npaths: {}\n")},
+			"docs":            &fstest.MapFile{Mode: fs.ModeDir | 0755},
+			"docs/README.md":  &fstest.MapFile{Data: []byte("# Test Service\n")},
+			"docs/runbook.md": &fstest.MapFile{Data: []byte("# Runbook\n")},
 		},
 	}
 }
@@ -106,6 +114,31 @@ func TestClient_PushPull_Roundtrip(t *testing.T) {
 	}
 	if len(got.Contract.Interfaces) != len(b.Contract.Interfaces) {
 		t.Errorf("len(Interfaces) = %d, want %d", len(got.Contract.Interfaces), len(b.Contract.Interfaces))
+	}
+
+	// Verify RawYAML is populated after pull.
+	if got.RawYAML == nil {
+		t.Fatal("expected RawYAML to be populated after pull")
+	}
+	if !bytes.Contains(got.RawYAML, []byte("test-svc")) {
+		t.Errorf("RawYAML should contain service name, got %q", string(got.RawYAML))
+	}
+
+	// Verify all bundle files survive the round-trip.
+	wantFiles := map[string]string{
+		"openapi.yaml":    "openapi:",
+		"docs/README.md":  "# Test Service",
+		"docs/runbook.md": "# Runbook",
+	}
+	for path, wantSubstr := range wantFiles {
+		data, err := fs.ReadFile(got.FS, path)
+		if err != nil {
+			t.Errorf("ReadFile(%s) error: %v — file not preserved in OCI round-trip", path, err)
+			continue
+		}
+		if !strings.Contains(string(data), wantSubstr) {
+			t.Errorf("%s content = %q, want it to contain %q", path, string(data), wantSubstr)
+		}
 	}
 }
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -5,6 +5,7 @@ package testutil
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -75,6 +76,7 @@ interfaces:
   - name: api
     type: http
     port: 8080
+    contract: openapi.yaml
 runtime:
   workload: service
   state:
@@ -89,14 +91,32 @@ runtime:
 `)
 }
 
+// TestOpenAPI returns a minimal OpenAPI spec for testing.
+func TestOpenAPI() []byte {
+	return []byte(`openapi: "3.0.0"
+info:
+  title: Test API
+  version: "1.0.0"
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        "200":
+          description: OK
+`)
+}
+
 // TestBundle returns a valid in-memory Bundle for testing.
+// The bundle includes pacto.yaml plus additional files (openapi.yaml,
+// docs/) to verify that the full directory tree survives round-trips.
 func TestBundle() *contract.Bundle {
 	port := 8080
 	return &contract.Bundle{
 		Contract: &contract.Contract{
 			PactoVersion: "1.0",
 			Service:      contract.ServiceIdentity{Name: "test-svc", Version: "1.0.0"},
-			Interfaces:   []contract.Interface{{Name: "api", Type: "http", Port: &port}},
+			Interfaces:   []contract.Interface{{Name: "api", Type: "http", Port: &port, Contract: "openapi.yaml"}},
 			Runtime: &contract.Runtime{
 				Workload: "service",
 				State: contract.State{
@@ -107,24 +127,37 @@ func TestBundle() *contract.Bundle {
 				Health: &contract.Health{Interface: "api", Path: "/health"},
 			},
 		},
+		RawYAML: ValidPactoYAML(),
 		FS: fstest.MapFS{
-			"pacto.yaml": &fstest.MapFile{Data: ValidPactoYAML()},
+			"pacto.yaml":      &fstest.MapFile{Data: ValidPactoYAML()},
+			"openapi.yaml":    &fstest.MapFile{Data: TestOpenAPI()},
+			"docs":            &fstest.MapFile{Mode: fs.ModeDir | 0755},
+			"docs/README.md":  &fstest.MapFile{Data: []byte("# Test Service\n")},
+			"docs/runbook.md": &fstest.MapFile{Data: []byte("# Runbook\n")},
 		},
 	}
 }
 
 // WriteTestBundle creates a valid bundle directory structure in a temp dir
-// and returns the bundle directory path.
+// and returns the bundle directory path. The directory includes pacto.yaml
+// plus additional files to verify full directory tree handling.
 func WriteTestBundle(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	bundleDir := filepath.Join(dir, "bundle")
-	if err := os.MkdirAll(bundleDir, 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(bundleDir, "docs"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	pactoPath := filepath.Join(bundleDir, "pacto.yaml")
-	if err := os.WriteFile(pactoPath, ValidPactoYAML(), 0644); err != nil {
-		t.Fatal(err)
+	files := map[string][]byte{
+		"pacto.yaml":      ValidPactoYAML(),
+		"openapi.yaml":    TestOpenAPI(),
+		"docs/README.md":  []byte("# Test Service\n"),
+		"docs/runbook.md": []byte("# Runbook\n"),
+	}
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(bundleDir, name), data, 0644); err != nil {
+			t.Fatal(err)
+		}
 	}
 	return bundleDir
 }


### PR DESCRIPTION
## Summary

- **`imageToBundle()` and `loadFromCache()` were not populating `RawYAML`** on pulled/cached bundles, making them inconsistent with locally-loaded bundles and causing downstream operations to fall back to re-reading from FS
- **All test fixtures only contained `pacto.yaml`**, so no tests verified that additional files (OpenAPI specs, schemas, docs, subdirectories) survived the push→pull→cache→extract round-trip
- Both `imageToBundle()` and `loadFromCache()` now use `fs.ReadFile` + `bytes.NewReader` to populate `RawYAML`, matching the behavior of `loadLocalBundle()`
- Test fixtures updated across `testutil`, `oci/bundle_test`, `oci/client_test`, and `oci/cache_test` to include `openapi.yaml` and `docs/` subdirectory
- New assertions verify all bundle files survive OCI round-trips, disk cache persistence, and `extractBundleFS` extraction
- 100% test coverage maintained on both `internal/oci` and `internal/app`

## Test plan

- [x] `go test ./...` — all 14 packages pass
- [x] `go test -cover ./internal/oci/... ./internal/app/...` — 100% statement coverage
- [x] `TestClient_PushPull_Roundtrip` verifies all files + RawYAML survive OCI push/pull
- [x] `TestCachedStore_Pull_AllFilesSurviveDiskCache` verifies all files + RawYAML survive disk cache
- [x] `TestPull_Success` verifies all files extracted to disk output directory