### PR TITLE
feat: add runtime.metrics section

### DIFF
--- a/docs/contract-reference.md
+++ b/docs/contract-reference.md
@@ -162,6 +162,10 @@ runtime:
     path: /health
     initialDelaySeconds: 15
 
+  metrics:
+    interface: rest-api
+    path: /metrics
+
 scaling:
   min: 2
   max: 10
@@ -328,6 +332,7 @@ Describes how the service behaves at runtime. This section is what lets platform
 | `state` | [State](#state) | Yes |
 | `lifecycle` | [Lifecycle](#lifecycle) | No |
 | `health` | [Health](#health) | No |
+| `metrics` | [Metrics](#metrics) | No |
 
 #### `runtime.workload`
 
@@ -417,6 +422,22 @@ Optional. Describes upgrade and shutdown behavior.
 | `path` | string | Conditional | Required when health interface is `http` |
 | `initialDelaySeconds` | integer | No | Minimum: 0 |
 
+#### `runtime.metrics`
+
+Optional. Tells the platform where to scrape metrics from the service (e.g. Prometheus endpoint).
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `interface` | string | Yes | Must reference a declared `http` or `grpc` interface |
+| `path` | string | Conditional | Required when metrics interface is `http` |
+
+```yaml
+runtime:
+  metrics:
+    interface: api
+    path: /metrics
+```
+
 ---
 
 ### `scaling`
@@ -495,6 +516,10 @@ Validates semantic references and consistency:
 | Health interface is not `event` type | `HEALTH_INTERFACE_INVALID` |
 | `health.path` required for `http` health interface | `HEALTH_PATH_REQUIRED` |
 | `health.path` on `grpc` health interface is ignored | `HEALTH_PATH_IGNORED` (warning) |
+| `metrics.interface` matches a declared interface | `METRICS_INTERFACE_NOT_FOUND` |
+| Metrics interface is not `event` type | `METRICS_INTERFACE_INVALID` |
+| `metrics.path` required for `http` metrics interface | `METRICS_PATH_REQUIRED` |
+| `metrics.path` on `grpc` metrics interface is ignored | `METRICS_PATH_IGNORED` (warning) |
 | Referenced files exist in the bundle | `FILE_NOT_FOUND` |
 | OCI dependency refs (`oci://`) are valid OCI references | `INVALID_OCI_REF` |
 | Compatibility ranges are valid semver constraints | `INVALID_COMPATIBILITY` |
@@ -684,6 +709,8 @@ Each change is classified as:
 | `runtime.health.interface` | Modified | POTENTIAL_BREAKING |
 | `runtime.health.path` | Modified | POTENTIAL_BREAKING |
 | `runtime.health.initialDelaySeconds` | Modified | NON_BREAKING |
+| `runtime.metrics.interface` | Modified | POTENTIAL_BREAKING |
+| `runtime.metrics.path` | Modified | POTENTIAL_BREAKING |
 
 ### Scaling
 

--- a/docs/examples/event-processor.md
+++ b/docs/examples/event-processor.md
@@ -1,0 +1,86 @@
+---
+title: Event Processor
+layout: default
+parent: Examples
+nav_order: 6
+---
+
+# Event Processor
+
+A Pacto contract for an event-driven service — a stateless consumer that processes messages from a message broker and exposes an HTTP health endpoint.
+
+```yaml
+pactoVersion: "1.0"
+
+service:
+  name: order-processor
+  version: 1.4.0
+  owner: team/orders
+  image:
+    ref: ghcr.io/acme/order-processor:1.4.0
+    private: true
+
+interfaces:
+  - name: order-events
+    type: event
+    visibility: internal
+    contract: interfaces/order-events.yaml
+
+  - name: health
+    type: http
+    port: 8080
+    visibility: internal
+
+configuration:
+  schema: configuration/schema.json
+  values:
+    BROKER_HOST: rabbitmq.internal
+    BROKER_PORT: 5672
+    BROKER_CREDENTIALS: secret://vault/order-processor/broker-credentials
+    DEAD_LETTER_QUEUE: orders.dlq
+    MAX_RETRIES: 3
+
+dependencies:
+  - ref: oci://ghcr.io/acme/rabbitmq-pacto@sha256:abc123
+    required: true
+    compatibility: "^3.13.0"
+
+runtime:
+  workload: service
+
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: medium
+
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 60
+
+  health:
+    interface: health
+    path: /health
+
+  metrics:
+    interface: health
+    path: /metrics
+
+scaling:
+  min: 2
+  max: 8
+
+metadata:
+  team: orders
+  tier: standard
+  consumer-group: order-processing
+```
+
+### Key decisions
+
+- **`type: event`** — declares that this service consumes events rather than serving HTTP/gRPC requests
+- **`contract: interfaces/order-events.yaml`** — the event contract (e.g. AsyncAPI or custom schema) is bundled and versioned alongside the service
+- **`dataCriticality: medium`** — event processing failures have moderate impact; dead-letter queues provide a safety net
+- **`gracefulShutdownSeconds: 60`** — allows in-flight messages to complete processing before shutdown
+- **Secret reference** — broker credentials use `secret://` so the platform injects actual credentials at deployment time

--- a/docs/examples/grpc-service.md
+++ b/docs/examples/grpc-service.md
@@ -1,0 +1,88 @@
+---
+title: gRPC Service
+layout: default
+parent: Examples
+nav_order: 7
+---
+
+# gRPC Service
+
+A Pacto contract for a gRPC microservice — a user service exposing a Protocol Buffer API with internal visibility.
+
+```yaml
+pactoVersion: "1.0"
+
+service:
+  name: user-service
+  version: 3.2.0
+  owner: team/identity
+  image:
+    ref: ghcr.io/acme/user-service:3.2.0
+    private: true
+
+interfaces:
+  - name: grpc-api
+    type: grpc
+    port: 9090
+    visibility: internal
+    contract: interfaces/user-service.proto
+
+  - name: health
+    type: http
+    port: 8080
+    visibility: internal
+
+  - name: metrics
+    type: http
+    port: 9102
+    visibility: internal
+
+configuration:
+  schema: configuration/schema.json
+  values:
+    DB_HOST: user-db.internal
+    DB_PORT: 5432
+    DB_PASSWORD: secret://vault/user-service/db-password
+    CACHE_TTL_SECONDS: 300
+
+dependencies:
+  - ref: oci://ghcr.io/acme/postgres-pacto@sha256:def456
+    required: true
+    compatibility: "^16.0.0"
+
+runtime:
+  workload: service
+
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 15
+
+  health:
+    interface: grpc-api
+
+  metrics:
+    interface: metrics
+    path: /metrics
+
+scaling:
+  min: 3
+  max: 12
+
+metadata:
+  team: identity
+  tier: critical
+```
+
+### Key decisions
+
+- **`type: grpc` with `contract`** — the `.proto` file is bundled in the OCI artifact, making the API contract portable and versionable
+- **Health on gRPC** — when the health interface is `grpc`, Pacto uses the [gRPC Health Checking Protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md); no `path` is needed
+- **Separate health and metrics** — the gRPC port serves application traffic, while HTTP ports expose health checks and Prometheus metrics independently
+- **`stateless`** — the service itself holds no state; data lives in PostgreSQL

--- a/docs/examples/hybrid-cache.md
+++ b/docs/examples/hybrid-cache.md
@@ -1,0 +1,97 @@
+---
+title: Hybrid Cache API
+layout: default
+parent: Examples
+nav_order: 8
+---
+
+# Hybrid Cache API
+
+A Pacto contract for a service with hybrid state — an API that caches data locally for performance but can rebuild its cache from an upstream source. Loss of local state degrades performance but does not break the service.
+
+```yaml
+pactoVersion: "1.0"
+
+service:
+  name: product-catalog
+  version: 2.0.1
+  owner: team/catalog
+  image:
+    ref: ghcr.io/acme/product-catalog:2.0.1
+    private: true
+
+interfaces:
+  - name: rest-api
+    type: http
+    port: 8080
+    visibility: public
+    contract: interfaces/openapi.yaml
+
+  - name: metrics
+    type: http
+    port: 9090
+    visibility: internal
+
+configuration:
+  schema: configuration/schema.json
+  values:
+    UPSTREAM_API: https://inventory.internal/api
+    CACHE_MAX_SIZE_MB: 512
+    CACHE_TTL_SECONDS: 3600
+    WARMUP_ON_START: true
+    API_KEY: secret://vault/product-catalog/upstream-api-key
+
+dependencies:
+  - ref: oci://ghcr.io/acme/inventory-pacto@sha256:789abc
+    required: true
+    compatibility: "^1.0.0"
+
+runtime:
+  workload: service
+
+  state:
+    type: hybrid
+    persistence:
+      scope: local
+      durability: persistent
+    dataCriticality: low
+
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 10
+
+  health:
+    interface: rest-api
+    path: /health
+
+  metrics:
+    interface: metrics
+    path: /metrics
+
+scaling:
+  min: 2
+  max: 6
+
+metadata:
+  team: catalog
+  tier: standard
+  cache-strategy: write-through
+```
+
+### Key decisions
+
+- **`state.type: hybrid`** — the service caches product data locally for fast reads, but can reconstruct the cache from the upstream inventory service on restart
+- **`durability: persistent`** — persisting the cache across restarts avoids cold-start latency, but the service functions correctly without it (it just needs time to warm up)
+- **`dataCriticality: low`** — the cache is reconstructible; losing it has no business impact beyond temporary performance degradation
+- **`upgradeStrategy: rolling`** — rolling updates prevent all instances from cold-starting simultaneously
+- **Secret reference** — the API key for the upstream service uses `secret://` so credentials never appear in the contract
+
+### When to use `hybrid`
+
+Use `hybrid` when your service:
+
+- Maintains local state that **improves** behavior (caches, pre-computed indexes, session stores)
+- Can **recover** from state loss by rebuilding from an upstream source
+- Would experience **degraded performance** but not **failure** if local state is lost
+
+If state loss would break the service, use `stateful` instead.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -34,6 +34,9 @@ These contracts represent the **operational interface** of each service — not 
 | [RabbitMQ]({{ site.baseurl }}{% link examples/rabbitmq.md %}) | service | stateful/persistent | Message broker |
 | [NGINX]({{ site.baseurl }}{% link examples/nginx.md %}) | service | stateless/ephemeral | Reverse proxy / web server |
 | [Cron Worker]({{ site.baseurl }}{% link examples/cron-worker.md %}) | scheduled | stateless/ephemeral | Scheduled batch job |
+| [Event Processor]({{ site.baseurl }}{% link examples/event-processor.md %}) | service | stateless/ephemeral | Event-driven message consumer |
+| [gRPC Service]({{ site.baseurl }}{% link examples/grpc-service.md %}) | service | stateless/ephemeral | gRPC microservice with Proto contract |
+| [Hybrid Cache API]({{ site.baseurl }}{% link examples/hybrid-cache.md %}) | service | hybrid/persistent | API with local cache and upstream rebuild |
 
 ---
 

--- a/docs/examples/nginx.md
+++ b/docs/examples/nginx.md
@@ -57,6 +57,10 @@ runtime:
     interface: http
     path: /health
 
+  metrics:
+    interface: metrics
+    path: /metrics
+
 scaling:
   min: 2
   max: 20

--- a/docs/examples/postgresql.md
+++ b/docs/examples/postgresql.md
@@ -53,6 +53,10 @@ runtime:
     interface: metrics
     path: /health
 
+  metrics:
+    interface: metrics
+    path: /metrics
+
 scaling:
   replicas: 1
 

--- a/docs/examples/rabbitmq.md
+++ b/docs/examples/rabbitmq.md
@@ -59,6 +59,10 @@ runtime:
     interface: management
     path: /api/health/checks/alarms
 
+  metrics:
+    interface: metrics
+    path: /metrics
+
 scaling:
   min: 3
   max: 5

--- a/docs/examples/redis.md
+++ b/docs/examples/redis.md
@@ -53,6 +53,10 @@ runtime:
     interface: metrics
     path: /health
 
+  metrics:
+    interface: metrics
+    path: /metrics
+
 scaling:
   replicas: 1
 

--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -63,6 +63,10 @@ runtime:
     path: /health
     initialDelaySeconds: 5
 
+  metrics:
+    interface: api
+    path: /metrics
+
 scaling:
   min: 1
   max: 3

--- a/internal/diff/classification.go
+++ b/internal/diff/classification.go
@@ -61,6 +61,10 @@ var rules = map[classificationKey]Classification{
 	{"runtime.health.path", Modified}:                PotentialBreaking,
 	{"runtime.health.initialDelaySeconds", Modified}: NonBreaking,
 
+	// Runtime — metrics
+	{"runtime.metrics.interface", Modified}: PotentialBreaking,
+	{"runtime.metrics.path", Modified}:      PotentialBreaking,
+
 	// Scaling
 	{"scaling.min", Modified}: PotentialBreaking,
 	{"scaling.max", Modified}: NonBreaking,

--- a/internal/diff/runtime.go
+++ b/internal/diff/runtime.go
@@ -47,6 +47,9 @@ func diffRuntime(old, new *contract.Contract) []Change {
 	// Health
 	changes = append(changes, diffHealth(oldRT.Health, newRT.Health)...)
 
+	// Metrics
+	changes = append(changes, diffMetrics(oldRT.Metrics, newRT.Metrics)...)
+
 	return changes
 }
 
@@ -69,6 +72,25 @@ func diffHealth(old, new *contract.Health) []Change {
 	}
 	if intPtrChanged(oldDelay, newDelay) {
 		changes = append(changes, newChange("runtime.health.initialDelaySeconds", Modified, intPtrVal(oldDelay), intPtrVal(newDelay)))
+	}
+	return changes
+}
+
+func diffMetrics(old, new *contract.Metrics) []Change {
+	var changes []Change
+	oldIface, newIface := "", ""
+	oldPath, newPath := "", ""
+	if old != nil {
+		oldIface, oldPath = old.Interface, old.Path
+	}
+	if new != nil {
+		newIface, newPath = new.Interface, new.Path
+	}
+	if oldIface != newIface {
+		changes = append(changes, newChange("runtime.metrics.interface", Modified, oldIface, newIface))
+	}
+	if oldPath != newPath {
+		changes = append(changes, newChange("runtime.metrics.path", Modified, oldPath, newPath))
 	}
 	return changes
 }

--- a/internal/diff/runtime_test.go
+++ b/internal/diff/runtime_test.go
@@ -285,6 +285,59 @@ func TestDiffRuntime_HealthInitialDelayChanged(t *testing.T) {
 	}
 }
 
+func TestDiffMetrics_BothNil(t *testing.T) {
+	changes := diffMetrics(nil, nil)
+	if len(changes) != 0 {
+		t.Errorf("expected 0 changes, got %d", len(changes))
+	}
+}
+
+func TestDiffMetrics_InterfaceChanged(t *testing.T) {
+	old := &contract.Metrics{Interface: "api", Path: "/metrics"}
+	new := &contract.Metrics{Interface: "metrics", Path: "/metrics"}
+	changes := diffMetrics(old, new)
+	found := false
+	for _, c := range changes {
+		if c.Path == "runtime.metrics.interface" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected runtime.metrics.interface change")
+	}
+}
+
+func TestDiffMetrics_PathChanged(t *testing.T) {
+	old := &contract.Metrics{Interface: "api", Path: "/metrics"}
+	new := &contract.Metrics{Interface: "api", Path: "/prometheus"}
+	changes := diffMetrics(old, new)
+	found := false
+	for _, c := range changes {
+		if c.Path == "runtime.metrics.path" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected runtime.metrics.path change")
+	}
+}
+
+func TestDiffMetrics_Added(t *testing.T) {
+	new := &contract.Metrics{Interface: "api", Path: "/metrics"}
+	changes := diffMetrics(nil, new)
+	if len(changes) != 2 {
+		t.Errorf("expected 2 changes (interface + path), got %d", len(changes))
+	}
+}
+
+func TestDiffMetrics_Removed(t *testing.T) {
+	old := &contract.Metrics{Interface: "api", Path: "/metrics"}
+	changes := diffMetrics(old, nil)
+	if len(changes) != 2 {
+		t.Errorf("expected 2 changes (interface + path), got %d", len(changes))
+	}
+}
+
 func TestDiffRuntime_BothNilRuntime(t *testing.T) {
 	old := &contract.Contract{Service: contract.ServiceIdentity{Name: "a", Version: "1.0.0"}}
 	new := &contract.Contract{Service: contract.ServiceIdentity{Name: "a", Version: "1.0.0"}}

--- a/internal/doc/generate.go
+++ b/internal/doc/generate.go
@@ -443,6 +443,9 @@ func buildIfaceLabel(iface contract.Interface, c *contract.Contract) string {
 	if c.Runtime != nil && c.Runtime.Health != nil && iface.Name == c.Runtime.Health.Interface {
 		label += "<br/>♥ health"
 	}
+	if c.Runtime != nil && c.Runtime.Metrics != nil && iface.Name == c.Runtime.Metrics.Interface {
+		label += "<br/>📊 metrics"
+	}
 	return label
 }
 
@@ -521,14 +524,16 @@ func writeInterfacesTable(b *strings.Builder, interfaces []contract.Interface) {
 
 func writeInterfaceDetails(b *strings.Builder, c *contract.Contract, fsys fs.FS, level int, num *sectionNumberer) {
 	var health *contract.Health
+	var metrics *contract.Metrics
 	if c.Runtime != nil {
 		health = c.Runtime.Health
+		metrics = c.Runtime.Metrics
 	}
 	for _, iface := range c.Interfaces {
 		if iface.Type == contract.InterfaceTypeHTTP {
-			writeHTTPInterfaceDetailLevel(b, iface, health, fsys, level, num)
+			writeHTTPInterfaceDetailLevel(b, iface, health, metrics, fsys, level, num)
 		} else {
-			writeNonHTTPInterfaceDetailLevel(b, iface, health, level, num)
+			writeNonHTTPInterfaceDetailLevel(b, iface, health, metrics, level, num)
 		}
 	}
 }
@@ -614,6 +619,16 @@ func healthSuffix(ifaceName string, health *contract.Health) string {
 	return ""
 }
 
+func metricsSuffix(ifaceName string, metrics *contract.Metrics) string {
+	if metrics == nil || metrics.Interface != ifaceName {
+		return ""
+	}
+	if metrics.Path != "" {
+		return fmt.Sprintf(" It serves metrics at `%s`.", metrics.Path)
+	}
+	return " It serves the metrics endpoint."
+}
+
 func writeInterfaceSentence(iface contract.Interface) string {
 	s := fmt.Sprintf("The `%s` interface", iface.Name)
 	if iface.Visibility != "" && iface.Port != nil {
@@ -626,9 +641,9 @@ func writeInterfaceSentence(iface contract.Interface) string {
 	return s
 }
 
-func writeHTTPInterfaceDetailLevel(b *strings.Builder, iface contract.Interface, health *contract.Health, fsys fs.FS, level int, num *sectionNumberer) {
+func writeHTTPInterfaceDetailLevel(b *strings.Builder, iface contract.Interface, health *contract.Health, metrics *contract.Metrics, fsys fs.FS, level int, num *sectionNumberer) {
 	writeHeading(b, level, interfaceHeading(iface), num)
-	fmt.Fprintf(b, "%s.%s\n\n", writeInterfaceSentence(iface), healthSuffix(iface.Name, health))
+	fmt.Fprintf(b, "%s.%s%s\n\n", writeInterfaceSentence(iface), healthSuffix(iface.Name, health), metricsSuffix(iface.Name, metrics))
 
 	if iface.Contract == "" {
 		return
@@ -657,14 +672,14 @@ func writeHTTPInterfaceDetailLevel(b *strings.Builder, iface contract.Interface,
 	fmt.Fprintln(b)
 }
 
-func writeNonHTTPInterfaceDetailLevel(b *strings.Builder, iface contract.Interface, health *contract.Health, level int, num *sectionNumberer) {
+func writeNonHTTPInterfaceDetailLevel(b *strings.Builder, iface contract.Interface, health *contract.Health, metrics *contract.Metrics, level int, num *sectionNumberer) {
 	writeHeading(b, level, interfaceHeading(iface), num)
 
 	desc := writeInterfaceSentence(iface)
 	if iface.Contract != "" {
 		desc += fmt.Sprintf(". Its contract is defined in `%s`", iface.Contract)
 	}
-	fmt.Fprintf(b, "%s.%s\n\n", desc, healthSuffix(iface.Name, health))
+	fmt.Fprintf(b, "%s.%s%s\n\n", desc, healthSuffix(iface.Name, health), metricsSuffix(iface.Name, metrics))
 }
 
 // writeHeading writes a heading at the given level. Levels 1-4 use markdown (#),

--- a/internal/doc/generate_test.go
+++ b/internal/doc/generate_test.go
@@ -77,6 +77,10 @@ func fullContract() *contract.Contract {
 				Path:                "/health",
 				InitialDelaySeconds: intPtr(15),
 			},
+			Metrics: &contract.Metrics{
+				Interface: "rest-api",
+				Path:      "/metrics",
+			},
 		},
 		Scaling: &contract.Scaling{Min: 2, Max: 10},
 		Metadata: map[string]interface{}{
@@ -172,6 +176,8 @@ func TestGenerate_Full(t *testing.T) {
 		{"auth dep name in mermaid", `"auth-service-pacto"`},
 		{"notification dep name in mermaid", `"notification-service-pacto"`},
 		{"health label in mermaid", "<br/>♥ health"},
+		{"metrics label in mermaid", "<br/>📊 metrics"},
+		{"metrics path in interface", "serves metrics at `/metrics`"},
 		{"interfaces section", "## 2. Interfaces"},
 		{"rest-api in interfaces table", "| `rest-api` | `http` | `8080` | `public` |"},
 		{"configuration section", "## 3. Configuration"},
@@ -957,6 +963,22 @@ func TestCollectAllContracts_NilGraph(t *testing.T) {
 	all := collectAllContracts(c, nil)
 	if len(all) != 1 || all[0].Service.Name != "svc" {
 		t.Errorf("expected single contract for nil graph, got %d", len(all))
+	}
+}
+
+func TestMetricsSuffix_WithoutPath(t *testing.T) {
+	m := &contract.Metrics{Interface: "api", Path: ""}
+	result := metricsSuffix("api", m)
+	if result != " It serves the metrics endpoint." {
+		t.Errorf("unexpected result: %q", result)
+	}
+}
+
+func TestMetricsSuffix_DifferentInterface(t *testing.T) {
+	m := &contract.Metrics{Interface: "other", Path: "/metrics"}
+	result := metricsSuffix("api", m)
+	if result != "" {
+		t.Errorf("expected empty string, got: %q", result)
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -317,6 +317,9 @@ func writeRuntime(b *strings.Builder, input generateInput) {
 		fmt.Fprintln(b, "  health:")
 		fmt.Fprintln(b, "    interface: http-api")
 		fmt.Fprintln(b, "    path: /health")
+		fmt.Fprintln(b, "  metrics:")
+		fmt.Fprintln(b, "    interface: http-api")
+		fmt.Fprintln(b, "    path: /metrics")
 	}
 }
 

--- a/internal/validation/crossfield.go
+++ b/internal/validation/crossfield.go
@@ -22,6 +22,7 @@ func ValidateCrossField(c *contract.Contract, bundleFS fs.FS) ValidationResult {
 	validateInterfacePorts(c, &result)
 	validateInterfaceContracts(c, &result)
 	validateHealthInterface(c, &result)
+	validateMetricsInterface(c, &result)
 	validateInterfaceFiles(c, bundleFS, &result)
 	validateConfigFiles(c, bundleFS, &result)
 	validateDependencyRefs(c, &result)
@@ -148,6 +149,55 @@ func validateHealthInterface(c *contract.Contract, result *ValidationResult) {
 			"runtime.health.path",
 			"HEALTH_PATH_IGNORED",
 			"health check path is not used for grpc interfaces; gRPC uses the standard health protocol",
+		)
+	}
+}
+
+func validateMetricsInterface(c *contract.Contract, result *ValidationResult) {
+	if c.Runtime == nil || c.Runtime.Metrics == nil {
+		return
+	}
+	metricsIface := c.Runtime.Metrics.Interface
+
+	var found *contract.Interface
+	for i := range c.Interfaces {
+		if c.Interfaces[i].Name == metricsIface {
+			found = &c.Interfaces[i]
+			break
+		}
+	}
+
+	if found == nil {
+		result.AddError(
+			"runtime.metrics.interface",
+			"METRICS_INTERFACE_NOT_FOUND",
+			fmt.Sprintf("metrics interface %q does not match any declared interface", metricsIface),
+		)
+		return
+	}
+
+	if found.Type == contract.InterfaceTypeEvent {
+		result.AddError(
+			"runtime.metrics.interface",
+			"METRICS_INTERFACE_INVALID",
+			fmt.Sprintf("metrics interface %q is an event interface; metrics require http or grpc", metricsIface),
+		)
+		return
+	}
+
+	if found.Type == contract.InterfaceTypeHTTP && c.Runtime.Metrics.Path == "" {
+		result.AddError(
+			"runtime.metrics.path",
+			"METRICS_PATH_REQUIRED",
+			"metrics path is required when the metrics interface type is http",
+		)
+	}
+
+	if found.Type == contract.InterfaceTypeGRPC && c.Runtime.Metrics.Path != "" {
+		result.AddWarning(
+			"runtime.metrics.path",
+			"METRICS_PATH_IGNORED",
+			"metrics path is not used for grpc interfaces",
 		)
 	}
 }

--- a/internal/validation/crossfield_test.go
+++ b/internal/validation/crossfield_test.go
@@ -320,6 +320,83 @@ func TestValidateHealthInterface_HTTPWithoutPath(t *testing.T) {
 	}
 }
 
+func TestValidateMetricsInterface_NotFound(t *testing.T) {
+	c := validContract()
+	c.Runtime.Metrics = &contract.Metrics{Interface: "nonexistent", Path: "/metrics"}
+	var result ValidationResult
+	validateMetricsInterface(c, &result)
+	if result.IsValid() {
+		t.Error("expected error for metrics interface not found")
+	}
+}
+
+func TestValidateMetricsInterface_EventInterface(t *testing.T) {
+	c := validContract()
+	c.Interfaces = []contract.Interface{
+		{Name: "events", Type: "event", Contract: "events.proto"},
+	}
+	c.Runtime.Metrics = &contract.Metrics{Interface: "events", Path: "/metrics"}
+	var result ValidationResult
+	validateMetricsInterface(c, &result)
+	if result.IsValid() {
+		t.Error("expected error for event metrics interface")
+	}
+}
+
+func TestValidateMetricsInterface_HTTPWithoutPath(t *testing.T) {
+	c := validContract()
+	c.Runtime.Metrics = &contract.Metrics{Interface: "api", Path: ""}
+	var result ValidationResult
+	validateMetricsInterface(c, &result)
+	if result.IsValid() {
+		t.Error("expected error for HTTP metrics interface without path")
+	}
+}
+
+func TestValidateMetricsInterface_GRPCWithPath(t *testing.T) {
+	c := validContract()
+	grpcPort := 9090
+	c.Interfaces = []contract.Interface{
+		{Name: "grpc", Type: "grpc", Port: &grpcPort, Contract: "service.proto"},
+	}
+	c.Runtime.Metrics = &contract.Metrics{Interface: "grpc", Path: "/metrics"}
+	var result ValidationResult
+	validateMetricsInterface(c, &result)
+	if len(result.Warnings) == 0 {
+		t.Error("expected METRICS_PATH_IGNORED warning for gRPC interface with path")
+	}
+}
+
+func TestValidateMetricsInterface_Valid(t *testing.T) {
+	c := validContract()
+	c.Runtime.Metrics = &contract.Metrics{Interface: "api", Path: "/metrics"}
+	var result ValidationResult
+	validateMetricsInterface(c, &result)
+	if !result.IsValid() {
+		t.Errorf("expected no error for valid metrics interface, got %v", result.Errors)
+	}
+}
+
+func TestValidateMetricsInterface_NilRuntime(t *testing.T) {
+	c := validContract()
+	c.Runtime = nil
+	var result ValidationResult
+	validateMetricsInterface(c, &result)
+	if !result.IsValid() {
+		t.Error("expected no error for nil runtime")
+	}
+}
+
+func TestValidateMetricsInterface_NilMetrics(t *testing.T) {
+	c := validContract()
+	c.Runtime.Metrics = nil
+	var result ValidationResult
+	validateMetricsInterface(c, &result)
+	if !result.IsValid() {
+		t.Error("expected no error for nil metrics")
+	}
+}
+
 func TestValidateImageRef_InvalidRef(t *testing.T) {
 	c := validContract()
 	c.Service.Image = &contract.Image{Ref: "invalid"}

--- a/internal/validation/schema/pacto-v1.0.schema.json
+++ b/internal/validation/schema/pacto-v1.0.schema.json
@@ -317,6 +317,23 @@
               "description": "The number of seconds to wait after the container starts before sending the first health check probe."
             }
           }
+        },
+
+        "metrics": {
+          "type": "object",
+          "description": "Configures where the platform scrapes metrics from the service (e.g. Prometheus endpoint).",
+          "required": ["interface"],
+          "additionalProperties": false,
+          "properties": {
+            "interface": {
+              "type": "string",
+              "description": "The name of the interface that serves the metrics endpoint."
+            },
+            "path": {
+              "type": "string",
+              "description": "The HTTP path for the metrics endpoint (e.g. /metrics)."
+            }
+          }
         }
       }
     },

--- a/pkg/contract/contract.go
+++ b/pkg/contract/contract.go
@@ -75,6 +75,7 @@ type Runtime struct {
 	State     State      `yaml:"state" json:"state"`
 	Lifecycle *Lifecycle `yaml:"lifecycle,omitempty" json:"lifecycle,omitempty"`
 	Health    *Health    `yaml:"health,omitempty" json:"health,omitempty"`
+	Metrics   *Metrics   `yaml:"metrics,omitempty" json:"metrics,omitempty"`
 }
 
 // WorkloadType constants.
@@ -141,6 +142,12 @@ type Health struct {
 	Interface           string `yaml:"interface" json:"interface"`
 	Path                string `yaml:"path,omitempty" json:"path,omitempty"`
 	InitialDelaySeconds *int   `yaml:"initialDelaySeconds,omitempty" json:"initialDelaySeconds,omitempty"`
+}
+
+// Metrics describes the metrics endpoint configuration.
+type Metrics struct {
+	Interface string `yaml:"interface" json:"interface"`
+	Path      string `yaml:"path,omitempty" json:"path,omitempty"`
 }
 
 // Scaling describes scaling parameters.


### PR DESCRIPTION
## Summary

- Adds `runtime.metrics` to the contract spec, mirroring `runtime.health` — declares which interface and path the platform should scrape for metrics (e.g. Prometheus)
- Full implementation across all layers: Go struct, JSON Schema, cross-field validation, diff classification, doc generation, Mermaid diagrams
- Includes 3 new example contracts: event-driven processor, gRPC service, hybrid cache API

## Details

The `metrics` section works exactly like `health`:
- `interface` (required) — must reference a declared `http` or `grpc` interface
- `path` (conditional) — required for `http` interfaces, ignored for `grpc`

Validation rules: `METRICS_INTERFACE_NOT_FOUND`, `METRICS_INTERFACE_INVALID`, `METRICS_PATH_REQUIRED`, `METRICS_PATH_IGNORED`

Diff classification: both `runtime.metrics.interface` and `runtime.metrics.path` are `POTENTIAL_BREAKING`