### PR TITLE
feat: replace --swagger with --ui flag and add multi-interface support

### DIFF
--- a/cmd/gendocs/main.go
+++ b/cmd/gendocs/main.go
@@ -111,7 +111,7 @@ Reports cycles, version conflicts, and unreachable dependencies.
 
 Sibling dependencies are resolved in parallel. OCI bundles are cached locally in ` + "`~/.cache/pacto/oci/`" + ` for faster subsequent operations. Use ` + "`--no-cache`" + ` to bypass the cache.`,
 
-	"doc": "`--serve` and `--output` are mutually exclusive.\n\nSibling dependencies are resolved in parallel. OCI bundles are cached locally in `~/.cache/pacto/oci/` for faster subsequent operations. Use `--no-cache` to bypass the cache.",
+	"doc": "`--serve`, `--ui`, and `--output` are mutually exclusive.\n\nUse `--interface` to select a specific OpenAPI interface when multiple are present. Without it, an index page is shown.\n\nThe `--target` flag supports per-interface mapping: `--target api=http://localhost:3000 --target admin=http://localhost:4000`.\n\nSibling dependencies are resolved in parallel. OCI bundles are cached locally in `~/.cache/pacto/oci/` for faster subsequent operations. Use `--no-cache` to bypass the cache.",
 
 	"login": "Credentials are stored in `~/.config/pacto/config.json` (or `$XDG_CONFIG_HOME/pacto/config.json`), keeping them separate from Docker's configuration.\n\n" +
 		"### GitHub Container Registry (ghcr.io)\n\n" +

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,9 +11,6 @@ logo: "/assets/images/logo.png"
 
 permalink: pretty
 
-aux_links:
-  GitHub: https://github.com/TrianaLab/pacto
-
 nav_external_links:
   - title: GitHub
     url: https://github.com/TrianaLab/pacto

--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -1,3 +1,6 @@
+<a href="https://github.com/TrianaLab/pacto" target="_blank" rel="noopener" aria-label="GitHub" class="site-button btn-reset" style="cursor:pointer;color:inherit;opacity:0.7;display:inline-flex;align-items:center;" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.7'">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="20" height="20" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+</a>
 <span id="release-badge" style="display:none;font-size:0.85rem;font-weight:600;padding:0.25rem 0.75rem;margin-right:0.5rem;border:1px solid;border-radius:2rem;opacity:0.6;align-self:center;"></span>
 <script>
 (function() {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -103,24 +103,35 @@ pacto doc [dir | oci://ref] [flags]
   pacto doc my-service --serve --port 9090
 
   # Launch an interactive API explorer (Swagger/Scalar UI)
-  pacto doc my-service --swagger
+  pacto doc my-service --ui swagger
+
+  # Select a specific interface
+  pacto doc my-service --ui swagger --interface public-api
 
   # Point try-it-out requests to a running backend
-  pacto doc my-service --swagger --target http://localhost:3000
+  pacto doc my-service --ui swagger --target http://localhost:3000
+
+  # Per-interface target mapping
+  pacto doc my-service --ui swagger --target public-api=http://localhost:3000 --target admin-api=http://localhost:3001
 ```
 
 **Flags:**
 
 ```
-  -h, --help            help for doc
-  -o, --output string   output directory for generated Markdown file
-      --port int        port for the documentation server (used with --serve or --swagger) (default 8484)
-      --serve           start a local HTTP server to view documentation in the browser
-      --swagger         start a local API explorer with interactive Swagger UI
-      --target string   target server URL for try-it-out requests (used with --swagger)
+  -h, --help                 help for doc
+      --interface string     interface name to display (used with --ui)
+  -o, --output string        output directory for generated Markdown file
+      --port int             port for the documentation server (used with --serve or --ui) (default 8484)
+      --serve                start a local HTTP server to view documentation in the browser
+      --target stringArray   target server URL for try-it-out requests; supports interface=url mapping (used with --ui)
+      --ui string            UI type for interactive API explorer (e.g. swagger)
 ```
 
-`--serve` and `--output` are mutually exclusive.
+`--serve`, `--ui`, and `--output` are mutually exclusive.
+
+Use `--interface` to select a specific OpenAPI interface when multiple are present. Without it, an index page is shown.
+
+The `--target` flag supports per-interface mapping: `--target api=http://localhost:3000 --target admin=http://localhost:4000`.
 
 Sibling dependencies are resolved in parallel. OCI bundles are cached locally in `~/.cache/pacto/oci/` for faster subsequent operations. Use `--no-cache` to bypass the cache.
 

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -708,7 +708,7 @@ func TestDocCommand_ServeMutuallyExclusive(t *testing.T) {
 	}
 }
 
-func TestDocCommand_SwaggerFlag(t *testing.T) {
+func TestDocCommand_UISwaggerFlag(t *testing.T) {
 	bundleDir := testutil.WriteTestBundle(t)
 	svc := app.NewService(nil, nil)
 
@@ -716,47 +716,95 @@ func TestDocCommand_SwaggerFlag(t *testing.T) {
 	cancel()
 
 	root := cli.NewRootCommand(svc, "test")
-	root.SetArgs([]string{"doc", "--swagger", "--port", "0", bundleDir})
+	root.SetArgs([]string{"doc", "--ui", "swagger", "--port", "0", bundleDir})
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
 
 	if err := root.ExecuteContext(ctx); err != nil {
-		t.Fatalf("doc --swagger failed: %v", err)
+		t.Fatalf("doc --ui swagger failed: %v", err)
 	}
 }
 
-func TestDocCommand_SwaggerServeMutuallyExclusive(t *testing.T) {
+func TestDocCommand_UIWithInterface(t *testing.T) {
+	bundleDir := testutil.WriteTestBundle(t)
+	svc := app.NewService(nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	root := cli.NewRootCommand(svc, "test")
+	root.SetArgs([]string{"doc", "--ui", "swagger", "--interface", "api", "--port", "0", bundleDir})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+
+	if err := root.ExecuteContext(ctx); err != nil {
+		t.Fatalf("doc --ui swagger --interface api failed: %v", err)
+	}
+}
+
+func TestDocCommand_UIWithUnknownInterface(t *testing.T) {
 	bundleDir := testutil.WriteTestBundle(t)
 	svc := app.NewService(nil, nil)
 	root := cli.NewRootCommand(svc, "test")
-	root.SetArgs([]string{"doc", "--swagger", "--serve", bundleDir})
+	root.SetArgs([]string{"doc", "--ui", "swagger", "--interface", "nonexistent", bundleDir})
 
 	err := root.Execute()
 	if err == nil {
-		t.Error("expected error when --swagger and --serve are both set")
+		t.Error("expected error for unknown interface")
+	}
+	if !strings.Contains(err.Error(), "not found among OpenAPI interfaces") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestDocCommand_InterfaceWithoutUI(t *testing.T) {
+	bundleDir := testutil.WriteTestBundle(t)
+	svc := app.NewService(nil, nil)
+	root := cli.NewRootCommand(svc, "test")
+	root.SetArgs([]string{"doc", "--interface", "api", bundleDir})
+
+	err := root.Execute()
+	if err == nil {
+		t.Error("expected error when --interface used without --ui")
+	}
+	if !strings.Contains(err.Error(), "--interface requires --ui") {
+		t.Errorf("expected '--interface requires --ui' error, got: %v", err)
+	}
+}
+
+func TestDocCommand_UIServeMutuallyExclusive(t *testing.T) {
+	bundleDir := testutil.WriteTestBundle(t)
+	svc := app.NewService(nil, nil)
+	root := cli.NewRootCommand(svc, "test")
+	root.SetArgs([]string{"doc", "--ui", "swagger", "--serve", bundleDir})
+
+	err := root.Execute()
+	if err == nil {
+		t.Error("expected error when --ui and --serve are both set")
 	}
 	if !strings.Contains(err.Error(), "mutually exclusive") {
 		t.Errorf("expected mutually exclusive error, got: %v", err)
 	}
 }
 
-func TestDocCommand_SwaggerOutputMutuallyExclusive(t *testing.T) {
+func TestDocCommand_UIOutputMutuallyExclusive(t *testing.T) {
 	bundleDir := testutil.WriteTestBundle(t)
 	svc := app.NewService(nil, nil)
 	root := cli.NewRootCommand(svc, "test")
-	root.SetArgs([]string{"doc", "--swagger", "--output", "/tmp/out", bundleDir})
+	root.SetArgs([]string{"doc", "--ui", "swagger", "--output", "/tmp/out", bundleDir})
 
 	err := root.Execute()
 	if err == nil {
-		t.Error("expected error when --swagger and --output are both set")
+		t.Error("expected error when --ui and --output are both set")
 	}
 	if !strings.Contains(err.Error(), "mutually exclusive") {
 		t.Errorf("expected mutually exclusive error, got: %v", err)
 	}
 }
 
-func TestDocCommand_SwaggerNoSpecs(t *testing.T) {
+func TestDocCommand_UINoSpecs(t *testing.T) {
 	// Create a bundle with no HTTP interfaces (only gRPC).
 	store := &testutil.MockBundleStore{
 		PullFn: func(_ context.Context, _ string) (*contract.Bundle, error) {
@@ -780,7 +828,7 @@ func TestDocCommand_SwaggerNoSpecs(t *testing.T) {
 	}
 	svc := app.NewService(store, nil)
 	root := cli.NewRootCommand(svc, "test")
-	root.SetArgs([]string{"doc", "--swagger", "oci://ghcr.io/acme/svc:1.0.0"})
+	root.SetArgs([]string{"doc", "--ui", "swagger", "oci://ghcr.io/acme/svc:1.0.0"})
 
 	err := root.Execute()
 	if err == nil {
@@ -788,6 +836,42 @@ func TestDocCommand_SwaggerNoSpecs(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no HTTP interfaces") {
 		t.Errorf("expected 'no HTTP interfaces' error, got: %v", err)
+	}
+}
+
+func TestDocCommand_UIWithTarget(t *testing.T) {
+	bundleDir := testutil.WriteTestBundle(t)
+	svc := app.NewService(nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	root := cli.NewRootCommand(svc, "test")
+	root.SetArgs([]string{"doc", "--ui", "swagger", "--target", "http://localhost:3000", "--port", "0", bundleDir})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+
+	if err := root.ExecuteContext(ctx); err != nil {
+		t.Fatalf("doc --ui swagger --target failed: %v", err)
+	}
+}
+
+func TestDocCommand_UIWithPerInterfaceTarget(t *testing.T) {
+	bundleDir := testutil.WriteTestBundle(t)
+	svc := app.NewService(nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	root := cli.NewRootCommand(svc, "test")
+	root.SetArgs([]string{"doc", "--ui", "swagger", "--target", "api=http://localhost:3000", "--port", "0", bundleDir})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+
+	if err := root.ExecuteContext(ctx); err != nil {
+		t.Fatalf("doc --ui swagger --target api=url failed: %v", err)
 	}
 }
 

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -29,10 +30,16 @@ func newDocCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
   pacto doc my-service --serve --port 9090
 
   # Launch an interactive API explorer (Swagger/Scalar UI)
-  pacto doc my-service --swagger
+  pacto doc my-service --ui swagger
+
+  # Select a specific interface
+  pacto doc my-service --ui swagger --interface public-api
 
   # Point try-it-out requests to a running backend
-  pacto doc my-service --swagger --target http://localhost:3000`,
+  pacto doc my-service --ui swagger --target http://localhost:3000
+
+  # Per-interface target mapping
+  pacto doc my-service --ui swagger --target public-api=http://localhost:3000 --target admin-api=http://localhost:3001`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var path string
@@ -42,11 +49,12 @@ func newDocCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 
 			output, _ := cmd.Flags().GetString("output")
 			serve, _ := cmd.Flags().GetBool("serve")
-			swagger, _ := cmd.Flags().GetBool("swagger")
+			ui, _ := cmd.Flags().GetString("ui")
+			iface, _ := cmd.Flags().GetString("interface")
 			port, _ := cmd.Flags().GetInt("port")
-			target, _ := cmd.Flags().GetString("target")
+			targets, _ := cmd.Flags().GetStringArray("target")
 
-			if err := validateDocFlags(serve, swagger, output); err != nil {
+			if err := validateDocFlags(serve, ui, output, iface); err != nil {
 				return err
 			}
 
@@ -58,27 +66,13 @@ func newDocCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 				return err
 			}
 
-			if serve || swagger {
+			if ui != "" {
+				return serveUI(cmd, result, ui, iface, port, targets)
+			}
+			if serve {
 				ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 				defer stop()
-
 				addr := fmt.Sprintf("http://127.0.0.1:%d", port)
-
-				if swagger {
-					specs := doc.CollectSwaggerSpecs(result.Bundle.Contract.Interfaces)
-					if len(specs) == 0 {
-						return fmt.Errorf("no HTTP interfaces with OpenAPI contracts found")
-					}
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Serving API explorer at %s\nPress Ctrl+C to stop\n", addr)
-					return doc.ServeSwagger(ctx, doc.SwaggerOptions{
-						Specs:  specs,
-						FS:     result.Bundle.FS,
-						Title:  result.ServiceName,
-						Port:   port,
-						Target: target,
-					})
-				}
-
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Serving documentation at %s\nPress Ctrl+C to stop\n", addr)
 				return doc.Serve(ctx, result.Markdown, result.ServiceName, port)
 			}
@@ -90,19 +84,77 @@ func newDocCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 
 	cmd.Flags().StringP("output", "o", "", "output directory for generated Markdown file")
 	cmd.Flags().Bool("serve", false, "start a local HTTP server to view documentation in the browser")
-	cmd.Flags().Bool("swagger", false, "start a local API explorer with interactive Swagger UI")
-	cmd.Flags().Int("port", 8484, "port for the documentation server (used with --serve or --swagger)")
-	cmd.Flags().String("target", "", "target server URL for try-it-out requests (used with --swagger)")
+	cmd.Flags().String("ui", "", "UI type for interactive API explorer (e.g. swagger)")
+	cmd.Flags().String("interface", "", "interface name to display (used with --ui)")
+	cmd.Flags().Int("port", 8484, "port for the documentation server (used with --serve or --ui)")
+	cmd.Flags().StringArray("target", nil, "target server URL for try-it-out requests; supports interface=url mapping (used with --ui)")
 
 	return cmd
 }
 
-func validateDocFlags(serve, swagger bool, output string) error {
-	if serve && swagger {
-		return fmt.Errorf("--serve and --swagger are mutually exclusive")
+func serveUI(cmd *cobra.Command, result *app.DocResult, ui, iface string, port int, targets []string) error {
+	_ = ui // reserved for future UI types (e.g. redoc)
+
+	specs := doc.CollectSwaggerSpecs(result.Bundle.Contract.Interfaces)
+	if len(specs) == 0 {
+		return fmt.Errorf("no HTTP interfaces with OpenAPI contracts found")
 	}
-	if (serve || swagger) && output != "" {
-		return fmt.Errorf("--serve/--swagger and --output are mutually exclusive")
+
+	if iface != "" {
+		filtered := doc.FilterSpecs(specs, iface)
+		if len(filtered) == 0 {
+			return fmt.Errorf("interface %q not found among OpenAPI interfaces", iface)
+		}
+		specs = filtered
+	}
+
+	globalTarget, ifaceTargets := parseTargets(targets)
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	addr := fmt.Sprintf("http://127.0.0.1:%d", port)
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Serving API explorer at %s\nPress Ctrl+C to stop\n", addr)
+
+	return doc.ServeSwagger(ctx, doc.SwaggerOptions{
+		Specs:   specs,
+		FS:      result.Bundle.FS,
+		Title:   result.ServiceName,
+		Port:    port,
+		Target:  globalTarget,
+		Targets: ifaceTargets,
+	})
+}
+
+func validateDocFlags(serve bool, ui, output, iface string) error {
+	if serve && ui != "" {
+		return fmt.Errorf("--serve and --ui are mutually exclusive")
+	}
+	if (serve || ui != "") && output != "" {
+		return fmt.Errorf("--serve/--ui and --output are mutually exclusive")
+	}
+	if iface != "" && ui == "" {
+		return fmt.Errorf("--interface requires --ui")
 	}
 	return nil
+}
+
+// parseTargets splits target values into a global target and per-interface
+// targets. A value like "http://host:port" is a global target that applies
+// to all interfaces. A value like "api=http://host:port" maps to a specific
+// interface.
+func parseTargets(targets []string) (string, map[string]string) {
+	var global string
+	var ifaceTargets map[string]string
+	for _, t := range targets {
+		if idx := strings.Index(t, "="); idx > 0 && !strings.Contains(t[:idx], "://") {
+			if ifaceTargets == nil {
+				ifaceTargets = make(map[string]string)
+			}
+			ifaceTargets[t[:idx]] = t[idx+1:]
+		} else {
+			global = t
+		}
+	}
+	return global, ifaceTargets
 }

--- a/internal/cli/doc_internal_test.go
+++ b/internal/cli/doc_internal_test.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestValidateDocFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		serve   bool
+		ui      string
+		output  string
+		iface   string
+		wantErr string
+	}{
+		{
+			name: "all empty is valid",
+		},
+		{
+			name:  "serve alone is valid",
+			serve: true,
+		},
+		{
+			name: "ui alone is valid",
+			ui:   "swagger",
+		},
+		{
+			name:   "output alone is valid",
+			output: "/tmp/out",
+		},
+		{
+			name:  "ui with interface is valid",
+			ui:    "swagger",
+			iface: "api",
+		},
+		{
+			name:    "serve and ui are mutually exclusive",
+			serve:   true,
+			ui:      "swagger",
+			wantErr: "--serve and --ui are mutually exclusive",
+		},
+		{
+			name:    "serve and output are mutually exclusive",
+			serve:   true,
+			output:  "/tmp/out",
+			wantErr: "--serve/--ui and --output are mutually exclusive",
+		},
+		{
+			name:    "ui and output are mutually exclusive",
+			ui:      "swagger",
+			output:  "/tmp/out",
+			wantErr: "--serve/--ui and --output are mutually exclusive",
+		},
+		{
+			name:    "interface requires ui",
+			iface:   "api",
+			wantErr: "--interface requires --ui",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDocFlags(tt.serve, tt.ui, tt.output, tt.iface)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("expected error %q, got nil", tt.wantErr)
+				return
+			}
+			if err.Error() != tt.wantErr {
+				t.Errorf("expected error %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestParseTargets(t *testing.T) {
+	tests := []struct {
+		name           string
+		targets        []string
+		wantGlobal     string
+		wantInterfaces map[string]string
+	}{
+		{
+			name: "nil targets",
+		},
+		{
+			name:    "empty targets",
+			targets: []string{},
+		},
+		{
+			name:       "single global target",
+			targets:    []string{"http://localhost:3000"},
+			wantGlobal: "http://localhost:3000",
+		},
+		{
+			name:           "single per-interface target",
+			targets:        []string{"api=http://localhost:3000"},
+			wantInterfaces: map[string]string{"api": "http://localhost:3000"},
+		},
+		{
+			name:           "global and per-interface",
+			targets:        []string{"http://global:3000", "admin=http://admin:4000"},
+			wantGlobal:     "http://global:3000",
+			wantInterfaces: map[string]string{"admin": "http://admin:4000"},
+		},
+		{
+			name:    "multiple per-interface",
+			targets: []string{"api=http://api:3000", "admin=http://admin:4000"},
+			wantInterfaces: map[string]string{
+				"api":   "http://api:3000",
+				"admin": "http://admin:4000",
+			},
+		},
+		{
+			name:       "last global wins",
+			targets:    []string{"http://first:3000", "http://second:4000"},
+			wantGlobal: "http://second:4000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			global, ifaces := parseTargets(tt.targets)
+			if global != tt.wantGlobal {
+				t.Errorf("global: expected %q, got %q", tt.wantGlobal, global)
+			}
+			if tt.wantInterfaces == nil {
+				if ifaces != nil {
+					t.Errorf("expected nil interfaces, got %v", ifaces)
+				}
+				return
+			}
+			if len(ifaces) != len(tt.wantInterfaces) {
+				t.Fatalf("expected %d interfaces, got %d: %v", len(tt.wantInterfaces), len(ifaces), ifaces)
+			}
+			for k, v := range tt.wantInterfaces {
+				if ifaces[k] != v {
+					t.Errorf("interface %q: expected %q, got %q", k, v, ifaces[k])
+				}
+			}
+		})
+	}
+}

--- a/internal/doc/swagger.go
+++ b/internal/doc/swagger.go
@@ -35,13 +35,52 @@ func CollectSwaggerSpecs(interfaces []contract.Interface) []SwaggerSpec {
 	return specs
 }
 
+// FilterSpecs returns only the spec matching the given interface name.
+// It returns nil if no match is found.
+func FilterSpecs(specs []SwaggerSpec, name string) []SwaggerSpec {
+	for _, s := range specs {
+		if s.InterfaceName == name {
+			return []SwaggerSpec{s}
+		}
+	}
+	return nil
+}
+
 // SwaggerOptions configures the interactive API explorer server.
 type SwaggerOptions struct {
-	Specs  []SwaggerSpec
-	FS     fs.FS
-	Title  string
-	Port   int
-	Target string // if set, overrides the servers array and proxies requests
+	Specs   []SwaggerSpec
+	FS      fs.FS
+	Title   string
+	Port    int
+	Target  string            // global target; applies to all interfaces
+	Targets map[string]string // per-interface targets; overrides Target
+}
+
+// targetFor returns the target URL for a specific interface.
+// Per-interface targets take precedence over the global target.
+func (o SwaggerOptions) targetFor(name string) string {
+	if t, ok := o.Targets[name]; ok {
+		return t
+	}
+	return o.Target
+}
+
+// allowedTargets returns all unique target URLs from both global and
+// per-interface targets, used for proxy validation.
+func allowedTargets(opts SwaggerOptions) []string {
+	seen := make(map[string]bool)
+	var targets []string
+	if opts.Target != "" {
+		seen[opts.Target] = true
+		targets = append(targets, opts.Target)
+	}
+	for _, t := range opts.Targets {
+		if !seen[t] {
+			seen[t] = true
+			targets = append(targets, t)
+		}
+	}
+	return targets
 }
 
 // ServeSwagger starts a local HTTP server that renders an interactive API
@@ -61,21 +100,24 @@ func ServeSwagger(ctx context.Context, opts SwaggerOptions) error {
 func ServeSwaggerOnListener(ctx context.Context, opts SwaggerOptions, ln net.Listener) error {
 	mux := http.NewServeMux()
 
-	if opts.Target != "" {
-		mux.HandleFunc("/proxy", newProxyHandler(opts.Target))
+	targets := allowedTargets(opts)
+	if len(targets) > 0 {
+		mux.HandleFunc("/proxy", newProxyHandler(targets))
 	}
 
 	for _, s := range opts.Specs {
-		registerSpecHandler(mux, s, opts.FS, opts.Target)
+		target := opts.targetFor(s.InterfaceName)
+		registerSpecHandler(mux, s, opts.FS, target)
 	}
 
+	hasProxy := len(targets) > 0
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {
 			http.NotFound(w, r)
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = fmt.Fprint(w, buildSwaggerPage(opts.Specs, opts.Title, opts.Target != ""))
+		_, _ = fmt.Fprint(w, buildSwaggerPage(opts.Specs, opts.Title, hasProxy))
 	})
 
 	srv := &http.Server{Handler: mux}
@@ -141,7 +183,10 @@ func overrideServers(specJSON []byte, serverURL string) ([]byte, error) {
 // target. Scalar sends requests to the proxy with the full upstream URL
 // in the scalar_url query parameter. This avoids CORS by keeping browser
 // traffic same-origin while showing the real URL in the UI.
-func newProxyHandler(target string) http.HandlerFunc {
+//
+// The allowed slice lists URL prefixes that the proxy is permitted to
+// forward to, preventing open-proxy abuse.
+func newProxyHandler(allowed []string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		targetURL := r.URL.Query().Get("scalar_url")
 		if targetURL == "" {
@@ -149,8 +194,14 @@ func newProxyHandler(target string) http.HandlerFunc {
 			return
 		}
 
-		// Only allow proxying to the configured target origin.
-		if !strings.HasPrefix(targetURL, target) {
+		ok := false
+		for _, t := range allowed {
+			if strings.HasPrefix(targetURL, t) {
+				ok = true
+				break
+			}
+		}
+		if !ok {
 			http.Error(w, "target not allowed", http.StatusForbidden)
 			return
 		}

--- a/internal/doc/swagger_test.go
+++ b/internal/doc/swagger_test.go
@@ -43,6 +43,106 @@ func TestCollectSwaggerSpecs_Empty(t *testing.T) {
 	}
 }
 
+func TestFilterSpecs(t *testing.T) {
+	specs := []SwaggerSpec{
+		{InterfaceName: "api", SpecPath: "api.yaml"},
+		{InterfaceName: "admin", SpecPath: "admin.yaml"},
+	}
+
+	filtered := FilterSpecs(specs, "admin")
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 spec, got %d", len(filtered))
+	}
+	if filtered[0].InterfaceName != "admin" {
+		t.Errorf("expected 'admin', got %q", filtered[0].InterfaceName)
+	}
+}
+
+func TestFilterSpecs_NotFound(t *testing.T) {
+	specs := []SwaggerSpec{
+		{InterfaceName: "api", SpecPath: "api.yaml"},
+	}
+	if filtered := FilterSpecs(specs, "missing"); filtered != nil {
+		t.Errorf("expected nil for missing interface, got %v", filtered)
+	}
+}
+
+func TestFilterSpecs_Empty(t *testing.T) {
+	if filtered := FilterSpecs(nil, "api"); filtered != nil {
+		t.Errorf("expected nil for empty specs, got %v", filtered)
+	}
+}
+
+func TestTargetFor(t *testing.T) {
+	opts := SwaggerOptions{
+		Target:  "http://global:3000",
+		Targets: map[string]string{"admin": "http://admin:4000"},
+	}
+
+	if got := opts.targetFor("admin"); got != "http://admin:4000" {
+		t.Errorf("expected per-interface target, got %q", got)
+	}
+	if got := opts.targetFor("api"); got != "http://global:3000" {
+		t.Errorf("expected global target fallback, got %q", got)
+	}
+}
+
+func TestTargetFor_NoTargets(t *testing.T) {
+	opts := SwaggerOptions{Target: "http://global:3000"}
+	if got := opts.targetFor("api"); got != "http://global:3000" {
+		t.Errorf("expected global target, got %q", got)
+	}
+}
+
+func TestTargetFor_NoGlobal(t *testing.T) {
+	opts := SwaggerOptions{Targets: map[string]string{"admin": "http://admin:4000"}}
+	if got := opts.targetFor("api"); got != "" {
+		t.Errorf("expected empty for unmatched interface, got %q", got)
+	}
+}
+
+func TestAllowedTargets(t *testing.T) {
+	opts := SwaggerOptions{
+		Target:  "http://global:3000",
+		Targets: map[string]string{"admin": "http://admin:4000"},
+	}
+	targets := allowedTargets(opts)
+	if len(targets) != 2 {
+		t.Fatalf("expected 2 targets, got %d", len(targets))
+	}
+}
+
+func TestAllowedTargets_Deduplicate(t *testing.T) {
+	opts := SwaggerOptions{
+		Target:  "http://same:3000",
+		Targets: map[string]string{"admin": "http://same:3000"},
+	}
+	targets := allowedTargets(opts)
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 deduplicated target, got %d", len(targets))
+	}
+}
+
+func TestAllowedTargets_Empty(t *testing.T) {
+	targets := allowedTargets(SwaggerOptions{})
+	if len(targets) != 0 {
+		t.Errorf("expected 0 targets, got %d", len(targets))
+	}
+}
+
+func TestAllowedTargets_OnlyPerInterface(t *testing.T) {
+	opts := SwaggerOptions{
+		Targets: map[string]string{"admin": "http://admin:4000"},
+	}
+	targets := allowedTargets(opts)
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+	if targets[0] != "http://admin:4000" {
+		t.Errorf("expected admin target, got %q", targets[0])
+	}
+}
+
 func TestServeSwagger(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -496,8 +596,132 @@ paths: {}
 	<-errCh
 }
 
+func TestServeSwaggerOnListener_PerInterfaceTargets(t *testing.T) {
+	fsys := fstest.MapFS{
+		"api.yaml": &fstest.MapFile{Data: []byte(`openapi: "3.0.0"
+info:
+  title: API
+  version: "1.0.0"
+paths: {}
+`)},
+		"admin.yaml": &fstest.MapFile{Data: []byte(`openapi: "3.0.0"
+info:
+  title: Admin API
+  version: "1.0.0"
+paths: {}
+`)},
+	}
+	specs := []SwaggerSpec{
+		{InterfaceName: "api", SpecPath: "api.yaml"},
+		{InterfaceName: "admin", SpecPath: "admin.yaml"},
+	}
+
+	upstream1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "upstream1")
+	}))
+	defer upstream1.Close()
+
+	upstream2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "upstream2")
+	}))
+	defer upstream2.Close()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- ServeSwaggerOnListener(ctx, SwaggerOptions{
+			Specs: specs,
+			FS:    fsys,
+			Title: "multi-target",
+			Targets: map[string]string{
+				"api":   upstream1.URL,
+				"admin": upstream2.URL,
+			},
+		}, ln)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify api spec has upstream1's URL in servers.
+	resp, err := http.Get(fmt.Sprintf("http://%s/spec/api", addr))
+	if err != nil {
+		t.Fatalf("GET /spec/api failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	var specJSON map[string]any
+	if err := json.Unmarshal(body, &specJSON); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	servers := specJSON["servers"].([]any)
+	if got := servers[0].(map[string]any)["url"].(string); got != upstream1.URL {
+		t.Errorf("expected api spec server to be upstream1, got %q", got)
+	}
+
+	// Verify admin spec has upstream2's URL in servers.
+	resp2, err := http.Get(fmt.Sprintf("http://%s/spec/admin", addr))
+	if err != nil {
+		t.Fatalf("GET /spec/admin failed: %v", err)
+	}
+	defer func() { _ = resp2.Body.Close() }()
+	body2, _ := io.ReadAll(resp2.Body)
+	var adminJSON map[string]any
+	if err := json.Unmarshal(body2, &adminJSON); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	adminServers := adminJSON["servers"].([]any)
+	if got := adminServers[0].(map[string]any)["url"].(string); got != upstream2.URL {
+		t.Errorf("expected admin spec server to be upstream2, got %q", got)
+	}
+
+	// Proxy should allow both upstreams.
+	proxyURL1 := fmt.Sprintf("http://%s/proxy?scalar_url=%s/test", addr, upstream1.URL)
+	pr1, err := http.Get(proxyURL1)
+	if err != nil {
+		t.Fatalf("proxy to upstream1 failed: %v", err)
+	}
+	defer func() { _ = pr1.Body.Close() }()
+	if pr1.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 from proxy to upstream1, got %d", pr1.StatusCode)
+	}
+
+	proxyURL2 := fmt.Sprintf("http://%s/proxy?scalar_url=%s/test", addr, upstream2.URL)
+	pr2, err := http.Get(proxyURL2)
+	if err != nil {
+		t.Fatalf("proxy to upstream2 failed: %v", err)
+	}
+	defer func() { _ = pr2.Body.Close() }()
+	if pr2.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 from proxy to upstream2, got %d", pr2.StatusCode)
+	}
+
+	// Page should have proxy attribute.
+	pageResp, err := http.Get(fmt.Sprintf("http://%s/", addr))
+	if err != nil {
+		t.Fatalf("GET / failed: %v", err)
+	}
+	defer func() { _ = pageResp.Body.Close() }()
+	pageBody, _ := io.ReadAll(pageResp.Body)
+	if !strings.Contains(string(pageBody), "proxyUrl") {
+		t.Error("expected proxy attribute in multi-spec page with targets")
+	}
+
+	cancel()
+	<-errCh
+}
+
 func TestProxyHandler_MissingScalarURL(t *testing.T) {
-	handler := newProxyHandler("http://example.com")
+	handler := newProxyHandler([]string{"http://example.com"})
 	req := httptest.NewRequest(http.MethodGet, "/proxy", nil)
 	rr := httptest.NewRecorder()
 
@@ -509,7 +733,7 @@ func TestProxyHandler_MissingScalarURL(t *testing.T) {
 }
 
 func TestProxyHandler_ForbiddenTarget(t *testing.T) {
-	handler := newProxyHandler("http://allowed.example.com")
+	handler := newProxyHandler([]string{"http://allowed.example.com"})
 	req := httptest.NewRequest(http.MethodGet, "/proxy?scalar_url=http://evil.example.com/path", nil)
 	rr := httptest.NewRecorder()
 
@@ -521,7 +745,7 @@ func TestProxyHandler_ForbiddenTarget(t *testing.T) {
 }
 
 func TestProxyHandler_UpstreamUnreachable(t *testing.T) {
-	handler := newProxyHandler("http://127.0.0.1:1")
+	handler := newProxyHandler([]string{"http://127.0.0.1:1"})
 	req := httptest.NewRequest(http.MethodGet, "/proxy?scalar_url=http://127.0.0.1:1/test", nil)
 	rr := httptest.NewRecorder()
 
@@ -529,6 +753,35 @@ func TestProxyHandler_UpstreamUnreachable(t *testing.T) {
 
 	if rr.Code != http.StatusBadGateway {
 		t.Errorf("expected 502, got %d", rr.Code)
+	}
+}
+
+func TestProxyHandler_MultipleAllowedTargets(t *testing.T) {
+	handler := newProxyHandler([]string{"http://a.example.com", "http://b.example.com"})
+
+	// First allowed target.
+	req1 := httptest.NewRequest(http.MethodGet, "/proxy?scalar_url=http://a.example.com/path", nil)
+	rr1 := httptest.NewRecorder()
+	handler.ServeHTTP(rr1, req1)
+	// Will be 502 (unreachable) not 403 (forbidden) — proving it's allowed.
+	if rr1.Code == http.StatusForbidden {
+		t.Error("expected target a to be allowed")
+	}
+
+	// Second allowed target.
+	req2 := httptest.NewRequest(http.MethodGet, "/proxy?scalar_url=http://b.example.com/path", nil)
+	rr2 := httptest.NewRecorder()
+	handler.ServeHTTP(rr2, req2)
+	if rr2.Code == http.StatusForbidden {
+		t.Error("expected target b to be allowed")
+	}
+
+	// Disallowed target.
+	req3 := httptest.NewRequest(http.MethodGet, "/proxy?scalar_url=http://c.example.com/path", nil)
+	rr3 := httptest.NewRecorder()
+	handler.ServeHTTP(rr3, req3)
+	if rr3.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for disallowed target, got %d", rr3.Code)
 	}
 }
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -879,6 +879,94 @@ func TestDocCommand(t *testing.T) {
 
 		assertContains(t, output, "# postgres-pacto")
 	})
+
+	t.Run("ui swagger with zero interfaces errors", func(t *testing.T) {
+		path := writeZeroInterfaceBundle(t)
+		_, err := runCommand(t, nil, "doc", "--ui", "swagger", path)
+		if err == nil {
+			t.Fatal("expected error for --ui swagger with zero HTTP interfaces")
+		}
+		assertContains(t, err.Error(), "no HTTP interfaces")
+	})
+
+	t.Run("ui swagger with one interface", func(t *testing.T) {
+		path := writeMyAppV1Bundle(t, "localhost")
+		_, err := runCommandWithCancelledCtx(t, nil, "doc", "--ui", "swagger", "--port", "0", path)
+		if err != nil {
+			t.Fatalf("doc --ui swagger failed: %v", err)
+		}
+	})
+
+	t.Run("ui swagger with two interfaces", func(t *testing.T) {
+		path := writeTwoInterfaceBundle(t)
+		_, err := runCommandWithCancelledCtx(t, nil, "doc", "--ui", "swagger", "--port", "0", path)
+		if err != nil {
+			t.Fatalf("doc --ui swagger with 2 interfaces failed: %v", err)
+		}
+	})
+
+	t.Run("ui swagger with interface filter", func(t *testing.T) {
+		path := writeTwoInterfaceBundle(t)
+		_, err := runCommandWithCancelledCtx(t, nil, "doc", "--ui", "swagger", "--interface", "admin-api", "--port", "0", path)
+		if err != nil {
+			t.Fatalf("doc --ui swagger --interface admin-api failed: %v", err)
+		}
+	})
+
+	t.Run("ui swagger with unknown interface errors", func(t *testing.T) {
+		path := writeTwoInterfaceBundle(t)
+		_, err := runCommand(t, nil, "doc", "--ui", "swagger", "--interface", "nonexistent", path)
+		if err == nil {
+			t.Fatal("expected error for unknown interface")
+		}
+		assertContains(t, err.Error(), "not found among OpenAPI interfaces")
+	})
+
+	t.Run("interface without ui errors", func(t *testing.T) {
+		path := writeMyAppV1Bundle(t, "localhost")
+		_, err := runCommand(t, nil, "doc", "--interface", "api", path)
+		if err == nil {
+			t.Fatal("expected error for --interface without --ui")
+		}
+		assertContains(t, err.Error(), "--interface requires --ui")
+	})
+
+	t.Run("ui and serve mutually exclusive", func(t *testing.T) {
+		path := writeMyAppV1Bundle(t, "localhost")
+		_, err := runCommand(t, nil, "doc", "--ui", "swagger", "--serve", path)
+		if err == nil {
+			t.Fatal("expected error for --ui with --serve")
+		}
+		assertContains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("ui and output mutually exclusive", func(t *testing.T) {
+		path := writeMyAppV1Bundle(t, "localhost")
+		_, err := runCommand(t, nil, "doc", "--ui", "swagger", "--output", t.TempDir(), path)
+		if err == nil {
+			t.Fatal("expected error for --ui with --output")
+		}
+		assertContains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("ui swagger with global target", func(t *testing.T) {
+		path := writeMyAppV1Bundle(t, "localhost")
+		_, err := runCommandWithCancelledCtx(t, nil, "doc", "--ui", "swagger", "--target", "http://localhost:3000", "--port", "0", path)
+		if err != nil {
+			t.Fatalf("doc --ui swagger --target failed: %v", err)
+		}
+	})
+
+	t.Run("ui swagger with per-interface targets", func(t *testing.T) {
+		path := writeTwoInterfaceBundle(t)
+		_, err := runCommandWithCancelledCtx(t, nil, "doc", "--ui", "swagger",
+			"--target", "public-api=http://localhost:3000",
+			"--target", "admin-api=http://localhost:3001",
+			"--port", "0", path)
+		if err != nil {
+			t.Fatalf("doc --ui swagger with per-interface targets failed: %v", err)
+		}
+	})
 }
 
 func TestGenerateCommand(t *testing.T) {

--- a/tests/e2e/fixtures_test.go
+++ b/tests/e2e/fixtures_test.go
@@ -585,6 +585,118 @@ func writeBundleWithSBOM(t *testing.T, version, sbomFileName, sbomContent string
 	return bundlePath
 }
 
+const twoInterfaceContract = `pactoVersion: "1.0"
+service:
+  name: two-iface-svc
+  version: "1.0.0"
+interfaces:
+  - name: public-api
+    type: http
+    port: 8080
+    visibility: public
+    contract: interfaces/public.yaml
+  - name: admin-api
+    type: http
+    port: 9090
+    visibility: internal
+    contract: interfaces/admin.yaml
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: public-api
+    path: /health
+`
+
+const publicOpenAPI = `openapi: "3.0.0"
+info:
+  title: Public API
+  version: "1.0.0"
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        "200":
+          description: OK
+  /products:
+    get:
+      summary: List products
+      responses:
+        "200":
+          description: Product list
+`
+
+const adminOpenAPI = `openapi: "3.0.0"
+info:
+  title: Admin API
+  version: "1.0.0"
+paths:
+  /admin/users:
+    get:
+      summary: List all users (admin)
+      responses:
+        "200":
+          description: User list
+  /admin/config:
+    put:
+      summary: Update configuration
+      responses:
+        "200":
+          description: Updated
+`
+
+const zeroInterfaceContract = `pactoVersion: "1.0"
+service:
+  name: zero-iface-svc
+  version: "1.0.0"
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+`
+
+// writeTwoInterfaceBundle creates a bundle with two HTTP/OpenAPI interfaces.
+func writeTwoInterfaceBundle(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "two-iface-svc")
+	if err := os.MkdirAll(filepath.Join(dir, "interfaces"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pacto.yaml"), []byte(twoInterfaceContract), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "interfaces", "public.yaml"), []byte(publicOpenAPI), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "interfaces", "admin.yaml"), []byte(adminOpenAPI), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// writeZeroInterfaceBundle creates a bundle with no interfaces.
+func writeZeroInterfaceBundle(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "zero-iface-svc")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pacto.yaml"), []byte(zeroInterfaceContract), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
 // writeOpenAPIDiffBundleV1 creates a bundle with the v1 OpenAPI spec.
 func writeOpenAPIDiffBundleV1(t *testing.T) string {
 	t.Helper()

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"io"
 	"net/http/httptest"
 	"os"
@@ -74,6 +75,31 @@ func runCommandWithVersion(t *testing.T, reg *testRegistry, version string, args
 	root.SetArgs(args)
 
 	err := root.Execute()
+	return out.String(), err
+}
+
+// runCommandWithCancelledCtx executes a pacto CLI command with a pre-cancelled
+// context, useful for testing commands that start servers (--serve, --ui).
+func runCommandWithCancelledCtx(t *testing.T, reg *testRegistry, args ...string) (string, error) {
+	t.Helper()
+
+	var store oci.BundleStore
+	if reg != nil {
+		store = reg.client
+	}
+
+	svc := app.NewService(store, &plugin.SubprocessRunner{})
+	root := cli.NewRootCommand(svc, "test-e2e")
+
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs(args)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := root.ExecuteContext(ctx)
 	return out.String(), err
 }
 


### PR DESCRIPTION
## Summary

- **Replace `--swagger` with `--ui swagger`** as the canonical flag for launching the interactive API explorer
- **Add `--interface` flag** to select a specific interface when multiple OpenAPI specs exist
- **Add per-interface `--target` mapping** (`--target api=http://localhost:3000 --target admin=http://localhost:4000`)
- **Handle 0, 1, and N interfaces** deterministically: error if none, direct serve if one, index page if many
- **Replace GitHub text link** in docs site header with a GitHub SVG icon
- **100% test coverage** across `internal/doc`, `internal/cli`, and `internal/app`

## Changes

| File | What |
|------|------|
| `internal/cli/doc.go` | New `--ui`, `--interface`, `--target` (StringArray) flags; extracted `serveUI` helper; `parseTargets` for global vs per-interface targets |
| `internal/doc/swagger.go` | `FilterSpecs`, `SwaggerOptions.Targets`, `targetFor`, `allowedTargets`, multi-target proxy validation |
| `internal/cli/doc_internal_test.go` | Unit tests for `validateDocFlags` (9 cases) and `parseTargets` (7 cases) |
| `internal/cli/commands_test.go` | 8 new CLI integration tests for `--ui`, `--interface`, mutual exclusivity, targets |
| `internal/doc/swagger_test.go` | 12 new tests: filter, targetFor, allowedTargets, per-interface proxy, multi-target |
| `tests/e2e/` | 10 new e2e tests covering 0/1/2 interfaces, filtering, errors, mutual exclusivity, targets |
| `docs/` | GitHub icon in header, regenerated CLI reference |
| `cmd/gendocs/main.go` | Updated doc command notes |

## Test plan

- [x] `make ci` passes (gofmt, gocyclo, all unit + e2e tests)
- [x] 100% coverage in `internal/doc`, `internal/cli`, `internal/app`
- [x] Manual testing with 0, 1, and 2 interface bundles
- [x] Manual testing of `--serve`, `--ui`, `--interface`, `--target`, mutual exclusivity
- [x] Proxy validates allowed targets and rejects disallowed ones
- [x] Per-interface `--target` overrides spec `servers` array correctly