### PR TITLE
fix: render Scalar API reference on each spec's own page

### DIFF
--- a/internal/doc/swagger.go
+++ b/internal/doc/swagger.go
@@ -111,13 +111,27 @@ func ServeSwaggerOnListener(ctx context.Context, opts SwaggerOptions, ln net.Lis
 	}
 
 	hasProxy := len(targets) > 0
+	if len(opts.Specs) > 1 {
+		for _, s := range opts.Specs {
+			page := buildNavSpecPage(s, opts.Specs, opts.Title, hasProxy)
+			pattern := "/ui/" + s.InterfaceName
+			mux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				_, _ = fmt.Fprint(w, page)
+			})
+		}
+	}
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {
 			http.NotFound(w, r)
 			return
 		}
+		if len(opts.Specs) > 1 {
+			http.Redirect(w, r, "/ui/"+opts.Specs[0].InterfaceName, http.StatusFound)
+			return
+		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = fmt.Fprint(w, buildSwaggerPage(opts.Specs, opts.Title, hasProxy))
+		_, _ = fmt.Fprint(w, buildSingleSpecPage(opts.Specs[0], opts.Title, hasProxy))
 	})
 
 	srv := &http.Server{Handler: mux}
@@ -285,13 +299,6 @@ func convertYAMLToJSON(v any) any {
 	}
 }
 
-func buildSwaggerPage(specs []SwaggerSpec, title string, useProxy bool) string {
-	if len(specs) == 1 {
-		return buildSingleSpecPage(specs[0], title, useProxy)
-	}
-	return buildMultiSpecPage(specs, title, useProxy)
-}
-
 func buildSingleSpecPage(spec SwaggerSpec, title string, useProxy bool) string {
 	proxyAttr := ""
 	if useProxy {
@@ -308,22 +315,26 @@ func buildSingleSpecPage(spec SwaggerSpec, title string, useProxy bool) string {
 </body></html>`, title, spec.InterfaceName, proxyAttr)
 }
 
-func buildMultiSpecPage(specs []SwaggerSpec, title string, useProxy bool) string {
+func buildNavSpecPage(active SwaggerSpec, allSpecs []SwaggerSpec, title string, useProxy bool) string {
 	var links strings.Builder
-	for _, s := range specs {
-		fmt.Fprintf(&links, `      <li><a href="#" onclick="loadSpec('/spec/%s','%s');return false">%s</a></li>`+"\n",
-			s.InterfaceName, s.InterfaceName, s.InterfaceName)
+	for _, s := range allSpecs {
+		activeClass := ""
+		if s.InterfaceName == active.InterfaceName {
+			activeClass = ` class="active"`
+		}
+		fmt.Fprintf(&links, `      <li><a href="/ui/%s"%s>%s</a></li>`+"\n",
+			s.InterfaceName, activeClass, s.InterfaceName)
 	}
 
-	proxyLine := ""
+	proxyAttr := ""
 	if useProxy {
-		proxyLine = `      el.dataset.proxyUrl = '/proxy';` + "\n"
+		proxyAttr = ` data-proxy-url="/proxy"`
 	}
 
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html><head>
   <meta charset="utf-8">
-  <title>%s - API Explorer</title>
+  <title>%s - %s - API Explorer</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     nav { background: #1a1a2e; padding: 12px 24px; display: flex; align-items: center; gap: 24px; }
@@ -338,21 +349,7 @@ func buildMultiSpecPage(specs []SwaggerSpec, title string, useProxy bool) string
     <ul>
 %s    </ul>
   </nav>
-  <div id="api-container"></div>
+  <script id="api-reference" data-url="/spec/%s"%s></script>
   <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
-  <script>
-    function loadSpec(url, name) {
-      document.querySelectorAll('nav a').forEach(a => a.classList.remove('active'));
-      event.target.classList.add('active');
-      const container = document.getElementById('api-container');
-      container.innerHTML = '';
-      const el = document.createElement('script');
-      el.id = 'api-reference';
-      el.dataset.url = url;
-%s      container.appendChild(el);
-    }
-    // Load first spec by default.
-    document.querySelector('nav a').click();
-  </script>
-</body></html>`, title, title, links.String(), proxyLine)
+</body></html>`, title, active.InterfaceName, title, links.String(), active.InterfaceName, proxyAttr)
 }

--- a/internal/doc/swagger_test.go
+++ b/internal/doc/swagger_test.go
@@ -392,26 +392,41 @@ paths: {}
 
 	time.Sleep(50 * time.Millisecond)
 
-	resp, err := http.Get(fmt.Sprintf("http://%s/", addr))
+	// Root should redirect to the first spec's UI page.
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp, err := client.Get(fmt.Sprintf("http://%s/", addr))
 	if err != nil {
 		t.Fatalf("GET / failed: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("read body: %v", err)
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("expected 302 redirect, got %d", resp.StatusCode)
+	}
+	if loc := resp.Header.Get("Location"); loc != "/ui/api" {
+		t.Errorf("expected redirect to /ui/api, got %q", loc)
 	}
 
+	// The UI page should contain nav links and a Scalar reference.
+	resp2, err := http.Get(fmt.Sprintf("http://%s/ui/api", addr))
+	if err != nil {
+		t.Fatalf("GET /ui/api failed: %v", err)
+	}
+	defer func() { _ = resp2.Body.Close() }()
+	body, _ := io.ReadAll(resp2.Body)
 	html := string(body)
 	if !strings.Contains(html, "multi-svc") {
 		t.Error("expected title in multi-spec page")
 	}
-	if !strings.Contains(html, "/spec/api") {
-		t.Error("expected api spec link")
+	if !strings.Contains(html, "/ui/api") {
+		t.Error("expected api nav link")
 	}
-	if !strings.Contains(html, "/spec/admin") {
-		t.Error("expected admin spec link")
+	if !strings.Contains(html, "/ui/admin") {
+		t.Error("expected admin nav link")
+	}
+	if !strings.Contains(html, "/spec/api") {
+		t.Error("expected spec data-url for api")
 	}
 
 	cancel()
@@ -705,15 +720,15 @@ paths: {}
 		t.Errorf("expected 200 from proxy to upstream2, got %d", pr2.StatusCode)
 	}
 
-	// Page should have proxy attribute.
-	pageResp, err := http.Get(fmt.Sprintf("http://%s/", addr))
+	// UI page should have proxy attribute.
+	pageResp, err := http.Get(fmt.Sprintf("http://%s/ui/api", addr))
 	if err != nil {
-		t.Fatalf("GET / failed: %v", err)
+		t.Fatalf("GET /ui/api failed: %v", err)
 	}
 	defer func() { _ = pageResp.Body.Close() }()
 	pageBody, _ := io.ReadAll(pageResp.Body)
-	if !strings.Contains(string(pageBody), "proxyUrl") {
-		t.Error("expected proxy attribute in multi-spec page with targets")
+	if !strings.Contains(string(pageBody), `data-proxy-url="/proxy"`) {
+		t.Error("expected data-proxy-url attribute in multi-spec page with targets")
 	}
 
 	cancel()
@@ -906,17 +921,18 @@ paths: {}
 
 	time.Sleep(50 * time.Millisecond)
 
-	resp, err := http.Get(fmt.Sprintf("http://%s/", addr))
+	// Check the UI page for proxy attribute.
+	resp, err := http.Get(fmt.Sprintf("http://%s/ui/api", addr))
 	if err != nil {
-		t.Fatalf("GET / failed: %v", err)
+		t.Fatalf("GET /ui/api failed: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	body, _ := io.ReadAll(resp.Body)
 	html := string(body)
 
-	if !strings.Contains(html, `el.dataset.proxyUrl = '/proxy'`) {
-		t.Error("expected proxyUrl script line in multi-spec page with target")
+	if !strings.Contains(html, `data-proxy-url="/proxy"`) {
+		t.Error("expected data-proxy-url attribute in multi-spec page with target")
 	}
 	if !strings.Contains(html, "multi-target") {
 		t.Error("expected title in multi-spec page")


### PR DESCRIPTION
## Summary

- Fixes multi-interface `--ui swagger` rendering where the nav bar appeared but the Scalar API reference content area was empty
- Root cause: Scalar only processes `<script id="api-reference">` elements on initial page load — dynamically created elements via JS were ignored
- Each interface now gets its own `/ui/{name}` route serving a full standalone Scalar page with a shared nav bar
- Root `/` redirects to `/ui/{first-interface}`
