### PR TITLE
fix: flatten nested properties in schema diff

### DIFF
--- a/internal/diff/schema.go
+++ b/internal/diff/schema.go
@@ -11,23 +11,39 @@ func diffSchema(oldPath, newPath string, oldFS, newFS fs.FS) []Change {
 	return diffFileSet(oldPath, newPath, oldFS, newFS, readSchemaProperties, "schema.properties", "configuration property")
 }
 
-// readSchemaProperties reads a JSON Schema and extracts top-level property keys.
+// readSchemaProperties reads a JSON Schema and extracts property keys,
+// recursively flattening nested objects using dot notation (e.g. "postgres.host").
 func readSchemaProperties(fsys fs.FS, path string) (map[string]bool, error) {
 	data, err := fs.ReadFile(fsys, path)
 	if err != nil {
 		return nil, err
 	}
 
-	var schema struct {
-		Properties map[string]any `json:"properties"`
-	}
+	var schema schemaNode
 	if err := json.Unmarshal(data, &schema); err != nil {
 		return nil, err
 	}
 
-	props := make(map[string]bool, len(schema.Properties))
-	for p := range schema.Properties {
-		props[p] = true
-	}
+	props := make(map[string]bool)
+	flattenSchemaKeys("", schema.Properties, props)
 	return props, nil
+}
+
+// schemaNode represents a JSON Schema node with properties and type.
+type schemaNode struct {
+	Properties map[string]schemaNode `json:"properties"`
+	Type       string                `json:"type"`
+}
+
+// flattenSchemaKeys recursively collects property keys from a schema,
+// using dot notation for nested object properties.
+func flattenSchemaKeys(prefix string, properties map[string]schemaNode, out map[string]bool) {
+	for name, node := range properties {
+		fullName := prefix + name
+		if len(node.Properties) > 0 {
+			flattenSchemaKeys(fullName+".", node.Properties, out)
+		} else {
+			out[fullName] = true
+		}
+	}
 }

--- a/internal/diff/schema_test.go
+++ b/internal/diff/schema_test.go
@@ -61,3 +61,100 @@ func TestReadSchemaProperties_InvalidJSON(t *testing.T) {
 		t.Error("expected error for invalid JSON")
 	}
 }
+
+func TestDiffSchema_NestedPropertyAdded(t *testing.T) {
+	oldSchema := `{
+  "type": "object",
+  "properties": {
+    "existing": {
+      "type": "object",
+      "properties": {
+        "host": { "type": "string", "description": "Hostname" }
+      }
+    }
+  }
+}`
+	newSchema := `{
+  "type": "object",
+  "properties": {
+    "existing": {
+      "type": "object",
+      "properties": {
+        "host": { "type": "string", "description": "Hostname" }
+      }
+    },
+    "telemetry": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "endpoint": { "type": "string" },
+        "sample_rate": { "type": "number", "default": 1.0 }
+      }
+    }
+  }
+}`
+	oldFS := fstest.MapFS{"schema.json": &fstest.MapFile{Data: []byte(oldSchema)}}
+	newFS := fstest.MapFS{"schema.json": &fstest.MapFile{Data: []byte(newSchema)}}
+
+	changes := diffSchema("schema.json", "schema.json", oldFS, newFS)
+
+	// Should detect all three child properties, not just "telemetry".
+	if len(changes) != 3 {
+		t.Fatalf("expected 3 changes (telemetry.enabled, telemetry.endpoint, telemetry.sample_rate), got %d: %+v", len(changes), changes)
+	}
+	added := make(map[string]bool)
+	for _, c := range changes {
+		if c.Type != Added {
+			t.Errorf("expected Added change, got %v", c.Type)
+		}
+		added[c.NewValue.(string)] = true
+	}
+	for _, want := range []string{"telemetry.enabled", "telemetry.endpoint", "telemetry.sample_rate"} {
+		if !added[want] {
+			t.Errorf("expected %q to be added, got changes: %+v", want, changes)
+		}
+	}
+}
+
+func TestReadSchemaProperties_FlattensNested(t *testing.T) {
+	schema := `{
+  "type": "object",
+  "properties": {
+    "database": {
+      "type": "object",
+      "properties": {
+        "host": { "type": "string" },
+        "connection": {
+          "type": "object",
+          "properties": {
+            "timeout": { "type": "integer" },
+            "retries": { "type": "integer" }
+          }
+        }
+      }
+    },
+    "port": { "type": "integer" }
+  }
+}`
+	fs := fstest.MapFS{"schema.json": &fstest.MapFile{Data: []byte(schema)}}
+
+	props, err := readSchemaProperties(fs, "schema.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]bool{
+		"database.host":               true,
+		"database.connection.timeout": true,
+		"database.connection.retries": true,
+		"port":                        true,
+	}
+	if len(props) != len(want) {
+		t.Fatalf("expected %d properties, got %d: %v", len(want), len(props), props)
+	}
+	for k := range want {
+		if !props[k] {
+			t.Errorf("missing expected property %q", k)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `readSchemaProperties` in `internal/diff/schema.go` only extracted top-level property keys from JSON Schema files
- When a new config section (e.g. `telemetry`) with child fields was added, the PR diff comment only reported the parent object as added — none of its children were visible
- Recursively flatten nested object properties using dot notation (e.g. `telemetry.enabled`, `telemetry.endpoint`) to match the behavior already used in `internal/doc/schema.go`

## Test plan

- [x] Added `TestDiffSchema_NestedPropertyAdded` — verifies all child properties of a newly added section appear as individual changes
- [x] Added `TestReadSchemaProperties_FlattensNested` — verifies deeply nested properties are flattened with dot notation
- [x] All existing tests pass
- [x] `make ci` passes