### PR TITLE
docs: update Example links to point to pacto-demo repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Where OpenAPI describes the API and Helm describes the deployment, Pacto describ
 
 No runtime agents. No sidecars. No new infrastructure. Pacto runs at build time and CI time only.
 
-**[Documentation](https://trianalab.github.io/pacto)** · **[Quickstart](https://trianalab.github.io/pacto/quickstart)** · **[Specification](https://trianalab.github.io/pacto/contract-reference)** · **[Examples](https://trianalab.github.io/pacto/examples)**
+**[Documentation](https://trianalab.github.io/pacto)** · **[Quickstart](https://trianalab.github.io/pacto/quickstart)** · **[Specification](https://trianalab.github.io/pacto/contract-reference)** · **[Examples](https://trianalab.github.io/pacto/examples)** · **[Demo](https://github.com/TrianaLab/pacto-demo)**
 
 ---
 
@@ -411,6 +411,7 @@ Full documentation at **[trianalab.github.io/pacto](https://trianalab.github.io/
 | [MCP Integration](https://trianalab.github.io/pacto/mcp-integration) | Connect AI tools (Claude, Cursor, Copilot) to Pacto via MCP |
 | [Plugin Development](https://trianalab.github.io/pacto/plugins) | Build plugins to generate artifacts from contracts |
 | [Examples](https://trianalab.github.io/pacto/examples) | PostgreSQL, Redis, RabbitMQ, NGINX, Cron Worker |
+| [Demo](https://github.com/TrianaLab/pacto-demo) | Complete working demo repository |
 | [Architecture](https://trianalab.github.io/pacto/architecture) | Internal design for contributors |
 
 ---

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -10,6 +10,8 @@ has_children: true
 
 This section provides ready-to-use Pacto contracts for common infrastructure services. Use these as references when writing your own contracts or as dependencies in your service contracts.
 
+For a complete working demo repository, see [pacto-demo](https://github.com/TrianaLab/pacto-demo).
+
 ---
 
 <details open markdown="block">

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,8 @@ nav_order: 1
 
 [Get Started]({{ site.baseurl }}{% link quickstart.md %}){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Specification]({{ site.baseurl }}{% link contract-reference.md %}){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
-[Examples]({{ site.baseurl }}{% link examples/index.md %}){: .btn .fs-5 .mb-4 .mb-md-0 }
+[Examples]({{ site.baseurl }}{% link examples/index.md %}){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Demo](https://github.com/TrianaLab/pacto-demo){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 ---
 


### PR DESCRIPTION
## Summary
- Update Example links in README, docs index, and examples index to point to https://github.com/TrianaLab/pacto-demo
- Add a link to the pacto-demo repo in the examples documentation page