### PR TITLE
Fix Codecov coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v6.0.2
+
       - uses: actions/download-artifact@v4
         with:
           name: coverage


### PR DESCRIPTION
## Summary
- Add missing `actions/checkout` step in the coverage job so Codecov can map coverage data to source files

## Test plan
- [x] Codecov should report correct coverage after this merge