### PR TITLE
docs: add environment-specific override examples

### DIFF
--- a/docs/contract-reference.md
+++ b/docs/contract-reference.md
@@ -276,6 +276,38 @@ Required configuration keys are derived from the JSON Schema's `required` array.
 
 The optional `values` field provides default configuration values that are validated against the referenced JSON Schema. This is useful for documenting expected defaults or providing environment-specific overrides via the `--set` and `--values` flags (see [Contract overrides](#contract-overrides)).
 
+{: .tip }
+All files referenced by the contract — including the configuration schema — are packaged into the bundle when you run `pacto push`. The bundle is a self-contained OCI artifact that includes `pacto.yaml`, interface contracts, the configuration schema, and any other files in the contract directory.
+
+#### Secret references
+
+Secrets should never be stored as literal values in a contract. Instead, use a reference convention that the platform resolves at deployment time. The contract declares *what* the service needs; the platform decides *how* to provide it.
+
+```yaml
+configuration:
+  schema: configuration/schema.json
+  values:
+    DB_HOST: prod-db.internal
+    DB_PORT: 5432
+    DB_PASSWORD: secret://vault/payments/db-password
+    API_KEY: secret://vault/payments/stripe-api-key
+```
+
+The `secret://` prefix is a convention — Pacto treats it as an opaque string value. Your platform tooling (Kubernetes operators, Terraform modules, deployment scripts) interprets these references and injects the actual secret at runtime. This keeps sensitive values out of the contract while making the dependency on secrets explicit and auditable.
+
+Your configuration JSON Schema should declare secret fields as strings:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "DB_PASSWORD": { "type": "string", "description": "Database password (secret reference)" },
+    "API_KEY": { "type": "string", "description": "Stripe API key (secret reference)" }
+  },
+  "required": ["DB_PASSWORD", "API_KEY"]
+}
+```
+
 ---
 
 ### `dependencies`
@@ -368,11 +400,11 @@ The combination of `state.type`, `persistence.scope`, and `persistence.durabilit
 
 | State | Persistence | Platform reasoning |
 |-------|-------------|--------------------|
-| `stateless` + `local/ephemeral` | No persistent storage needed. Horizontally scalable. Use a Deployment with HPA. |
-| `stateful` + `local/persistent` | Needs stable identity and local durable storage. Use a StatefulSet with PVCs. |
-| `stateful` + `shared/persistent` | Needs durable storage shared across instances. Provision network-attached or shared storage. |
-| `hybrid` + `local/ephemeral` | Tolerates instance loss. Can use a Deployment, but consider warm-up time if caches are large. |
-| `hybrid` + `local/persistent` | Wants persistent local state but survives without it. StatefulSet with PVC, but can fall back to emptyDir if needed. |
+| `stateless` | `local/ephemeral` | No persistent storage needed. Horizontally scalable. Use a Deployment with HPA. |
+| `stateful` | `local/persistent` | Needs stable identity and local durable storage. Use a StatefulSet with PVCs. |
+| `stateful` | `shared/persistent` | Needs durable storage shared across instances. Provision network-attached or shared storage. |
+| `hybrid` | `local/ephemeral` | Tolerates instance loss. Can use a Deployment, but consider warm-up time if caches are large. |
+| `hybrid` | `local/persistent` | Wants persistent local state but survives without it. StatefulSet with PVC, but can fall back to emptyDir if needed. |
 
 These aren't Kubernetes prescriptions — they're platform-agnostic signals. Whether you deploy to Kubernetes, Nomad, ECS, or a custom platform, the reasoning is the same.
 
@@ -655,6 +687,7 @@ configuration:
   values:
     DB_HOST: localhost
     DB_PORT: 5432
+    DB_PASSWORD: dev-password
     LOG_LEVEL: debug
 scaling:
   replicas: 1
@@ -666,6 +699,7 @@ configuration:
   values:
     DB_HOST: staging-db.internal
     DB_PORT: 5432
+    DB_PASSWORD: secret://vault/payments-staging/db-password
     LOG_LEVEL: info
 scaling:
   min: 2
@@ -678,6 +712,7 @@ configuration:
   values:
     DB_HOST: prod-db.internal
     DB_PORT: 5432
+    DB_PASSWORD: secret://vault/payments-prod/db-password
     LOG_LEVEL: warn
 scaling:
   min: 3

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -11,6 +11,102 @@ Automate contract validation, breaking-change detection, and publishing in your 
 
 ---
 
-## Getting Started
+<details open markdown="block">
+  <summary>Table of contents</summary>
+- TOC
+{:toc}
+</details>
 
-For usage examples, available commands, inputs, outputs, and advanced configuration see the [pacto-actions](https://github.com/TrianaLab/pacto-actions) repository.
+## Quick start
+
+Add the Pacto CLI action to any workflow step. The action installs the `pacto` binary and makes it available for subsequent steps.
+
+```yaml
+name: Contract CI
+
+on:
+  pull_request:
+    paths:
+      - 'pacto.yaml'
+      - 'interfaces/**'
+      - 'configuration/**'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Pacto CLI
+        uses: TrianaLab/pacto-actions@v1
+
+      - name: Validate contract
+        run: pacto validate .
+```
+
+## Common workflows
+
+### Validate on pull request
+
+Catch schema violations and cross-field errors before they reach main:
+
+```yaml
+      - name: Validate contract
+        run: pacto validate .
+```
+
+### Detect breaking changes
+
+Compare the PR contract against the published version to block breaking changes:
+
+```yaml
+      - name: Check for breaking changes
+        run: |
+          pacto diff oci://ghcr.io/acme/my-service-pacto . --output json > diff.json
+          if jq -e '.classification == "BREAKING"' diff.json > /dev/null 2>&1; then
+            echo "::error::Breaking contract change detected"
+            exit 1
+          fi
+```
+
+### Publish on release
+
+Push the contract bundle to an OCI registry when a release is created:
+
+```yaml
+name: Publish Contract
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Pacto CLI
+        uses: TrianaLab/pacto-actions@v1
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | pacto login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Push contract
+        run: pacto push oci://ghcr.io/${{ github.repository }}-pacto -p .
+```
+
+### Environment-specific validation
+
+Validate the contract with environment-specific overrides:
+
+```yaml
+      - name: Validate production config
+        run: pacto validate . --values values/production.yaml
+```
+
+## Further reading
+
+For the full list of inputs, outputs, and advanced configuration options, see the [pacto-actions](https://github.com/TrianaLab/pacto-actions) repository.


### PR DESCRIPTION
## Summary
- Adds a practical example to the contract overrides documentation showing how to maintain per-environment values files (dev, staging, production) with different configuration values and scaling settings.
- Shows the workflow: validate per environment, diff between environments, push with production config.

## Test plan
- [x] Documentation renders correctly in markdown