### PR TITLE
fix: prevent install script abort when checksums.txt is unavailable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,32 @@ jobs:
             go build -ldflags "-s -w -X main.version=${{ github.event.release.tag_name }}" \
             -o dist/$output ./cmd/pacto
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pacto_${{ matrix.goos }}_${{ matrix.goarch }}
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.release.tag_name, 'v')
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum * > checksums.txt
+
       - name: Publish to GitHub Release
         uses: softprops/action-gh-release@v2.5.0
-        if: startsWith(github.event.release.tag_name, 'v')
         with:
-          files: dist/pacto_${{ matrix.goos }}_${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.exe' || '' }}
+          files: dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/get-pacto.sh
+++ b/scripts/get-pacto.sh
@@ -95,9 +95,9 @@ verifyChecksum() {
 
   tmp_checksums="$(mktemp)"
   if [ "$HAS_CURL" = "true" ]; then
-    curl -fsSL "$checksums_url" -o "$tmp_checksums" 2>/dev/null
+    curl -fsSL "$checksums_url" -o "$tmp_checksums" 2>/dev/null || true
   else
-    wget -qO "$tmp_checksums" "$checksums_url" 2>/dev/null
+    wget -qO "$tmp_checksums" "$checksums_url" 2>/dev/null || true
   fi
 
   if [ ! -s "$tmp_checksums" ]; then


### PR DESCRIPTION
## Summary

- The `verifyChecksum` function downloads `checksums.txt` via curl/wget, but under `set -e` a non-zero exit (file not found) aborts the entire install script
- Appends `|| true` so the failure falls through to the existing graceful skip logic

## Test plan

- [x] Run `scripts/get-pacto.sh` on a release without `checksums.txt` — installs successfully with a warning
- [x] Run on a release with `checksums.txt` — verifies checksum normally