### PR TITLE
fix: reduce cyclomatic complexity in test functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ci-vet:
 ci-cyclo:
 	@echo "==> Checking cyclomatic complexity..."
 	go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
-	gocyclo -over 15 $$(find . -name '*.go' ! -name '*_test.go' ! -path './vendor/*')
+	gocyclo -over 15 $$(find . -name '*.go' ! -path './vendor/*')
 
 ci-lint:
 	@echo "==> Running linter..."

--- a/internal/doc/swagger_test.go
+++ b/internal/doc/swagger_test.go
@@ -186,7 +186,8 @@ func TestServeSwaggerOnListener_ClosedListener(t *testing.T) {
 	}
 }
 
-func TestServeSwaggerOnListener_SingleSpec(t *testing.T) {
+func startSingleSpecServer(t *testing.T) (addr string, cancel context.CancelFunc, wait func()) {
+	t.Helper()
 	fsys := fstest.MapFS{
 		"openapi.yaml": &fstest.MapFile{Data: []byte(`openapi: "3.0.0"
 info:
@@ -204,10 +205,9 @@ paths:
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	addr := ln.Addr().String()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	var ctx context.Context
+	ctx, cancel = context.WithCancel(context.Background())
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -216,7 +216,18 @@ paths:
 
 	time.Sleep(50 * time.Millisecond)
 
-	// Test the landing page.
+	wait = func() {
+		if err := <-errCh; err != nil {
+			t.Errorf("serve returned error: %v", err)
+		}
+	}
+	return ln.Addr().String(), cancel, wait
+}
+
+func TestServeSwaggerOnListener_SingleSpecLandingPage(t *testing.T) {
+	addr, cancel, wait := startSingleSpecServer(t)
+	defer func() { cancel(); wait() }()
+
 	resp, err := http.Get(fmt.Sprintf("http://%s/", addr))
 	if err != nil {
 		t.Fatalf("GET / failed: %v", err)
@@ -242,39 +253,37 @@ paths:
 	if !strings.Contains(html, "/spec/api") {
 		t.Error("expected spec URL in HTML")
 	}
-	// No proxy attr when target is not set.
 	if strings.Contains(html, "proxy") {
 		t.Error("expected no proxy attribute without target")
 	}
+}
 
-	// Test the spec endpoint.
-	resp2, err := http.Get(fmt.Sprintf("http://%s/spec/api", addr))
+func TestServeSwaggerOnListener_SingleSpecEndpoint(t *testing.T) {
+	addr, cancel, wait := startSingleSpecServer(t)
+	defer func() { cancel(); wait() }()
+
+	resp, err := http.Get(fmt.Sprintf("http://%s/spec/api", addr))
 	if err != nil {
 		t.Fatalf("GET /spec/api failed: %v", err)
 	}
-	defer func() { _ = resp2.Body.Close() }()
+	defer func() { _ = resp.Body.Close() }()
 
-	if resp2.StatusCode != http.StatusOK {
-		t.Errorf("expected 200 for spec, got %d", resp2.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 for spec, got %d", resp.StatusCode)
 	}
-	if ct := resp2.Header.Get("Content-Type"); ct != "application/json" {
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
 		t.Errorf("expected application/json, got %q", ct)
 	}
-	if cors := resp2.Header.Get("Access-Control-Allow-Origin"); cors != "*" {
+	if cors := resp.Header.Get("Access-Control-Allow-Origin"); cors != "*" {
 		t.Errorf("expected CORS header *, got %q", cors)
 	}
 
-	specBody, err := io.ReadAll(resp2.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("read spec body: %v", err)
 	}
-	if !strings.Contains(string(specBody), "Test API") {
+	if !strings.Contains(string(body), "Test API") {
 		t.Error("expected spec content in response")
-	}
-
-	cancel()
-	if err := <-errCh; err != nil {
-		t.Errorf("serve returned error: %v", err)
 	}
 }
 

--- a/plugins/pacto-plugin-schema-infer/internal/infer/infer_test.go
+++ b/plugins/pacto-plugin-schema-infer/internal/infer/infer_test.go
@@ -97,8 +97,8 @@ func TestInferArray(t *testing.T) {
 	}
 }
 
-func TestSchema(t *testing.T) {
-	data := map[string]any{
+func testSchemaData() map[string]any {
+	return map[string]any{
 		"app": map[string]any{
 			"name":  "my-service",
 			"debug": true,
@@ -112,8 +112,10 @@ func TestSchema(t *testing.T) {
 		"timeout":  float64(30),
 		"nothing":  nil,
 	}
+}
 
-	schema := Schema(data)
+func TestSchemaMetadata(t *testing.T) {
+	schema := Schema(testSchemaData())
 
 	if schema["$schema"] != "https://json-schema.org/draft/2020-12/schema" {
 		t.Errorf("$schema = %v, want draft/2020-12", schema["$schema"])
@@ -130,14 +132,12 @@ func TestSchema(t *testing.T) {
 		t.Fatal("properties is not a map")
 	}
 
-	// Check top-level keys exist
 	for _, key := range []string{"app", "database", "features", "timeout", "nothing"} {
 		if _, exists := props[key]; !exists {
 			t.Errorf("missing property %q", key)
 		}
 	}
 
-	// Check required is sorted
 	required, ok := schema["required"].([]string)
 	if !ok {
 		t.Fatal("required is not a string slice")
@@ -151,8 +151,12 @@ func TestSchema(t *testing.T) {
 			t.Errorf("required[%d] = %q, want %q", i, r, expectedRequired[i])
 		}
 	}
+}
 
-	// Check nested type inference
+func TestSchemaTypeInference(t *testing.T) {
+	schema := Schema(testSchemaData())
+	props := schema["properties"].(map[string]any)
+
 	appProps := props["app"].(map[string]any)["properties"].(map[string]any)
 	if appProps["name"].(map[string]any)["type"] != "string" {
 		t.Error("app.name should be string")
@@ -161,14 +165,12 @@ func TestSchema(t *testing.T) {
 		t.Error("app.debug should be boolean")
 	}
 
-	// Check database nested object with array
 	dbProps := props["database"].(map[string]any)["properties"].(map[string]any)
 	replicas := dbProps["replicas"].(map[string]any)
 	if replicas["type"] != "array" {
 		t.Error("database.replicas should be array")
 	}
 
-	// Check scalar types
 	if props["timeout"].(map[string]any)["type"] != "number" {
 		t.Error("timeout should be number")
 	}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -880,7 +880,10 @@ func TestDocCommand(t *testing.T) {
 		assertContains(t, output, "# postgres-pacto")
 	})
 
-	t.Run("ui swagger with zero interfaces errors", func(t *testing.T) {
+}
+
+func TestDocCommandUI(t *testing.T) {
+	t.Run("zero interfaces errors", func(t *testing.T) {
 		path := writeZeroInterfaceBundle(t)
 		_, err := runCommand(t, nil, "doc", "--ui", "swagger", path)
 		if err == nil {
@@ -889,7 +892,7 @@ func TestDocCommand(t *testing.T) {
 		assertContains(t, err.Error(), "no HTTP interfaces")
 	})
 
-	t.Run("ui swagger with one interface", func(t *testing.T) {
+	t.Run("one interface", func(t *testing.T) {
 		path := writeMyAppV1Bundle(t, "localhost")
 		_, err := runCommandWithCancelledCtx(t, nil, "doc", "--ui", "swagger", "--port", "0", path)
 		if err != nil {
@@ -897,7 +900,7 @@ func TestDocCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("ui swagger with two interfaces", func(t *testing.T) {
+	t.Run("two interfaces", func(t *testing.T) {
 		path := writeTwoInterfaceBundle(t)
 		_, err := runCommandWithCancelledCtx(t, nil, "doc", "--ui", "swagger", "--port", "0", path)
 		if err != nil {
@@ -905,7 +908,7 @@ func TestDocCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("ui swagger with interface filter", func(t *testing.T) {
+	t.Run("interface filter", func(t *testing.T) {
 		path := writeTwoInterfaceBundle(t)
 		_, err := runCommandWithCancelledCtx(t, nil, "doc", "--ui", "swagger", "--interface", "admin-api", "--port", "0", path)
 		if err != nil {
@@ -913,7 +916,7 @@ func TestDocCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("ui swagger with unknown interface errors", func(t *testing.T) {
+	t.Run("unknown interface errors", func(t *testing.T) {
 		path := writeTwoInterfaceBundle(t)
 		_, err := runCommand(t, nil, "doc", "--ui", "swagger", "--interface", "nonexistent", path)
 		if err == nil {
@@ -949,7 +952,7 @@ func TestDocCommand(t *testing.T) {
 		assertContains(t, err.Error(), "mutually exclusive")
 	})
 
-	t.Run("ui swagger with global target", func(t *testing.T) {
+	t.Run("global target", func(t *testing.T) {
 		path := writeMyAppV1Bundle(t, "localhost")
 		_, err := runCommandWithCancelledCtx(t, nil, "doc", "--ui", "swagger", "--target", "http://localhost:3000", "--port", "0", path)
 		if err != nil {
@@ -957,7 +960,7 @@ func TestDocCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("ui swagger with per-interface targets", func(t *testing.T) {
+	t.Run("per-interface targets", func(t *testing.T) {
 		path := writeTwoInterfaceBundle(t)
 		_, err := runCommandWithCancelledCtx(t, nil, "doc", "--ui", "swagger",
 			"--target", "public-api=http://localhost:3000",


### PR DESCRIPTION
## Summary

- Split `TestDocCommand` (complexity 22) into `TestDocCommand` + `TestDocCommandUI`
- Split `TestServeSwaggerOnListener_SingleSpec` (complexity 16) into `TestServeSwaggerOnListener_SingleSpecLandingPage` + `TestServeSwaggerOnListener_SingleSpecEndpoint` with shared `startSingleSpecServer` helper
- Split `TestSchema` (complexity 17) into `TestSchemaMetadata` + `TestSchemaTypeInference` with shared `testSchemaData` helper
- **Updated `ci-cyclo` Makefile target** to include test files (`*_test.go`), matching Go Report Card's behavior

## Why

Go Report Card runs `gocyclo` on all `.go` files including tests, while `make ci` was excluding `*_test.go`. This caused gocyclo warnings to slip through CI undetected.

## Test plan

- [x] `make ci` passes (now includes test file complexity checks)
- [x] `gocyclo -over 15` returns no violations across all Go files
- [x] All unit, integration, and e2e tests pass