### PR TITLE
docs: improve README, quickstart, and platform engineers guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ No runtime agents. No sidecars. No new infrastructure. Pacto runs at build time 
 
 ---
 
+## Breaking change detection
+
+Someone changed a service — bumped the version, moved the port, removed an API endpoint, and dropped a config property. Pacto caught it before the merge:
+
+| Classification | Path | Change | Old | New |
+|---|---|---|---|---|
+| NON_BREAKING | `service.version` | modified | `1.0.0` | `2.0.0` |
+| BREAKING | `interfaces.port` | modified | `8081` | `9090` |
+| BREAKING | `openapi.paths[/predict]` | removed | `/predict` | — |
+| BREAKING | `configuration.properties[model_path]` | removed | `model_path` | — |
+
+This output is generated automatically by `pacto diff` (with `--output-format markdown` for the table). The exit code is non-zero on breaking changes, so it can gate merges in CI.
+
+---
+
 ## How it works
 
 ```
@@ -256,6 +271,8 @@ This distinction matters because:
 - **SBOM diffing** — optional SPDX or CycloneDX SBOM inclusion with automatic package-level change detection on `pacto diff`
 - **AI assistant integration** — `pacto mcp` exposes all operations as [MCP](https://modelcontextprotocol.io) tools for Claude, Cursor, and Copilot
 
+Interested in contributing? See the [Architecture](https://trianalab.github.io/pacto/architecture/) guide for the internal design.
+
 ---
 
 ## AI-native contracts
@@ -411,7 +428,6 @@ Full documentation at **[trianalab.github.io/pacto](https://trianalab.github.io/
 | [MCP Integration](https://trianalab.github.io/pacto/mcp-integration) | Connect AI tools (Claude, Cursor, Copilot) to Pacto via MCP |
 | [Plugin Development](https://trianalab.github.io/pacto/plugins) | Build plugins to generate artifacts from contracts |
 | [Examples](https://trianalab.github.io/pacto/examples) | PostgreSQL, Redis, RabbitMQ, NGINX, Cron Worker |
-| [Demo](https://github.com/TrianaLab/pacto-demo) | Complete working demo repository |
 | [Architecture](https://trianalab.github.io/pacto/architecture) | Internal design for contributors |
 
 ---

--- a/docs/platform-engineers.md
+++ b/docs/platform-engineers.md
@@ -202,14 +202,36 @@ steps:
     run: pacto graph .
 ```
 
-{: .tip }
-Using GitHub Actions? Check out the official [Pacto CLI action]({{ site.baseurl }}{% link github-actions.md %}).
+Using GitHub Actions? The same workflow with [pacto-actions](https://github.com/trianalab/pacto-actions):
+
+```yaml
+steps:
+  - uses: trianalab/pacto-actions@v1
+    with:
+      command: validate
+      path: ./my-service
+
+  - uses: trianalab/pacto-actions@v1
+    with:
+      command: diff
+      old: oci://ghcr.io/my-org/my-service
+      new: ./my-service
+      comment-on-pr: 'true'
+
+  - uses: trianalab/pacto-actions@v1
+    if: github.ref == 'refs/heads/main'
+    with:
+      command: push
+      ref: oci://ghcr.io/my-org/my-service
+      path: ./my-service
+```
+
+See [pacto-actions](https://github.com/trianalab/pacto-actions) for full documentation including multi-service workflows, doc generation, and authentication options.
 
 ---
 
 ## Tips
 
-- **Automate diff checks.** Run `pacto diff` in CI to catch breaking changes before they reach production.
 - **Build a plugin for your platform.** A Helm plugin, Terraform plugin, or custom manifest generator can consume Pacto contracts deterministically.
 - **Use `pacto graph` to understand impact.** Before upgrading a shared service, check what depends on it.
 - **Disable cache in CI.** Use `--no-cache` or `PACTO_NO_CACHE=1` to ensure fresh OCI pulls in pipelines where the cache might be stale.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -114,6 +114,21 @@ $ pacto doc my-service --serve
 Serving documentation at http://127.0.0.1:8484
 ```
 
+## 7. Detect breaking changes
+
+Make a change to your contract (e.g. modify a port number) and diff it against the version you just pushed:
+
+```bash
+# Edit your contract — change the port in pacto.yaml
+# Then diff against the published version
+$ pacto diff oci://ghcr.io/your-org/my-service-pacto:1.0.0 my-service
+Classification: BREAKING
+Changes (1):
+  [BREAKING] interfaces.port (modified): interfaces.port modified [8080 -> 9090]
+```
+
+Exit code is non-zero when breaking changes are detected — use this in CI to gate merges. See [For Platform Engineers]({{ site.baseurl }}{% link platform-engineers.md %}) for the full CI integration guide.
+
 ---
 
 ## What to do next


### PR DESCRIPTION
## Summary
- Add breaking change detection section with `pacto diff` table to README (before "How it works")
- Add contributing link to Architecture guide after "Key capabilities" section
- Move Demo row from documentation table (already in header nav)
- Add step 7 (detect breaking changes) to quickstart guide
- Add `pacto-actions` CI pipeline example to platform engineers guide, consolidating with existing CI section

## Files changed
- `README.md`
- `docs/quickstart.md`
- `docs/platform-engineers.md`