### PR TITLE
fix: disable Scalar Agent in API explorer

### DIFF
--- a/internal/doc/swagger.go
+++ b/internal/doc/swagger.go
@@ -300,9 +300,10 @@ func convertYAMLToJSON(v any) any {
 }
 
 func buildSingleSpecPage(spec SwaggerSpec, title string, useProxy bool) string {
-	proxyAttr := ""
+	proxyURL := ""
 	if useProxy {
-		proxyAttr = ` data-proxy-url="/proxy"`
+		proxyURL = `
+      proxyUrl: '/proxy',`
 	}
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html><head>
@@ -310,9 +311,15 @@ func buildSingleSpecPage(spec SwaggerSpec, title string, useProxy bool) string {
   <title>%s - API Explorer</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head><body>
-  <script id="api-reference" data-url="/spec/%s"%s></script>
+  <div id="app"></div>
   <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
-</body></html>`, title, spec.InterfaceName, proxyAttr)
+  <script>
+    Scalar.createApiReference('#app', {
+      url: '/spec/%s',%s
+      agent: { disabled: true },
+    })
+  </script>
+</body></html>`, title, spec.InterfaceName, proxyURL)
 }
 
 func buildNavSpecPage(active SwaggerSpec, allSpecs []SwaggerSpec, title string, useProxy bool) string {
@@ -326,9 +333,10 @@ func buildNavSpecPage(active SwaggerSpec, allSpecs []SwaggerSpec, title string, 
 			s.InterfaceName, activeClass, s.InterfaceName)
 	}
 
-	proxyAttr := ""
+	proxyURL := ""
 	if useProxy {
-		proxyAttr = ` data-proxy-url="/proxy"`
+		proxyURL = `
+      proxyUrl: '/proxy',`
 	}
 
 	return fmt.Sprintf(`<!DOCTYPE html>
@@ -349,7 +357,13 @@ func buildNavSpecPage(active SwaggerSpec, allSpecs []SwaggerSpec, title string, 
     <ul>
 %s    </ul>
   </nav>
-  <script id="api-reference" data-url="/spec/%s"%s></script>
+  <div id="app"></div>
   <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
-</body></html>`, title, active.InterfaceName, title, links.String(), active.InterfaceName, proxyAttr)
+  <script>
+    Scalar.createApiReference('#app', {
+      url: '/spec/%s',%s
+      agent: { disabled: true },
+    })
+  </script>
+</body></html>`, title, active.InterfaceName, title, links.String(), active.InterfaceName, proxyURL)
 }

--- a/internal/doc/swagger_test.go
+++ b/internal/doc/swagger_test.go
@@ -584,7 +584,7 @@ paths: {}
 	}
 	defer func() { _ = pageResp.Body.Close() }()
 	pageBody, _ := io.ReadAll(pageResp.Body)
-	if !strings.Contains(string(pageBody), `data-proxy-url="/proxy"`) {
+	if !strings.Contains(string(pageBody), `proxyUrl: '/proxy'`) {
 		t.Error("expected data-proxy-url attribute in HTML")
 	}
 
@@ -736,7 +736,7 @@ paths: {}
 	}
 	defer func() { _ = pageResp.Body.Close() }()
 	pageBody, _ := io.ReadAll(pageResp.Body)
-	if !strings.Contains(string(pageBody), `data-proxy-url="/proxy"`) {
+	if !strings.Contains(string(pageBody), `proxyUrl: '/proxy'`) {
 		t.Error("expected data-proxy-url attribute in multi-spec page with targets")
 	}
 
@@ -940,7 +940,7 @@ paths: {}
 	body, _ := io.ReadAll(resp.Body)
 	html := string(body)
 
-	if !strings.Contains(html, `data-proxy-url="/proxy"`) {
+	if !strings.Contains(html, `proxyUrl: '/proxy'`) {
 		t.Error("expected data-proxy-url attribute in multi-spec page with target")
 	}
 	if !strings.Contains(html, "multi-target") {


### PR DESCRIPTION
## Summary
- Migrate from legacy `<script id="api-reference">` to `Scalar.createApiReference()` API
- Set `agent: { disabled: true }` to prevent the AI chat interface from appearing on localhost
- Update tests to match new proxy configuration format