### PR TITLE
fix: security, nil guards, and documentation improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,11 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 LDFLAGS := -ldflags "-X main.version=$(VERSION)"
 GOBIN := $(shell go env GOBIN 2>/dev/null)
 ifeq ($(GOBIN),)
-GOBIN := $(shell go env GOPATH)/bin
+GOPATH := $(shell go env GOPATH 2>/dev/null)
+ifeq ($(GOPATH),)
+GOPATH := $(HOME)/go
+endif
+GOBIN := $(GOPATH)/bin
 endif
 
 .PHONY: build test e2e coverage lint clean docs gen-cli-docs ci

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -102,7 +102,7 @@ pacto doc [dir | oci://ref] [flags]
   # Serve on a custom port
   pacto doc my-service --serve --port 9090
 
-  # Launch an interactive API explorer (Swagger/Scalar UI)
+  # Launch an interactive API explorer (Scalar UI)
   pacto doc my-service --ui swagger
 
   # Select a specific interface

--- a/docs/examples/postgresql.md
+++ b/docs/examples/postgresql.md
@@ -62,6 +62,9 @@ metadata:
   storage-class: ssd
 ```
 
+{: .note }
+> The `sql` interface uses `type: grpc` as the closest available protocol type for PostgreSQL's binary wire protocol. The Pacto schema currently supports `http`, `grpc`, and `event` — there is no dedicated `tcp` type. The `.proto` contract file is illustrative; in practice you may omit the interface or use a custom schema.
+
 ### Key decisions
 
 - **`state.type: stateful`** with **`durability: persistent`** — PostgreSQL needs persistent storage that survives pod restarts

--- a/docs/examples/rabbitmq.md
+++ b/docs/examples/rabbitmq.md
@@ -69,6 +69,9 @@ metadata:
   quorum-queues: enabled
 ```
 
+{: .note }
+> The `amqp` interface uses `type: grpc` as the closest available protocol type for RabbitMQ's AMQP binary protocol. The Pacto schema currently supports `http`, `grpc`, and `event` — there is no dedicated `tcp` type. The `.proto` contract file is illustrative; in practice you may omit the interface or use a custom schema.
+
 ### Key decisions
 
 - **`dataCriticality: high`** — message loss can cause data integrity issues across the system

--- a/docs/examples/redis.md
+++ b/docs/examples/redis.md
@@ -61,6 +61,9 @@ metadata:
   eviction-policy: allkeys-lru
 ```
 
+{: .note }
+> The `resp` interface uses `type: grpc` as the closest available protocol type for Redis's RESP binary protocol. The Pacto schema currently supports `http`, `grpc`, and `event` — there is no dedicated `tcp` type. The `.proto` contract file is illustrative; in practice you may omit the interface or use a custom schema.
+
 ### Key decisions
 
 - **`state.type: stateful`** with **`durability: persistent`** — Redis with AOF/RDB persistence enabled needs durable storage

--- a/internal/app/generate.go
+++ b/internal/app/generate.go
@@ -87,6 +87,9 @@ func (s *Service) Generate(ctx context.Context, opts GenerateOptions) (*Generate
 		if rel, relErr := filepath.Rel(absOutput, outPath); relErr != nil || strings.HasPrefix(rel, "..") {
 			return nil, fmt.Errorf("plugin file path %q escapes output directory", f.Path)
 		}
+		if strings.Contains(f.Path, "..") {
+			return nil, fmt.Errorf("plugin file path %q contains path traversal", f.Path)
+		}
 		if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
 			return nil, fmt.Errorf("failed to create directory for %s: %w", f.Path, err)
 		}

--- a/internal/app/validate.go
+++ b/internal/app/validate.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
 	"log/slog"
 
@@ -42,12 +43,14 @@ func (s *Service) Validate(ctx context.Context, opts ValidateOptions) (*Validate
 	var rawYAML []byte
 	if bundle.RawYAML != nil {
 		rawYAML = bundle.RawYAML
-	} else {
+	} else if bundle.FS != nil {
 		var readErr error
 		rawYAML, readErr = fs.ReadFile(bundle.FS, DefaultContractPath)
 		if readErr != nil {
 			return nil, readErr
 		}
+	} else {
+		return nil, fmt.Errorf("bundle has no raw YAML or filesystem")
 	}
 
 	slog.Debug("running validation", "ref", ref)

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -29,7 +29,7 @@ func newDocCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
   # Serve on a custom port
   pacto doc my-service --serve --port 9090
 
-  # Launch an interactive API explorer (Swagger/Scalar UI)
+  # Launch an interactive API explorer (Scalar UI)
   pacto doc my-service --ui swagger
 
   # Select a specific interface

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -72,6 +72,11 @@ func NewRootCommand(svc *app.Service, version string) *cobra.Command {
 		// Start async update check
 		if version != "dev" && os.Getenv("PACTO_NO_UPDATE_CHECK") != "1" {
 			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						updateResultCh <- nil
+					}
+				}()
 				updateResultCh <- update.CheckForUpdate(version)
 			}()
 		}

--- a/internal/doc/swagger.go
+++ b/internal/doc/swagger.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/trianalab/pacto/pkg/contract"
@@ -208,9 +209,18 @@ func newProxyHandler(allowed []string) http.HandlerFunc {
 			return
 		}
 
+		parsed, parseErr := url.Parse(targetURL)
+		if parseErr != nil || parsed.Host == "" {
+			http.Error(w, "invalid target URL", http.StatusBadRequest)
+			return
+		}
 		ok := false
 		for _, t := range allowed {
-			if strings.HasPrefix(targetURL, t) {
+			allowedParsed, err := url.Parse(t)
+			if err != nil {
+				continue
+			}
+			if parsed.Scheme == allowedParsed.Scheme && parsed.Host == allowedParsed.Host && strings.HasPrefix(parsed.Path, allowedParsed.Path) {
 				ok = true
 				break
 			}

--- a/internal/graph/resolver.go
+++ b/internal/graph/resolver.go
@@ -177,6 +177,16 @@ func (r *resolver) resolveEdge(ctx context.Context, dep contract.Dependency, pat
 		edge.Error = err.Error()
 		return edge
 	}
+	if bundle == nil || bundle.Contract == nil {
+		errMsg := fmt.Sprintf("fetcher returned nil bundle for %s", dep.Ref)
+		r.mu.Lock()
+		r.errors[dep.Ref] = errMsg
+		delete(r.pending, dep.Ref)
+		r.mu.Unlock()
+		close(ch)
+		edge.Error = errMsg
+		return edge
+	}
 
 	node := &Node{
 		Name:     bundle.Contract.Service.Name,

--- a/internal/oci/bundle.go
+++ b/internal/oci/bundle.go
@@ -33,6 +33,10 @@ var (
 
 // bundleToImage converts a contract.Bundle into an OCI v1.Image.
 func bundleToImage(b *contract.Bundle) (v1.Image, error) {
+	if b == nil || b.Contract == nil || b.FS == nil {
+		return nil, fmt.Errorf("bundle, contract, and filesystem are required")
+	}
+
 	// Start with empty image, store metadata as labels.
 	img := empty.Image
 
@@ -179,6 +183,9 @@ func extractTar(r io.Reader) (fs.FS, error) {
 		name := filepath.ToSlash(strings.TrimPrefix(header.Name, "./"))
 		if name == "" || name == "." {
 			continue
+		}
+		if strings.Contains(name, "..") {
+			return nil, fmt.Errorf("invalid path in tar: %s", header.Name)
 		}
 
 		if header.Typeflag == tar.TypeDir {

--- a/scripts/get-pacto.sh
+++ b/scripts/get-pacto.sh
@@ -88,9 +88,53 @@ checkInstalledVersion() {
   fi
 }
 
+verifyChecksum() {
+  local file="$1"
+  local checksums_url="$2"
+  local filename="$3"
+
+  tmp_checksums="$(mktemp)"
+  if [ "$HAS_CURL" = "true" ]; then
+    curl -fsSL "$checksums_url" -o "$tmp_checksums" 2>/dev/null
+  else
+    wget -qO "$tmp_checksums" "$checksums_url" 2>/dev/null
+  fi
+
+  if [ ! -s "$tmp_checksums" ]; then
+    rm -f "$tmp_checksums"
+    echo "Warning: checksums file not available, skipping verification" >&2
+    return 0
+  fi
+
+  expected=$(grep "$filename" "$tmp_checksums" | awk '{print $1}')
+  rm -f "$tmp_checksums"
+
+  if [ -z "$expected" ]; then
+    echo "Warning: no checksum found for $filename, skipping verification" >&2
+    return 0
+  fi
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual=$(sha256sum "$file" | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    actual=$(shasum -a 256 "$file" | awk '{print $1}')
+  else
+    echo "Warning: sha256sum/shasum not found, skipping verification" >&2
+    return 0
+  fi
+
+  if [ "$expected" != "$actual" ]; then
+    echo "Checksum verification failed for $filename" >&2
+    echo "  expected: $expected" >&2
+    echo "  actual:   $actual" >&2
+    return 1
+  fi
+}
+
 downloadFile() {
   filename="${BINARY_NAME}_${OS}_${ARCH}${EXT}"
   url="https://github.com/$REPO/releases/download/$TAG/$filename"
+  checksums_url="https://github.com/$REPO/releases/download/$TAG/checksums.txt"
   tmp="$(mktemp -d)"
   target="$tmp/$filename"
   if [ "$HAS_CURL" = "true" ]; then
@@ -98,6 +142,7 @@ downloadFile() {
   else
     wget -qO "$target" "$url"
   fi
+  verifyChecksum "$target" "$checksums_url" "$filename"
   chmod +x "$target"
   mv "$target" "$tmp/$BINARY_NAME$EXT"
   DOWNLOAD_DIR="$tmp"


### PR DESCRIPTION
## Summary

Addresses issues found during a deep codebase analysis covering security, defensive coding, and documentation accuracy.

### Security
- **Proxy URL validation**: Replaced `strings.HasPrefix` with proper `url.Parse` scheme+host matching to prevent prefix-confusion bypasses
- **Path traversal**: Added `..` rejection in OCI `extractTar` and plugin `generate` output paths
- **Install script**: Added SHA256 checksum verification for downloaded binaries (gracefully skips if checksums file is unavailable)

### Nil guards & defensive coding
- `validate.go`: Guard against nil `bundle.FS` when `RawYAML` is also nil
- `bundleToImage`: Guard against nil bundle/contract/FS
- `graph/resolver.go`: Guard against nil bundle returned by fetcher
- `cli/root.go`: Added `recover()` in async update-check goroutine to prevent app crash

### Build
- `Makefile`: Safe `GOPATH` fallback to `$HOME/go` when `go env GOPATH` is empty, preventing `GOBIN` from resolving to `/bin`

### Documentation
- Fixed "Swagger/Scalar UI" references to just "Scalar UI" (only Scalar is implemented)
- Added clarification notes to PostgreSQL, Redis, and RabbitMQ examples explaining that `type: grpc` is used as the closest available protocol type for binary TCP protocols

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `go test ./...` all tests pass