### PR TITLE
feat: update plugins alongside pacto during update

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -291,6 +291,110 @@ func TestUpdateCommand_Success(t *testing.T) {
 	}
 }
 
+func TestUpdateCommand_WithPlugins(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("PACTO_NO_UPDATE_CHECK", "1")
+	if err := os.MkdirAll(filepath.Join(tmpDir, "pacto"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/TrianaLab/pacto/releases/tags/v2.0.0":
+			_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": "v2.0.0"})
+		case "/repos/TrianaLab/pacto-plugins/releases/latest":
+			_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": "v1.0.0"})
+		default:
+			_, _ = w.Write([]byte("new-binary"))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, "pacto")
+	if err := os.WriteFile(execPath, []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(execDir, "pacto-plugin-foo"), []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanup := update.SetTestOverrides(
+		server.Client(), server.URL, server.URL,
+		func() (string, error) { return execPath, nil },
+	)
+	defer cleanup()
+
+	svc := app.NewService(nil, nil)
+	root := cli.NewRootCommand(svc, "v0.0.1")
+	root.SetArgs([]string{"update", "v2.0.0"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "Updated pacto v0.0.1 -> v2.0.0") {
+		t.Errorf("expected pacto update message, got: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "Updated plugin pacto-plugin-foo -> v1.0.0") {
+		t.Errorf("expected plugin update message, got: %s", out.String())
+	}
+}
+
+func TestUpdateCommand_PluginFailureIsWarning(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("PACTO_NO_UPDATE_CHECK", "1")
+	if err := os.MkdirAll(filepath.Join(tmpDir, "pacto"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/TrianaLab/pacto/releases/tags/v2.0.0":
+			_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": "v2.0.0"})
+		case "/repos/TrianaLab/pacto-plugins/releases/latest":
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			_, _ = w.Write([]byte("new-binary"))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, "pacto")
+	if err := os.WriteFile(execPath, []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(execDir, "pacto-plugin-foo"), []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanup := update.SetTestOverrides(
+		server.Client(), server.URL, server.URL,
+		func() (string, error) { return execPath, nil },
+	)
+	defer cleanup()
+
+	svc := app.NewService(nil, nil)
+	root := cli.NewRootCommand(svc, "v0.0.1")
+	root.SetArgs([]string{"update", "v2.0.0"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+
+	// Should NOT return an error - plugin failure is a warning
+	if err := root.Execute(); err != nil {
+		t.Fatalf("update should succeed even if plugin update fails: %v", err)
+	}
+	if !strings.Contains(out.String(), "Warning: plugin update failed") {
+		t.Errorf("expected plugin warning, got: %s", out.String())
+	}
+}
+
 func TestUpdateCommand_Error(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -36,6 +36,14 @@ func newUpdateCommand(version string) *cobra.Command {
 			}
 
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Updated pacto %s -> %s\n", result.PreviousVersion, result.NewVersion)
+
+			pluginResults, err := update.UpdatePlugins()
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.OutOrStderr(), "Warning: plugin update failed: %v\n", err)
+			}
+			for _, pr := range pluginResults {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Updated plugin %s -> %s\n", pr.Name, pr.Version)
+			}
 			return nil
 		},
 	}

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -157,9 +157,14 @@ func SetTestOverrides(client *http.Client, apiBaseURL, downloadBaseURL string, e
 	}
 }
 
-// fetchLatestVersion fetches the latest release tag from GitHub.
+// fetchLatestVersion fetches the latest release tag for pacto from GitHub.
 func fetchLatestVersion() (string, error) {
-	url := githubAPIBaseURL + "/repos/TrianaLab/pacto/releases/latest"
+	return fetchLatestRepoVersion("TrianaLab/pacto")
+}
+
+// fetchLatestRepoVersion fetches the latest release tag for the given repo from GitHub.
+func fetchLatestRepoVersion(repo string) (string, error) {
+	url := githubAPIBaseURL + "/repos/" + repo + "/releases/latest"
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err

--- a/internal/update/plugins.go
+++ b/internal/update/plugins.go
@@ -1,0 +1,92 @@
+package update
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const pluginsRepo = "TrianaLab/pacto-plugins"
+
+// PluginUpdateResult holds the outcome of a single plugin update.
+type PluginUpdateResult struct {
+	Name    string
+	Version string
+}
+
+// Testability hook.
+var osReadDir = os.ReadDir
+
+// UpdatePlugins discovers installed pacto plugins and updates them to the latest version.
+func UpdatePlugins() ([]PluginUpdateResult, error) {
+	plugins, execDir, err := discoverInstalledPlugins()
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover plugins: %w", err)
+	}
+	if len(plugins) == 0 {
+		return nil, nil
+	}
+
+	tag, err := fetchLatestRepoVersion(pluginsRepo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch latest plugins version: %w", err)
+	}
+
+	var results []PluginUpdateResult
+	for _, name := range plugins {
+		url := buildPluginDownloadURL(tag, name)
+		ext := ""
+		if runtimeGOOS == "windows" {
+			ext = ".exe"
+		}
+		targetPath := filepath.Join(execDir, name+ext)
+		if err := downloadAndInstall(url, targetPath); err != nil {
+			return results, fmt.Errorf("failed to update plugin %s: %w", name, err)
+		}
+		results = append(results, PluginUpdateResult{Name: name, Version: tag})
+	}
+	return results, nil
+}
+
+// discoverInstalledPlugins finds pacto-plugin-* binaries in the same directory as the pacto executable.
+func discoverInstalledPlugins() ([]string, string, error) {
+	execPath, err := osExecutable()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to determine executable path: %w", err)
+	}
+	execPath, err = filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to resolve executable path: %w", err)
+	}
+	dir := filepath.Dir(execPath)
+
+	entries, err := osReadDir(dir)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	var plugins []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".exe")
+		if strings.HasPrefix(name, "pacto-plugin-") {
+			plugins = append(plugins, name)
+		}
+	}
+	return plugins, dir, nil
+}
+
+// buildPluginDownloadURL constructs the download URL for a plugin binary.
+func buildPluginDownloadURL(tag, pluginName string) string {
+	ext := ""
+	if runtimeGOOS == "windows" {
+		ext = ".exe"
+	}
+	return fmt.Sprintf(
+		"%s/%s/releases/download/%s/%s_%s_%s%s",
+		githubDownloadURL, pluginsRepo, tag, pluginName, runtimeGOOS, runtimeGOARCH, ext,
+	)
+}

--- a/internal/update/plugins_test.go
+++ b/internal/update/plugins_test.go
@@ -1,0 +1,381 @@
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildPluginDownloadURL(t *testing.T) {
+	tests := []struct {
+		name, tag, plugin, goos, goarch, expected string
+	}{
+		{"linux amd64", "v1.0.0", "pacto-plugin-foo", "linux", "amd64",
+			githubDownloadURL + "/TrianaLab/pacto-plugins/releases/download/v1.0.0/pacto-plugin-foo_linux_amd64"},
+		{"darwin arm64", "v1.2.3", "pacto-plugin-bar", "darwin", "arm64",
+			githubDownloadURL + "/TrianaLab/pacto-plugins/releases/download/v1.2.3/pacto-plugin-bar_darwin_arm64"},
+		{"windows amd64", "v1.0.0", "pacto-plugin-baz", "windows", "amd64",
+			githubDownloadURL + "/TrianaLab/pacto-plugins/releases/download/v1.0.0/pacto-plugin-baz_windows_amd64.exe"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origGOOS, origGOARCH := runtimeGOOS, runtimeGOARCH
+			runtimeGOOS, runtimeGOARCH = tt.goos, tt.goarch
+			defer func() { runtimeGOOS, runtimeGOARCH = origGOOS, origGOARCH }()
+
+			if got := buildPluginDownloadURL(tt.tag, tt.plugin); got != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestDiscoverInstalledPlugins(t *testing.T) {
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, "pacto")
+	if err := os.WriteFile(execPath, []byte("bin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Create plugin binaries
+	for _, name := range []string{"pacto-plugin-alpha", "pacto-plugin-beta"} {
+		if err := os.WriteFile(filepath.Join(execDir, name), []byte("plugin"), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Create a non-plugin file (should be ignored)
+	if err := os.WriteFile(filepath.Join(execDir, "other-binary"), []byte("other"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Create a directory with plugin-like name (should be ignored)
+	if err := os.Mkdir(filepath.Join(execDir, "pacto-plugin-dir"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origExec := osExecutable
+	osExecutable = func() (string, error) { return execPath, nil }
+	defer func() { osExecutable = origExec }()
+
+	plugins, dir, err := discoverInstalledPlugins()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// EvalSymlinks may resolve /var -> /private/var on macOS
+	resolvedExecDir, _ := filepath.EvalSymlinks(execDir)
+	if dir != resolvedExecDir {
+		t.Errorf("expected dir %s, got %s", resolvedExecDir, dir)
+	}
+	if len(plugins) != 2 {
+		t.Fatalf("expected 2 plugins, got %d: %v", len(plugins), plugins)
+	}
+	if plugins[0] != "pacto-plugin-alpha" || plugins[1] != "pacto-plugin-beta" {
+		t.Errorf("unexpected plugins: %v", plugins)
+	}
+}
+
+func TestDiscoverInstalledPlugins_WindowsExe(t *testing.T) {
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, "pacto")
+	if err := os.WriteFile(execPath, []byte("bin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(execDir, "pacto-plugin-foo.exe"), []byte("plugin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origExec := osExecutable
+	osExecutable = func() (string, error) { return execPath, nil }
+	defer func() { osExecutable = origExec }()
+
+	plugins, _, err := discoverInstalledPlugins()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(plugins) != 1 || plugins[0] != "pacto-plugin-foo" {
+		t.Errorf("expected [pacto-plugin-foo], got %v", plugins)
+	}
+}
+
+func TestDiscoverInstalledPlugins_NoPlugins(t *testing.T) {
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, "pacto")
+	if err := os.WriteFile(execPath, []byte("bin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origExec := osExecutable
+	osExecutable = func() (string, error) { return execPath, nil }
+	defer func() { osExecutable = origExec }()
+
+	plugins, _, err := discoverInstalledPlugins()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(plugins) != 0 {
+		t.Errorf("expected no plugins, got %v", plugins)
+	}
+}
+
+func TestDiscoverInstalledPlugins_ExecutableError(t *testing.T) {
+	origExec := osExecutable
+	osExecutable = func() (string, error) { return "", fmt.Errorf("exec error") }
+	defer func() { osExecutable = origExec }()
+
+	_, _, err := discoverInstalledPlugins()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestDiscoverInstalledPlugins_EvalSymlinksError(t *testing.T) {
+	origExec := osExecutable
+	osExecutable = func() (string, error) { return "/nonexistent/path/pacto", nil }
+	defer func() { osExecutable = origExec }()
+
+	_, _, err := discoverInstalledPlugins()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestDiscoverInstalledPlugins_ReadDirError(t *testing.T) {
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, "pacto")
+	if err := os.WriteFile(execPath, []byte("bin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origExec := osExecutable
+	osExecutable = func() (string, error) { return execPath, nil }
+	defer func() { osExecutable = origExec }()
+
+	origReadDir := osReadDir
+	osReadDir = func(string) ([]os.DirEntry, error) { return nil, fmt.Errorf("read dir error") }
+	defer func() { osReadDir = origReadDir }()
+
+	_, _, err := discoverInstalledPlugins()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestUpdatePlugins_Success(t *testing.T) {
+	setupTestEnv(t)
+
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, "pacto")
+	if err := os.WriteFile(execPath, []byte("bin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(execDir, "pacto-plugin-foo"), []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/TrianaLab/pacto-plugins/releases/latest":
+			_ = json.NewEncoder(w).Encode(githubRelease{TagName: "v1.0.0"})
+		default:
+			_, _ = w.Write([]byte("new-plugin-binary"))
+		}
+	}))
+	t.Cleanup(server.Close)
+	overrideGitHubAPI(t, server)
+
+	origDownload := githubDownloadURL
+	githubDownloadURL = server.URL
+	defer func() { githubDownloadURL = origDownload }()
+
+	origExec := osExecutable
+	osExecutable = func() (string, error) { return execPath, nil }
+	defer func() { osExecutable = origExec }()
+
+	results, err := UpdatePlugins()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Name != "pacto-plugin-foo" || results[0].Version != "v1.0.0" {
+		t.Errorf("unexpected result: %+v", results[0])
+	}
+
+	data, _ := os.ReadFile(filepath.Join(execDir, "pacto-plugin-foo"))
+	if string(data) != "new-plugin-binary" {
+		t.Errorf("expected updated binary, got %q", data)
+	}
+}
+
+func TestUpdatePlugins_NoPlugins(t *testing.T) {
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, "pacto")
+	if err := os.WriteFile(execPath, []byte("bin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origExec := osExecutable
+	osExecutable = func() (string, error) { return execPath, nil }
+	defer func() { osExecutable = origExec }()
+
+	results, err := UpdatePlugins()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results != nil {
+		t.Errorf("expected nil, got %v", results)
+	}
+}
+
+func TestUpdatePlugins_DiscoverError(t *testing.T) {
+	origExec := osExecutable
+	osExecutable = func() (string, error) { return "", fmt.Errorf("exec error") }
+	defer func() { osExecutable = origExec }()
+
+	_, err := UpdatePlugins()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestUpdatePlugins_FetchVersionError(t *testing.T) {
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, "pacto")
+	if err := os.WriteFile(execPath, []byte("bin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(execDir, "pacto-plugin-foo"), []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	overrideGitHubAPI(t, server)
+
+	origExec := osExecutable
+	osExecutable = func() (string, error) { return execPath, nil }
+	defer func() { osExecutable = origExec }()
+
+	_, err := UpdatePlugins()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestUpdatePlugins_DownloadError(t *testing.T) {
+	setupTestEnv(t)
+
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, "pacto")
+	if err := os.WriteFile(execPath, []byte("bin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(execDir, "pacto-plugin-foo"), []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/TrianaLab/pacto-plugins/releases/latest":
+			_ = json.NewEncoder(w).Encode(githubRelease{TagName: "v1.0.0"})
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(server.Close)
+	overrideGitHubAPI(t, server)
+
+	origDownload := githubDownloadURL
+	githubDownloadURL = server.URL
+	defer func() { githubDownloadURL = origDownload }()
+
+	origExec := osExecutable
+	osExecutable = func() (string, error) { return execPath, nil }
+	defer func() { osExecutable = origExec }()
+
+	_, err := UpdatePlugins()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// Verify original plugin is unchanged
+	data, _ := os.ReadFile(filepath.Join(execDir, "pacto-plugin-foo"))
+	if string(data) != "old" {
+		t.Errorf("expected original plugin to be unchanged, got %q", data)
+	}
+}
+
+func TestUpdatePlugins_WindowsExt(t *testing.T) {
+	setupTestEnv(t)
+
+	origGOOS := runtimeGOOS
+	runtimeGOOS = "windows"
+	defer func() { runtimeGOOS = origGOOS }()
+
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, "pacto")
+	if err := os.WriteFile(execPath, []byte("bin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(execDir, "pacto-plugin-foo.exe"), []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/TrianaLab/pacto-plugins/releases/latest":
+			_ = json.NewEncoder(w).Encode(githubRelease{TagName: "v1.0.0"})
+		default:
+			_, _ = w.Write([]byte("new-plugin"))
+		}
+	}))
+	t.Cleanup(server.Close)
+	overrideGitHubAPI(t, server)
+
+	origDownload := githubDownloadURL
+	githubDownloadURL = server.URL
+	defer func() { githubDownloadURL = origDownload }()
+
+	origExec := osExecutable
+	osExecutable = func() (string, error) { return execPath, nil }
+	defer func() { osExecutable = origExec }()
+
+	results, err := UpdatePlugins()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 || results[0].Name != "pacto-plugin-foo" {
+		t.Errorf("unexpected results: %+v", results)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(execDir, "pacto-plugin-foo.exe"))
+	if string(data) != "new-plugin" {
+		t.Errorf("expected updated binary, got %q", data)
+	}
+}
+
+func TestFetchLatestRepoVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/TrianaLab/pacto-plugins/releases/latest" {
+			_ = json.NewEncoder(w).Encode(githubRelease{TagName: "v2.0.0"})
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	overrideGitHubAPI(t, server)
+
+	version, err := fetchLatestRepoVersion("TrianaLab/pacto-plugins")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if version != "v2.0.0" {
+		t.Errorf("expected v2.0.0, got %s", version)
+	}
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -71,8 +71,13 @@ func downloadAndReplace(downloadURL string) error {
 		return fmt.Errorf("failed to resolve executable path: %w", err)
 	}
 
+	return downloadAndInstall(downloadURL, execPath)
+}
+
+// downloadAndInstall downloads a binary and atomically replaces the file at targetPath.
+func downloadAndInstall(downloadURL, targetPath string) error {
 	// Download to temp file in the same directory (ensures same filesystem for atomic rename)
-	tmpFile, err := os.CreateTemp(filepath.Dir(execPath), "pacto-update-*")
+	tmpFile, err := os.CreateTemp(filepath.Dir(targetPath), "pacto-update-*")
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
@@ -91,7 +96,7 @@ func downloadAndReplace(downloadURL string) error {
 		return fmt.Errorf("failed to set executable permission: %w", err)
 	}
 
-	if err := osRename(tmpPath, execPath); err != nil {
+	if err := osRename(tmpPath, targetPath); err != nil {
 		return fmt.Errorf("failed to replace binary: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- `pacto update` now also updates installed plugins to the latest release from `TrianaLab/pacto-plugins`
- Discovers `pacto-plugin-*` binaries in the same directory as the pacto executable
- Plugin update failures are treated as warnings, not blocking errors

## Test plan
- [x] 100% statement coverage on `internal/update` package
- [x] CLI tests cover plugin update output and warning path
- [x] Full test suite passes