### PR TITLE
feat: add policy enforcement and external schema references

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,13 +169,15 @@ my-service/
   src/
   Dockerfile
   pacto.yaml             ← single source of truth
-  interfaces/
+  interfaces/            ← optional
     openapi.yaml
-  configuration/
+  configuration/         ← optional
     schema.json
-  docs/                   ← optional documentation
+  policy/                ← optional
+    schema.json
+  docs/                  ← optional
     README.md
-  sbom/                   ← optional SBOM
+  sbom/                  ← optional
     sbom.spdx.json
 ```
 
@@ -193,32 +195,42 @@ pacto graph .             # shows dependency tree
 ## What's inside a Pacto bundle
 
 ```mermaid
-graph TD
+graph LR
     subgraph Bundle["Pacto Bundle"]
-        YAML["pacto.yaml"]
-        YAML --> Interfaces["Interfaces<br/>HTTP, gRPC, ports, visibility"]
-        YAML --> Dependencies["Dependencies<br/>oci://auth:2.0.0<br/>oci://db:1.0.0"]
-        YAML --> Runtime["Runtime<br/>state, health, lifecycle, scaling"]
-        YAML --> Config["Configuration<br/>JSON Schema"]
-        Docs["docs/<br/>README · runbooks · guides"]
-        SBOM["sbom/<br/>SPDX · CycloneDX"]
+        direction TB
+        YAML["pacto.yaml<br/><i>required</i>"]
+
+        subgraph Sections["Contract Sections <i>(all optional)</i>"]
+            direction TB
+            Interfaces["Interfaces<br/>HTTP · gRPC · ports · visibility"]
+            Dependencies["Dependencies<br/>oci://auth:2.0.0 · oci://db:1.0.0"]
+            Runtime["Runtime<br/>state · health · lifecycle · scaling"]
+            Config["Configuration<br/>schema.json"]
+            Policy["Policy<br/>schema.json"]
+        end
+
+        subgraph Extras["Metadata <i>(optional)</i>"]
+            direction TB
+            Docs["docs/<br/>README · runbooks · guides"]
+            SBOM["sbom/<br/>SPDX · CycloneDX"]
+        end
+
+        YAML --> Sections
     end
 
-    IF["interfaces/<br/>openapi.yaml · service.proto"]
-    CF["configuration/<br/>schema.json"]
-
-    Interfaces -.-> IF
-    Config -.-> CF
-    Bundle -- "pacto push" --> Registry["OCI Registry<br/>GHCR · ECR · ACR · Docker Hub"]
+    Bundle -- "pacto push" --> Registry["OCI Registry<br/>GHCR · ECR · ACR<br/>Docker Hub"]
 ```
 
 A bundle is a self-contained directory (or OCI artifact) containing:
 
-- **`pacto.yaml`** — the contract: interfaces, dependencies, runtime semantics, scaling
-- **`interfaces/`** — OpenAPI specs, protobuf definitions, event schemas
-- **`configuration/`** — JSON Schema for environment variables and settings
+- **`pacto.yaml`** — the contract: interfaces, dependencies, runtime semantics, scaling *(required)*
+- **`interfaces/`** *(optional)* — OpenAPI specs, protobuf definitions, event schemas
+- **`configuration/`** *(optional)* — JSON Schema for environment variables and settings
+- **`policy/`** *(optional)* — JSON Schema that validates the contract itself, enabling platform teams to enforce organizational standards
 - **`docs/`** *(optional)* — service documentation (README, runbooks, architecture notes, integration guides). Travels with the contract but has no effect on validation, diffing, or compatibility classification
 - **`sbom/`** *(optional)* — Software Bill of Materials in SPDX 2.3 (`.spdx.json`) or CycloneDX 1.5 (`.cdx.json`) format. When present, `pacto diff` reports package-level changes (added, removed, version/license modified). Generate with tools like [Syft](https://github.com/anchore/syft), [Trivy](https://github.com/aquasecurity/trivy), or [cdxgen](https://github.com/CycloneDX/cdxgen)
+
+Only `pacto.yaml` is required. All other directories are optional — include them when your contract references files in them.
 
 ## Example repository layout
 
@@ -227,14 +239,16 @@ payments-api/
   src/                           ← your application code
   Dockerfile
   pacto.yaml                     ← the contract (committed to the repo)
-  interfaces/
-    openapi.yaml                 ← referenced by pacto.yaml
-  configuration/
-    schema.json                  ← JSON Schema for env vars / config
-  docs/                          ← optional service documentation
+  interfaces/                    ← optional, referenced by pacto.yaml
+    openapi.yaml
+  configuration/                 ← optional, JSON Schema for config
+    schema.json
+  policy/                        ← optional, policy enforcement
+    schema.json
+  docs/                          ← optional, service documentation
     README.md
     runbook.md
-  sbom/                          ← optional SBOM (SPDX or CycloneDX)
+  sbom/                          ← optional, SBOM (SPDX or CycloneDX)
     sbom.spdx.json
   .github/workflows/
     ci.yml                       ← pacto validate + pacto diff + pacto push

--- a/cmd/gendocs/main.go
+++ b/cmd/gendocs/main.go
@@ -87,7 +87,7 @@ No credentials are ever stored in contract files.
 // details, output examples, and cross-references that cannot be derived
 // from the cobra command definition alone.
 var commandNotes = map[string]string{
-	"init": `Creates a complete bundle with a valid ` + "`pacto.yaml`" + `, a placeholder OpenAPI spec, and a configuration JSON Schema.`,
+	"init": `Scaffolds a bundle with a valid ` + "`pacto.yaml`" + `, a placeholder OpenAPI spec, and a configuration JSON Schema. Only ` + "`pacto.yaml`" + ` is required — the ` + "`interfaces/`" + ` and ` + "`configuration/`" + ` directories are optional conveniences.`,
 
 	"validate": `**Exit code:** Non-zero if validation fails.`,
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,7 @@ Dependencies flow **downward only**. No package imports a package above it.
 
 The only public package. Contains pure Go types and logic with **zero I/O and zero framework dependencies**.
 
-- `Contract`, `ServiceIdentity`, `Interface`, `Runtime`, `State`, etc.
+- `Contract`, `ServiceIdentity`, `Interface`, `Runtime`, `State`, `Configuration`, `Policy`, etc.
 - `Parse()` — YAML deserialization
 - `OCIReference` — OCI reference parsing
 - `Range` — Semver constraint evaluation
@@ -93,7 +93,7 @@ Compares two contracts and classifies every change using a deterministic rule ta
 
 - `contract.go` — service identity, scaling
 - `runtime.go` — workload, state, lifecycle, health
-- `interfaces.go` — interface additions/removals/changes
+- `interfaces.go` — interface additions/removals/changes, configuration and policy diffing
 - `dependency.go` — dependency list changes
 - `openapi.go` — deep OpenAPI diff (paths, methods, parameters, request bodies, responses)
 - `schema.go` — JSON Schema property-level diff

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -243,7 +243,7 @@ pacto init <name> [flags]
   -h, --help   help for init
 ```
 
-Creates a complete bundle with a valid `pacto.yaml`, a placeholder OpenAPI spec, and a configuration JSON Schema.
+Scaffolds a bundle with a valid `pacto.yaml`, a placeholder OpenAPI spec, and a configuration JSON Schema. Only `pacto.yaml` is required — the `interfaces/` and `configuration/` directories are optional conveniences.
 
 ---
 

--- a/docs/contract-reference.md
+++ b/docs/contract-reference.md
@@ -28,11 +28,13 @@ A Pacto bundle is a self-contained directory (or OCI artifact) with the followin
 ```
 /
 ├── pacto.yaml
-├── interfaces/
+├── interfaces/              ← optional
 │   ├── openapi.yaml
 │   ├── service.proto
 │   └── events.yaml
-├── configuration/
+├── configuration/           ← optional
+│   └── schema.json
+├── policy/                  ← optional
 │   └── schema.json
 ├── docs/                    ← optional
 │   ├── README.md
@@ -43,7 +45,7 @@ A Pacto bundle is a self-contained directory (or OCI artifact) with the followin
     └── sbom.spdx.json
 ```
 
-All files referenced by `pacto.yaml` must exist within the bundle. Validation enforces this.
+Only `pacto.yaml` is required. All other directories are optional — include them when your contract references files in them. Validation enforces that every file referenced by `pacto.yaml` exists within the bundle.
 
 When you run `pacto push`, the bundle is packaged as an OCI artifact — versioned, content-addressed, and distributable through any OCI registry. This is how contracts travel between teams, services, and environments.
 
@@ -133,6 +135,9 @@ interfaces:
 
 configuration:
   schema: configuration/schema.json
+
+policy:
+  ref: oci://ghcr.io/acme/platform-policy-pacto:1.0.0
 
 dependencies:
   - ref: oci://ghcr.io/acme/auth-pacto@sha256:abc123def456
@@ -265,19 +270,36 @@ Interface names must be unique within a contract. The `contract` field for `http
 
 ### `configuration`
 
-Defines the service's configuration model.
+Defines the service's configuration model. Optional — services with no configuration schema may omit this section entirely. When present, at least one of `schema` or `ref` must be specified.
 
 | Field | Type | Required | Constraints |
 |-------|------|----------|-------------|
-| `schema` | string | Yes | Non-empty. Must reference a file in the bundle |
+| `schema` | string | Conditional | Non-empty. Must reference a file in the bundle. Required if `ref` is not set |
+| `ref` | string | Conditional | Non-empty. OCI or local reference to another Pacto contract. Required if `schema` is not set |
 | `values` | object | No | Must conform to the schema defined in `schema` |
+
+When `schema` is used, the configuration schema is a local file within the bundle. When `ref` is used, the schema is resolved from another Pacto contract's bundle at the fixed path `configuration/schema.json`. Both may be specified simultaneously.
 
 Required configuration keys are derived from the JSON Schema's `required` array.
 
-The optional `values` field provides default configuration values that are validated against the referenced JSON Schema. This is useful for documenting expected defaults or providing environment-specific overrides via the `--set` and `--values` flags (see [Contract overrides](#contract-overrides)).
+The optional `values` field provides default configuration values that are validated against the referenced JSON Schema. When using `ref`, values validation is deferred to runtime resolution. This is useful for documenting expected defaults or providing environment-specific overrides via the `--set` and `--values` flags (see [Contract overrides](#contract-overrides)).
 
 {: .tip }
 All files referenced by the contract — including the configuration schema — are packaged into the bundle when you run `pacto push`. The bundle is a self-contained OCI artifact that includes `pacto.yaml`, interface contracts, the configuration schema, and any other files in the contract directory.
+
+#### External configuration schema reference
+
+Instead of vendoring a configuration schema into the bundle, you can reference another Pacto contract that contains it. The referenced contract's bundle must have the schema at the fixed path `configuration/schema.json`:
+
+```yaml
+configuration:
+  ref: oci://ghcr.io/acme/platform-config-pacto:1.0.0
+```
+
+This enables centralized configuration management — a platform team publishes a single configuration contract, and all services reference it. The reference supports recursive resolution: if the referenced contract itself has a `configuration.ref`, Pacto follows the chain (with cycle detection) using the same OCI resolution and caching infrastructure as dependencies.
+
+{: .warning }
+Local configuration references (`file://` and bare paths) are only allowed during development. `pacto push` rejects contracts with local `configuration.ref` — all refs must use `oci://` before publishing.
 
 #### Secret references
 
@@ -331,13 +353,22 @@ Characteristics:
 
 #### Platform-Defined Schema
 
-When a platform team defines a shared configuration schema, the schema expresses **what the platform provides**. It describes the platform's capabilities — databases, caches, observability endpoints, feature flags — as a structured contract. Services vendor this schema into their bundle and conform to it.
+When a platform team defines a shared configuration schema, the schema expresses **what the platform provides**. It describes the platform's capabilities — databases, caches, observability endpoints, feature flags — as a structured contract.
 
-The schema file always lives inside the bundle — `configuration.schema` is a local path. The platform team publishes and distributes the schema externally (e.g. via an OCI registry, a shared repository, or a CI step that copies it in), but the contract references the vendored copy:
+There are two approaches for distributing platform schemas:
+
+**Vendored (local path):** The platform team publishes the schema externally, and services copy it into their bundle at build time:
 
 ```yaml
 configuration:
   schema: configuration/platform-schema.json
+```
+
+**Referenced (OCI):** Services reference the platform's configuration contract directly via `configuration.ref`. No vendoring required — Pacto resolves the schema from the referenced bundle at the fixed path `configuration/schema.json`:
+
+```yaml
+configuration:
+  ref: oci://ghcr.io/acme/platform-config-pacto:1.0.0
 ```
 
 Characteristics:
@@ -345,7 +376,7 @@ Characteristics:
 - **Standardization** — all services on the platform share a common configuration vocabulary
 - **Strong governance** — the platform team controls what configuration is available and validates it centrally
 - **Platform-as-a-product model** — the schema becomes part of the platform's public interface
-- **Vendored distribution** — services pull the schema at build time and bundle it locally
+- **Centralized or vendored** — choose between referencing the schema via OCI or vendoring it locally
 
 {: .important }
 > In Pacto, the configuration schema is an **interface**. Depending on ownership, it describes either:
@@ -357,7 +388,87 @@ Characteristics:
 
 #### Hybrid Approaches
 
-In practice, organizations may combine both models — a platform-defined base schema that covers shared infrastructure (database connections, observability, secrets) with service-specific extensions for application-level configuration. Pacto does not prescribe a specific pattern; the `configuration.schema` field accepts any valid JSON Schema reference regardless of where it originates.
+In practice, organizations may combine both models — a platform-defined base schema that covers shared infrastructure (database connections, observability, secrets) with service-specific extensions for application-level configuration. Pacto does not prescribe a specific pattern; both `configuration.schema` and `configuration.ref` can coexist, and the schema format is identical regardless of where it originates.
+
+---
+
+### `policy`
+
+Defines or references policy constraints for the contract. Optional — services not subject to a policy may omit this section entirely. A policy is a JSON Schema that validates the contract itself, enabling platform teams to enforce organizational standards (e.g., require health endpoints, mandate specific ports, enforce visibility rules).
+
+When present, at least one of `schema` or `ref` must be specified.
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `schema` | string | Conditional | Non-empty. Path to a JSON Schema file in the bundle (convention: `policy/schema.json`). Required if `ref` is not set |
+| `ref` | string | Conditional | Non-empty. OCI or local reference to another Pacto contract whose bundle contains the policy schema at the fixed path `policy/schema.json`. Required if `schema` is not set |
+
+Both `schema` and `ref` may be specified simultaneously — the contract defines its own policy and also conforms to an external one.
+
+#### Policy as a contract author
+
+To define a policy, create a JSON Schema that describes constraints on `pacto.yaml` contracts and place it at `policy/schema.json` in the bundle:
+
+```yaml
+# pacto.yaml — a policy contract
+pactoVersion: "1.0"
+service:
+  name: platform-policy
+  version: 1.0.0
+  owner: team/platform
+policy:
+  schema: policy/schema.json
+```
+
+Example policy schema (`policy/schema.json`) requiring all contracts to have a health check:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["runtime"],
+  "properties": {
+    "runtime": {
+      "type": "object",
+      "required": ["health"],
+      "properties": {
+        "health": {
+          "type": "object",
+          "required": ["interface", "path"]
+        }
+      }
+    }
+  }
+}
+```
+
+#### Policy as a contract consumer
+
+To adopt a policy, reference the policy contract via OCI:
+
+```yaml
+policy:
+  ref: oci://ghcr.io/acme/platform-policy-pacto:1.0.0
+```
+
+The referenced contract's bundle must have the policy schema at the fixed path `policy/schema.json`. The reference supports recursive resolution: if the referenced contract itself has a `policy.ref`, Pacto follows the chain (with cycle detection) using the same OCI resolution and caching infrastructure as dependencies.
+
+{: .warning }
+Local policy references (`file://` and bare paths) are only allowed during development. `pacto push` rejects contracts with local `policy.ref` — all refs must use `oci://` before publishing.
+
+#### Bundle structure with policy
+
+```
+/
+├── pacto.yaml
+├── interfaces/              ← optional
+├── configuration/           ← optional
+│   └── schema.json
+├── policy/                  ← optional
+│   └── schema.json          ← policy schema (for policy authors)
+├── docs/                    ← optional
+└── sbom/                    ← optional
+```
 
 ---
 
@@ -611,9 +722,13 @@ Validates semantic references and consistency:
 | `image.ref` is a valid OCI reference | `INVALID_IMAGE_REF` |
 | `chart.ref` (OCI) is a valid OCI reference | `INVALID_CHART_REF` |
 | `chart.version` is valid semver | `INVALID_CHART_VERSION` |
+| `configuration.ref` is not a valid OCI reference | `INVALID_CONFIG_REF` |
 | `configuration.values` without a `configuration.schema` | `VALUES_WITHOUT_SCHEMA` |
 | `configuration.schema` file is not valid JSON Schema | `INVALID_CONFIG_SCHEMA` |
 | `configuration.values` don't match the schema | `CONFIG_VALUES_VALIDATION_FAILED` |
+| `policy` has neither `schema` nor `ref` | `POLICY_EMPTY` |
+| `policy.schema` file does not exist in the bundle | `FILE_NOT_FOUND` |
+| `policy.ref` is not a valid OCI reference | `INVALID_POLICY_REF` |
 | `scaling.min` <= `scaling.max` | `SCALING_MIN_EXCEEDS_MAX` |
 | Job workloads cannot have scaling | `JOB_SCALING_NOT_ALLOWED` |
 | Stateless + persistent is invalid | `STATELESS_PERSISTENT_CONFLICT` |
@@ -851,6 +966,18 @@ Each change is classified as:
 | `configuration.schema` | Added | NON_BREAKING |
 | `configuration.schema` | Modified | POTENTIAL_BREAKING |
 | `configuration.schema` | Removed | **BREAKING** |
+| `configuration.ref` | Added | NON_BREAKING |
+| `configuration.ref` | Modified | POTENTIAL_BREAKING |
+| `configuration.ref` | Removed | **BREAKING** |
+
+### Policy
+
+| Field | Change | Classification |
+|-------|--------|----------------|
+| `policy` | Added | NON_BREAKING |
+| `policy` | Removed | POTENTIAL_BREAKING |
+| `policy.schema` | Modified | POTENTIAL_BREAKING |
+| `policy.ref` | Modified | POTENTIAL_BREAKING |
 
 ### Runtime
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -56,7 +56,14 @@ configuration:
   schema: config.schema.json
 ```
 
-When you define your own configuration schema, you are declaring **what your service requires** to run. This is the most common model for services that need to be portable across environments. If your platform team provides a shared schema instead, your service vendors it into the bundle and conforms to it. See [Configuration Schema Ownership Models]({{ site.baseurl }}{% link contract-reference.md %}#configuration-schema-ownership-models) for details.
+When you define your own configuration schema, you are declaring **what your service requires** to run. This is the most common model for services that need to be portable across environments. If your platform team provides a shared schema instead, you can either vendor it into your bundle or reference it via OCI:
+
+```yaml
+configuration:
+  ref: oci://ghcr.io/acme/platform-config-pacto:1.0.0
+```
+
+See [Configuration Schema Ownership Models]({{ site.baseurl }}{% link contract-reference.md %}#configuration-schema-ownership-models) for details.
 
 If your service exposes an HTTP API using FastAPI or Huma, use the `openapi-infer` plugin to extract an OpenAPI 3.1 spec from your source code:
 
@@ -168,7 +175,18 @@ If your service depends on a cloud-managed resource (e.g. a database or message 
 
 Use `pacto graph` to visualize your dependency tree.
 
-### 6. Reference your Helm chart (optional)
+### 6. Adopt a policy (optional)
+
+If your platform team publishes a policy contract, reference it in your contract:
+
+```yaml
+policy:
+  ref: oci://ghcr.io/acme/platform-policy-pacto:1.0.0
+```
+
+A policy is a JSON Schema that validates the contract itself — enforcing organizational standards like requiring health endpoints or mandating specific ports. See [policy]({{ site.baseurl }}{% link contract-reference.md %}#policy) in the Contract Reference for details.
+
+### 7. Reference your Helm chart (optional)
 
 If your service is deployed via a Helm chart, reference it in the contract:
 
@@ -193,7 +211,7 @@ service:
 {: .warning }
 Local chart references are rejected by `pacto push`. Switch to an OCI reference before publishing.
 
-### 7. Validate before pushing
+### 8. Validate before pushing
 
 ```bash
 pacto validate my-service
@@ -205,7 +223,7 @@ Validation catches errors in three layers:
 2. **Cross-field** — interface references match, state invariants hold, files exist
 3. **Semantic** — strategy consistency warnings
 
-### 8. Pack and push
+### 9. Pack and push
 
 ```bash
 pacto pack my-service

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -30,6 +30,7 @@ on:
       - 'pacto.yaml'
       - 'interfaces/**'
       - 'configuration/**'
+      - 'policy/**'
 
 jobs:
   validate:

--- a/docs/index.md
+++ b/docs/index.md
@@ -149,34 +149,42 @@ Instead of filing tickets, attending meetings, and writing wiki pages, a develop
 ## What's inside a Pacto bundle
 
 ```mermaid
-graph TD
+graph LR
     subgraph Bundle["Pacto Bundle"]
-        YAML["pacto.yaml"]
-        YAML --> Interfaces["Interfaces<br/>HTTP, gRPC, ports, visibility"]
-        YAML --> Dependencies["Dependencies<br/>oci://auth:2.0.0<br/>oci://db:1.0.0"]
-        YAML --> Runtime["Runtime<br/>state, health, lifecycle, scaling"]
-        YAML --> Config["Configuration<br/>JSON Schema"]
-        Docs["docs/<br/>README · runbooks · guides"]
-        SBOM["sbom/<br/>SPDX · CycloneDX"]
+        direction TB
+        YAML["pacto.yaml<br/><i>required</i>"]
+
+        subgraph Sections["Contract Sections <i>(all optional)</i>"]
+            direction TB
+            Interfaces["Interfaces<br/>HTTP · gRPC · ports · visibility"]
+            Dependencies["Dependencies<br/>oci://auth:2.0.0 · oci://db:1.0.0"]
+            Runtime["Runtime<br/>state · health · lifecycle · scaling"]
+            Config["Configuration<br/>schema.json"]
+            Policy["Policy<br/>schema.json"]
+        end
+
+        subgraph Extras["Metadata <i>(optional)</i>"]
+            direction TB
+            Docs["docs/<br/>README · runbooks · guides"]
+            SBOM["sbom/<br/>SPDX · CycloneDX"]
+        end
+
+        YAML --> Sections
     end
 
-    IF["interfaces/<br/>openapi.yaml · service.proto"]
-    CF["configuration/<br/>schema.json"]
-
-    Interfaces -.-> IF
-    Config -.-> CF
-    Bundle -- "pacto push" --> Registry["OCI Registry<br/>GHCR · ECR · ACR · Docker Hub"]
+    Bundle -- "pacto push" --> Registry["OCI Registry<br/>GHCR · ECR · ACR<br/>Docker Hub"]
 ```
 
 A bundle is a self-contained directory (or OCI artifact) containing:
 
-- **`pacto.yaml`** — the contract: interfaces, dependencies, runtime semantics, scaling
-- **`interfaces/`** — OpenAPI specs, protobuf definitions, event schemas
-- **`configuration/`** — JSON Schema for environment variables and settings
+- **`pacto.yaml`** — the contract: interfaces, dependencies, runtime semantics, scaling *(required)*
+- **`interfaces/`** *(optional)* — OpenAPI specs, protobuf definitions, event schemas
+- **`configuration/`** *(optional)* — JSON Schema for environment variables and settings
+- **`policy/`** *(optional)* — JSON Schema that validates the contract itself (organizational standards enforcement)
 - **`docs/`** *(optional)* — service documentation (README, runbooks, architecture notes)
 - **`sbom/`** *(optional)* — Software Bill of Materials in [SPDX](https://spdx.dev/) or [CycloneDX](https://cyclonedx.org/) format. `pacto diff` reports package-level changes when present
 
-All files referenced by `pacto.yaml` must exist within the bundle. Validation enforces this.
+Only `pacto.yaml` is required. All other directories are optional — include them when your contract references files in them. Validation enforces that every referenced file exists within the bundle.
 
 ---
 

--- a/docs/platform-engineers.md
+++ b/docs/platform-engineers.md
@@ -39,7 +39,8 @@ Every question you'd normally have to ask the dev team — or discover in produc
 | `runtime.lifecycle.upgradeStrategy: ordered` | Use ordered pod management |
 | `runtime.lifecycle.gracefulShutdownSeconds` | Set termination grace period |
 | `scaling.min` / `scaling.max` | Configure auto-scaling bounds |
-| `configuration.schema` | Validate required configuration, generate config templates. Platform teams can publish a shared schema that services vendor into their bundles — the schema then expresses what the platform *provides*. See [Configuration Schema Ownership Models]({{ site.baseurl }}{% link contract-reference.md %}#configuration-schema-ownership-models) |
+| `configuration.schema` / `configuration.ref` | Validate required configuration, generate config templates. Platform teams can publish a shared schema that services vendor into their bundles or reference via OCI — the schema then expresses what the platform *provides*. See [Configuration Schema Ownership Models]({{ site.baseurl }}{% link contract-reference.md %}#configuration-schema-ownership-models) |
+| `policy.ref` | Enforce organizational standards — require health endpoints, mandate ports, enforce visibility rules. See [policy]({{ site.baseurl }}{% link contract-reference.md %}#policy) |
 | `dependencies[].ref` | Validate dependency graph, check compatibility |
 | `docs/` *(optional)* | Access service documentation, runbooks, integration guides |
 | `sbom/` *(optional)* | Audit third-party packages, track license compliance |
@@ -154,6 +155,98 @@ The state model tells you exactly what storage and scheduling strategy a service
 
 ---
 
+## Configuration and policy
+
+Two features give platform teams direct control over the boundary between developers and infrastructure: **configuration schemas** and **policies**. Both can be centralized via OCI references, making them a cornerstone of the platform-as-a-product model.
+
+### Configuration: the interface between dev and platform
+
+The `configuration` section defines **the interface boundary between a service and its environment**. When a platform team publishes a shared configuration schema, it declares *what the platform provides* — database connections, observability endpoints, feature flags, secret paths. When a service author defines one, it declares *what the service requires*.
+
+There are two approaches:
+
+**Vendored:** The platform publishes a schema externally, and services copy it into their bundle at build time:
+
+```yaml
+configuration:
+  schema: configuration/platform-schema.json
+```
+
+**Referenced (OCI):** Services reference the platform's configuration contract directly. No vendoring required — Pacto resolves the schema from the referenced bundle at the fixed path `configuration/schema.json`:
+
+```yaml
+configuration:
+  ref: oci://ghcr.io/acme/platform-config-pacto:1.0.0
+```
+
+The OCI approach enables centralized configuration management: the platform team publishes one configuration contract, all services reference it, and updates propagate through version bumps — not copy-pasting files.
+
+See [Configuration Schema Ownership Models]({{ site.baseurl }}{% link contract-reference.md %}#configuration-schema-ownership-models) for the full breakdown of service-defined vs. platform-defined schemas.
+
+### Policy: enforcing contract standards
+
+The `policy` section lets platform teams enforce **minimum requirements on contracts themselves**. A policy is a JSON Schema that validates `pacto.yaml` — requiring health endpoints, mandating specific ports, enforcing visibility rules, or any other organizational standard.
+
+**How it works:**
+
+1. The platform team creates a policy contract containing a JSON Schema at `policy/schema.json`:
+
+```yaml
+# platform-policy/pacto.yaml
+pactoVersion: "1.0"
+service:
+  name: platform-policy
+  version: 1.0.0
+  owner: team/platform
+policy:
+  schema: policy/schema.json
+```
+
+2. The platform publishes it: `pacto push oci://ghcr.io/acme/platform-policy-pacto -p platform-policy`
+
+3. Services adopt the policy by referencing it:
+
+```yaml
+policy:
+  ref: oci://ghcr.io/acme/platform-policy-pacto:1.0.0
+```
+
+Example policy schema (`policy/schema.json`) requiring all contracts to have a health check:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["runtime"],
+  "properties": {
+    "runtime": {
+      "type": "object",
+      "required": ["health"],
+      "properties": {
+        "health": {
+          "type": "object",
+          "required": ["interface", "path"]
+        }
+      }
+    }
+  }
+}
+```
+
+Policy references support recursive resolution — if the referenced contract itself has a `policy.ref`, Pacto follows the chain with cycle detection.
+
+See [policy]({{ site.baseurl }}{% link contract-reference.md %}#policy) in the Contract Reference for the full specification.
+
+{: .important }
+> Configuration and policy are complementary:
+>
+> - **Configuration** defines what a service needs (or what the platform provides) — the *data interface*
+> - **Policy** enforces how contracts must be structured — the *contract interface*
+>
+> Together, they give platform teams a centralized, versioned, machine-validated governance model — without tickets, wikis, or manual review.
+
+---
+
 ## Breaking change detection
 
 `pacto diff` doesn't just compare contract fields — it performs deep OpenAPI diffing (paths, methods, parameters, request bodies, responses) and resolves both dependency trees to show the full blast radius.
@@ -256,4 +349,6 @@ See [pacto-actions](https://github.com/trianalab/pacto-actions) for full documen
 - **Use markdown output for PR comments.** `pacto diff --output-format markdown` renders changes as tables with old/new values — pipe it into `gh pr comment` for rich CI feedback.
 - **Use `--verbose` for debugging.** Pass `-v` to any command to see debug-level logs (OCI operations, resolution steps, cache hits/misses) on stderr.
 - **Check SBOM changes.** When bundles include SBOMs, `pacto diff` reports package-level changes — useful for tracking dependency drift, license compliance, and supply chain audits across contract versions.
+- **Enforce policies.** Publish a policy contract with a JSON Schema that validates contracts against your organizational standards. Services reference it via `policy.ref` — see [policy]({{ site.baseurl }}{% link contract-reference.md %}#policy) in the Contract Reference.
+- **Centralize configuration schemas.** Publish a configuration contract and have services reference it via `configuration.ref` instead of vendoring schemas. See [Configuration Schema Ownership Models]({{ site.baseurl }}{% link contract-reference.md %}#configuration-schema-ownership-models).
 - **Leverage AI assistants.** Pacto contracts are machine-consumable. In addition to CI pipelines and platform controllers, AI assistants can interact with contracts directly through the [MCP interface]({{ site.baseurl }}{% link mcp-integration.md %}) — useful for ad-hoc inspection, dependency analysis, and contract generation.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -43,7 +43,7 @@ Created my-service/
   my-service/configuration/
 ```
 
-This creates a complete bundle structure with a valid contract, a placeholder OpenAPI spec, and a configuration JSON Schema.
+This scaffolds a bundle with a valid contract, a placeholder OpenAPI spec, and a configuration JSON Schema. Only `pacto.yaml` is required — the `interfaces/` and `configuration/` directories are optional conveniences that you can remove if your service doesn't need them.
 
 ## 3. Validate
 
@@ -67,7 +67,7 @@ service:
   owner: team/backend
 ```
 
-Add sections as needed — interfaces, runtime semantics, dependencies, configuration, scaling. See the [Contract Reference]({{ site.baseurl }}{% link contract-reference.md %}) for every available field.
+Add sections as needed — interfaces, runtime semantics, dependencies, configuration, policy, scaling. See the [Contract Reference]({{ site.baseurl }}{% link contract-reference.md %}) for every available field.
 
 ## 5. Pack and push
 

--- a/internal/app/push.go
+++ b/internal/app/push.go
@@ -71,6 +71,10 @@ func (s *Service) Push(ctx context.Context, opts PushOptions) (*PushResult, erro
 		return nil, err
 	}
 
+	if err := rejectLocalRefs(c); err != nil {
+		return nil, err
+	}
+
 	ref := parsed.Location
 	if !hasTagOrDigest(ref) {
 		ref = ref + ":" + c.Service.Version
@@ -127,6 +131,21 @@ func rejectLocalDeps(c *contract.Contract) error {
 	for _, dep := range c.Dependencies {
 		if graph.ParseDependencyRef(dep.Ref).IsLocal() {
 			return fmt.Errorf("local dependency detected: %s\nLocal dependencies are not allowed when publishing. All dependencies must use OCI references (oci://...)", dep.Ref)
+		}
+	}
+	return nil
+}
+
+// rejectLocalRefs returns an error if configuration.ref or policy.ref uses a local reference.
+func rejectLocalRefs(c *contract.Contract) error {
+	if c.Configuration != nil && c.Configuration.Ref != "" {
+		if graph.ParseDependencyRef(c.Configuration.Ref).IsLocal() {
+			return fmt.Errorf("local configuration ref detected: %s\nLocal references are not allowed when publishing. Use an OCI reference (oci://...)", c.Configuration.Ref)
+		}
+	}
+	if c.Policy != nil && c.Policy.Ref != "" {
+		if graph.ParseDependencyRef(c.Policy.Ref).IsLocal() {
+			return fmt.Errorf("local policy ref detected: %s\nLocal references are not allowed when publishing. Use an OCI reference (oci://...)", c.Policy.Ref)
 		}
 	}
 	return nil

--- a/internal/app/push_test.go
+++ b/internal/app/push_test.go
@@ -377,6 +377,97 @@ func TestPush_ResolveNonNotFoundError(t *testing.T) {
 	}
 }
 
+func TestPush_RejectsLocalConfigRef(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte(`pactoVersion: "1.0"
+service:
+  name: test-svc
+  version: "1.0.0"
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+configuration:
+  ref: "../local-config"
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+`)
+	if err := os.WriteFile(filepath.Join(dir, "pacto.yaml"), content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	store := &mockBundleStore{}
+	svc := NewService(store, nil)
+	_, err := svc.Push(context.Background(), PushOptions{Ref: "oci://ghcr.io/acme/svc:1.0.0", Path: dir})
+	if err == nil {
+		t.Fatal("expected error for local config ref")
+	}
+	if !strings.Contains(err.Error(), "local configuration ref detected") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRejectLocalRefs_NilPolicyAndConfig(t *testing.T) {
+	c := &contract.Contract{}
+	if err := rejectLocalRefs(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRejectLocalRefs_LocalConfigRef(t *testing.T) {
+	c := &contract.Contract{
+		Configuration: &contract.Configuration{Ref: "file://../config"},
+	}
+	err := rejectLocalRefs(c)
+	if err == nil {
+		t.Fatal("expected error for local config ref")
+	}
+	if !strings.Contains(err.Error(), "local configuration ref detected") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRejectLocalRefs_LocalPolicyRef(t *testing.T) {
+	c := &contract.Contract{
+		Policy: &contract.Policy{Ref: "../policy"},
+	}
+	err := rejectLocalRefs(c)
+	if err == nil {
+		t.Fatal("expected error for local policy ref")
+	}
+	if !strings.Contains(err.Error(), "local policy ref detected") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRejectLocalRefs_OCIRefsAllowed(t *testing.T) {
+	c := &contract.Contract{
+		Configuration: &contract.Configuration{Ref: "oci://ghcr.io/acme/config:1.0.0"},
+		Policy:        &contract.Policy{Ref: "oci://ghcr.io/acme/policy:1.0.0"},
+	}
+	if err := rejectLocalRefs(c); err != nil {
+		t.Fatalf("unexpected error for OCI refs: %v", err)
+	}
+}
+
+func TestRejectLocalRefs_EmptyRefs(t *testing.T) {
+	c := &contract.Contract{
+		Configuration: &contract.Configuration{Schema: "configuration/schema.json"},
+		Policy:        &contract.Policy{Schema: "policy/schema.json"},
+	}
+	if err := rejectLocalRefs(c); err != nil {
+		t.Fatalf("unexpected error for empty refs: %v", err)
+	}
+}
+
 func TestIsNotFound(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/diff/classification.go
+++ b/internal/diff/classification.go
@@ -38,8 +38,17 @@ var rules = map[classificationKey]Classification{
 	{"configuration.schema", Modified}: PotentialBreaking,
 	{"configuration.schema", Added}:    NonBreaking,
 	{"configuration.schema", Removed}:  Breaking,
+	{"configuration.ref", Modified}:    PotentialBreaking,
+	{"configuration.ref", Added}:       NonBreaking,
+	{"configuration.ref", Removed}:     Breaking,
 	{"configuration", Added}:           NonBreaking,
 	{"configuration", Removed}:         Breaking,
+
+	// Policy
+	{"policy", Added}:           NonBreaking,
+	{"policy", Removed}:         PotentialBreaking,
+	{"policy.schema", Modified}: PotentialBreaking,
+	{"policy.ref", Modified}:    PotentialBreaking,
 
 	// Runtime — workload
 	{"runtime.workload", Modified}: Breaking,

--- a/internal/diff/engine.go
+++ b/internal/diff/engine.go
@@ -109,6 +109,7 @@ func Compare(old, new *contract.Contract, oldFS, newFS fs.FS) *Result {
 	changes = append(changes, diffDependencies(old, new)...)
 	changes = append(changes, diffInterfaces(old, new, oldFS, newFS)...)
 	changes = append(changes, diffConfiguration(old, new, oldFS, newFS)...)
+	changes = append(changes, diffPolicy(old, new)...)
 
 	overall := NonBreaking
 	for i := range changes {

--- a/internal/diff/interfaces.go
+++ b/internal/diff/interfaces.go
@@ -59,16 +59,26 @@ func diffConfiguration(old, new *contract.Contract, oldFS, newFS fs.FS) []Change
 		return nil
 	}
 	if old.Configuration == nil {
-		changes = append(changes, newChange("configuration", Added, nil, new.Configuration.Schema))
+		changes = append(changes, newChange("configuration", Added, nil, configSummary(new.Configuration)))
 		return changes
 	}
 	if new.Configuration == nil {
-		changes = append(changes, newChange("configuration", Removed, old.Configuration.Schema, nil))
+		changes = append(changes, newChange("configuration", Removed, configSummary(old.Configuration), nil))
 		return changes
 	}
 
 	if old.Configuration.Schema != new.Configuration.Schema {
 		changes = append(changes, newChange("configuration.schema", Modified, old.Configuration.Schema, new.Configuration.Schema))
+	}
+
+	if old.Configuration.Ref != new.Configuration.Ref {
+		ct := Modified
+		if old.Configuration.Ref == "" {
+			ct = Added
+		} else if new.Configuration.Ref == "" {
+			ct = Removed
+		}
+		changes = append(changes, newChange("configuration.ref", ct, old.Configuration.Ref, new.Configuration.Ref))
 	}
 
 	// Diff the JSON Schema files.
@@ -79,6 +89,46 @@ func diffConfiguration(old, new *contract.Contract, oldFS, newFS fs.FS) []Change
 	}
 
 	return changes
+}
+
+func configSummary(cfg *contract.Configuration) string {
+	if cfg.Ref != "" {
+		return cfg.Ref
+	}
+	return cfg.Schema
+}
+
+// diffPolicy compares policy fields.
+func diffPolicy(old, new *contract.Contract) []Change {
+	var changes []Change
+
+	if old.Policy == nil && new.Policy == nil {
+		return nil
+	}
+	if old.Policy == nil {
+		changes = append(changes, newChange("policy", Added, nil, policySummary(new.Policy)))
+		return changes
+	}
+	if new.Policy == nil {
+		changes = append(changes, newChange("policy", Removed, policySummary(old.Policy), nil))
+		return changes
+	}
+
+	if old.Policy.Schema != new.Policy.Schema {
+		changes = append(changes, newChange("policy.schema", Modified, old.Policy.Schema, new.Policy.Schema))
+	}
+	if old.Policy.Ref != new.Policy.Ref {
+		changes = append(changes, newChange("policy.ref", Modified, old.Policy.Ref, new.Policy.Ref))
+	}
+
+	return changes
+}
+
+func policySummary(p *contract.Policy) string {
+	if p.Ref != "" {
+		return p.Ref
+	}
+	return p.Schema
 }
 
 func indexInterfaces(ifaces []contract.Interface) map[string]contract.Interface {

--- a/internal/diff/interfaces_test.go
+++ b/internal/diff/interfaces_test.go
@@ -192,6 +192,209 @@ func TestDiffConfiguration_EmptySchemaNoFileDiff(t *testing.T) {
 	}
 }
 
+func TestDiffConfiguration_RefChanged(t *testing.T) {
+	old := minimalContract()
+	old.Configuration = &contract.Configuration{Ref: "oci://ghcr.io/acme/config:1.0.0"}
+	new := minimalContract()
+	new.Configuration = &contract.Configuration{Ref: "oci://ghcr.io/acme/config:2.0.0"}
+	changes := diffConfiguration(old, new, nil, nil)
+	found := false
+	for _, c := range changes {
+		if c.Path == "configuration.ref" && c.Type == Modified {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected configuration.ref Modified change")
+	}
+}
+
+func TestDiffConfiguration_RefAdded(t *testing.T) {
+	old := minimalContract()
+	old.Configuration = &contract.Configuration{Schema: "configuration/schema.json"}
+	new := minimalContract()
+	new.Configuration = &contract.Configuration{Schema: "configuration/schema.json", Ref: "oci://ghcr.io/acme/config:1.0.0"}
+	changes := diffConfiguration(old, new, nil, nil)
+	found := false
+	for _, c := range changes {
+		if c.Path == "configuration.ref" && c.Type == Added {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected configuration.ref Added change")
+	}
+}
+
+func TestDiffConfiguration_RefRemoved(t *testing.T) {
+	old := minimalContract()
+	old.Configuration = &contract.Configuration{Ref: "oci://ghcr.io/acme/config:1.0.0"}
+	new := minimalContract()
+	new.Configuration = &contract.Configuration{Schema: "configuration/schema.json"}
+	changes := diffConfiguration(old, new, nil, nil)
+	found := false
+	for _, c := range changes {
+		if c.Path == "configuration.ref" && c.Type == Removed {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected configuration.ref Removed change")
+	}
+}
+
+func TestDiffConfiguration_OldNilWithRef(t *testing.T) {
+	old := minimalContract()
+	old.Configuration = nil
+	new := minimalContract()
+	new.Configuration = &contract.Configuration{Ref: "oci://ghcr.io/acme/config:1.0.0"}
+	changes := diffConfiguration(old, new, nil, nil)
+	found := false
+	for _, c := range changes {
+		if c.Path == "configuration" && c.Type == Added {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected configuration Added change")
+	}
+}
+
+func TestDiffConfiguration_NewNilWithRef(t *testing.T) {
+	old := minimalContract()
+	old.Configuration = &contract.Configuration{Ref: "oci://ghcr.io/acme/config:1.0.0"}
+	new := minimalContract()
+	new.Configuration = nil
+	changes := diffConfiguration(old, new, nil, nil)
+	found := false
+	for _, c := range changes {
+		if c.Path == "configuration" && c.Type == Removed {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected configuration Removed change")
+	}
+}
+
+func TestDiffPolicy_BothNil(t *testing.T) {
+	old := minimalContract()
+	new := minimalContract()
+	changes := diffPolicy(old, new)
+	if len(changes) != 0 {
+		t.Errorf("expected 0 changes, got %d", len(changes))
+	}
+}
+
+func TestDiffPolicy_Added(t *testing.T) {
+	old := minimalContract()
+	new := minimalContract()
+	new.Policy = &contract.Policy{Schema: "policy/schema.json"}
+	changes := diffPolicy(old, new)
+	found := false
+	for _, c := range changes {
+		if c.Path == "policy" && c.Type == Added {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected policy Added change")
+	}
+}
+
+func TestDiffPolicy_AddedWithRef(t *testing.T) {
+	old := minimalContract()
+	new := minimalContract()
+	new.Policy = &contract.Policy{Ref: "oci://ghcr.io/acme/policy:1.0.0"}
+	changes := diffPolicy(old, new)
+	found := false
+	for _, c := range changes {
+		if c.Path == "policy" && c.Type == Added {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected policy Added change")
+	}
+}
+
+func TestDiffPolicy_Removed(t *testing.T) {
+	old := minimalContract()
+	old.Policy = &contract.Policy{Schema: "policy/schema.json"}
+	new := minimalContract()
+	changes := diffPolicy(old, new)
+	found := false
+	for _, c := range changes {
+		if c.Path == "policy" && c.Type == Removed {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected policy Removed change")
+	}
+}
+
+func TestDiffPolicy_RemovedWithRef(t *testing.T) {
+	old := minimalContract()
+	old.Policy = &contract.Policy{Ref: "oci://ghcr.io/acme/policy:1.0.0"}
+	new := minimalContract()
+	changes := diffPolicy(old, new)
+	found := false
+	for _, c := range changes {
+		if c.Path == "policy" && c.Type == Removed {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected policy Removed change")
+	}
+}
+
+func TestDiffPolicy_SchemaChanged(t *testing.T) {
+	old := minimalContract()
+	old.Policy = &contract.Policy{Schema: "policy/old.json"}
+	new := minimalContract()
+	new.Policy = &contract.Policy{Schema: "policy/new.json"}
+	changes := diffPolicy(old, new)
+	found := false
+	for _, c := range changes {
+		if c.Path == "policy.schema" && c.Type == Modified {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected policy.schema Modified change")
+	}
+}
+
+func TestDiffPolicy_RefChanged(t *testing.T) {
+	old := minimalContract()
+	old.Policy = &contract.Policy{Ref: "oci://ghcr.io/acme/policy:1.0.0"}
+	new := minimalContract()
+	new.Policy = &contract.Policy{Ref: "oci://ghcr.io/acme/policy:2.0.0"}
+	changes := diffPolicy(old, new)
+	found := false
+	for _, c := range changes {
+		if c.Path == "policy.ref" && c.Type == Modified {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected policy.ref Modified change")
+	}
+}
+
+func TestDiffPolicy_NoChanges(t *testing.T) {
+	old := minimalContract()
+	old.Policy = &contract.Policy{Schema: "policy/schema.json", Ref: "oci://ghcr.io/acme/policy:1.0.0"}
+	new := minimalContract()
+	new.Policy = &contract.Policy{Schema: "policy/schema.json", Ref: "oci://ghcr.io/acme/policy:1.0.0"}
+	changes := diffPolicy(old, new)
+	if len(changes) != 0 {
+		t.Errorf("expected 0 changes, got %d", len(changes))
+	}
+}
+
 func TestDiffConfiguration_SchemaFilesDiffed(t *testing.T) {
 	oldFS := fstest.MapFS{
 		"configuration/schema.json": &fstest.MapFile{Data: []byte(`{"type":"object","properties":{"a":{"type":"string"}}}`)},

--- a/internal/validation/crossfield.go
+++ b/internal/validation/crossfield.go
@@ -25,6 +25,8 @@ func ValidateCrossField(c *contract.Contract, bundleFS fs.FS) ValidationResult {
 	validateMetricsInterface(c, &result)
 	validateInterfaceFiles(c, bundleFS, &result)
 	validateConfigFiles(c, bundleFS, &result)
+	validateConfigRef(c, &result)
+	validatePolicyFields(c, bundleFS, &result)
 	validateDependencyRefs(c, &result)
 	validateImageRef(c, &result)
 	validateChartRef(c, &result)
@@ -236,6 +238,45 @@ func validateConfigFiles(c *contract.Contract, bundleFS fs.FS, result *Validatio
 	}
 }
 
+func validateConfigRef(c *contract.Contract, result *ValidationResult) {
+	if c.Configuration == nil || c.Configuration.Ref == "" {
+		return
+	}
+	parsed := graph.ParseDependencyRef(c.Configuration.Ref)
+	if parsed.IsOCI() {
+		validateOCIRef(parsed.Location, "configuration.ref", "INVALID_CONFIG_REF", result)
+	}
+}
+
+func validatePolicyFields(c *contract.Contract, bundleFS fs.FS, result *ValidationResult) {
+	if c.Policy == nil {
+		return
+	}
+	if c.Policy.Schema == "" && c.Policy.Ref == "" {
+		result.AddError(
+			"policy",
+			"POLICY_EMPTY",
+			"policy must specify at least one of schema or ref",
+		)
+		return
+	}
+	if c.Policy.Schema != "" && bundleFS != nil {
+		if _, err := fs.Stat(bundleFS, c.Policy.Schema); err != nil {
+			result.AddError(
+				"policy.schema",
+				"FILE_NOT_FOUND",
+				fmt.Sprintf("policy schema file %q not found in bundle", c.Policy.Schema),
+			)
+		}
+	}
+	if c.Policy.Ref != "" {
+		parsed := graph.ParseDependencyRef(c.Policy.Ref)
+		if parsed.IsOCI() {
+			validateOCIRef(parsed.Location, "policy.ref", "INVALID_POLICY_REF", result)
+		}
+	}
+}
+
 func validateDependencyRefs(c *contract.Contract, result *ValidationResult) {
 	for i, dep := range c.Dependencies {
 		parsed := graph.ParseDependencyRef(dep.Ref)
@@ -318,12 +359,16 @@ func validateConfigValues(c *contract.Contract, bundleFS fs.FS, result *Validati
 	if c.Configuration == nil || len(c.Configuration.Values) == 0 {
 		return
 	}
-	if c.Configuration.Schema == "" {
+	if c.Configuration.Schema == "" && c.Configuration.Ref == "" {
 		result.AddError(
 			"configuration.values",
 			"VALUES_WITHOUT_SCHEMA",
 			"configuration values require a configuration schema to validate against",
 		)
+		return
+	}
+	if c.Configuration.Schema == "" {
+		// Schema is external (ref) — values validation deferred to runtime resolution.
 		return
 	}
 	if bundleFS == nil {

--- a/internal/validation/crossfield_test.go
+++ b/internal/validation/crossfield_test.go
@@ -639,3 +639,166 @@ func TestValidateConfigValues_InvalidValue(t *testing.T) {
 		t.Error("expected error for config value type mismatch")
 	}
 }
+
+func TestValidateConfigValues_ExternalRef(t *testing.T) {
+	c := validContract()
+	c.Configuration = &contract.Configuration{
+		Ref:    "oci://ghcr.io/acme/config-pacto:1.0.0",
+		Values: map[string]interface{}{"key": "val"},
+	}
+	var result ValidationResult
+	validateConfigValues(c, nil, &result)
+	if !result.IsValid() {
+		t.Error("expected no error when using external ref with values")
+	}
+}
+
+func TestValidateConfigRef_NilConfig(t *testing.T) {
+	c := validContract()
+	c.Configuration = nil
+	var result ValidationResult
+	validateConfigRef(c, &result)
+	if !result.IsValid() {
+		t.Error("expected no error for nil config")
+	}
+}
+
+func TestValidateConfigRef_EmptyRef(t *testing.T) {
+	c := validContract()
+	c.Configuration = &contract.Configuration{Schema: "schema.json"}
+	var result ValidationResult
+	validateConfigRef(c, &result)
+	if !result.IsValid() {
+		t.Error("expected no error for empty ref")
+	}
+}
+
+func TestValidateConfigRef_ValidOCI(t *testing.T) {
+	c := validContract()
+	c.Configuration = &contract.Configuration{Ref: "oci://ghcr.io/acme/config-pacto:1.0.0"}
+	var result ValidationResult
+	validateConfigRef(c, &result)
+	if !result.IsValid() {
+		t.Errorf("expected no error for valid OCI ref, got %v", result.Errors)
+	}
+}
+
+func TestValidateConfigRef_InvalidOCI(t *testing.T) {
+	c := validContract()
+	c.Configuration = &contract.Configuration{Ref: "oci://invalid"}
+	var result ValidationResult
+	validateConfigRef(c, &result)
+	if result.IsValid() {
+		t.Error("expected error for invalid OCI config ref")
+	}
+}
+
+func TestValidateConfigRef_LocalRef(t *testing.T) {
+	c := validContract()
+	c.Configuration = &contract.Configuration{Ref: "file://../config"}
+	var result ValidationResult
+	validateConfigRef(c, &result)
+	if !result.IsValid() {
+		t.Error("expected no error for local config ref")
+	}
+}
+
+func TestValidatePolicyFields_NilPolicy(t *testing.T) {
+	c := validContract()
+	c.Policy = nil
+	var result ValidationResult
+	validatePolicyFields(c, nil, &result)
+	if !result.IsValid() {
+		t.Error("expected no error for nil policy")
+	}
+}
+
+func TestValidatePolicyFields_EmptyPolicy(t *testing.T) {
+	c := validContract()
+	c.Policy = &contract.Policy{}
+	var result ValidationResult
+	validatePolicyFields(c, nil, &result)
+	if result.IsValid() {
+		t.Error("expected error for empty policy")
+	}
+}
+
+func TestValidatePolicyFields_SchemaFileNotFound(t *testing.T) {
+	c := validContract()
+	c.Policy = &contract.Policy{Schema: "policy/schema.json"}
+	bundleFS := fstest.MapFS{}
+	var result ValidationResult
+	validatePolicyFields(c, bundleFS, &result)
+	if result.IsValid() {
+		t.Error("expected error when policy schema file not found")
+	}
+}
+
+func TestValidatePolicyFields_SchemaFileExists(t *testing.T) {
+	c := validContract()
+	c.Policy = &contract.Policy{Schema: "policy/schema.json"}
+	bundleFS := fstest.MapFS{
+		"policy/schema.json": &fstest.MapFile{Data: []byte("{}")},
+	}
+	var result ValidationResult
+	validatePolicyFields(c, bundleFS, &result)
+	if !result.IsValid() {
+		t.Errorf("expected no error when policy schema file exists, got %v", result.Errors)
+	}
+}
+
+func TestValidatePolicyFields_SchemaNilBundleFS(t *testing.T) {
+	c := validContract()
+	c.Policy = &contract.Policy{Schema: "policy/schema.json"}
+	var result ValidationResult
+	validatePolicyFields(c, nil, &result)
+	if !result.IsValid() {
+		t.Error("expected no error when bundleFS is nil")
+	}
+}
+
+func TestValidatePolicyFields_ValidOCIRef(t *testing.T) {
+	c := validContract()
+	c.Policy = &contract.Policy{Ref: "oci://ghcr.io/acme/policy-pacto:1.0.0"}
+	var result ValidationResult
+	validatePolicyFields(c, nil, &result)
+	if !result.IsValid() {
+		t.Errorf("expected no error for valid OCI policy ref, got %v", result.Errors)
+	}
+}
+
+func TestValidatePolicyFields_InvalidOCIRef(t *testing.T) {
+	c := validContract()
+	c.Policy = &contract.Policy{Ref: "oci://invalid"}
+	var result ValidationResult
+	validatePolicyFields(c, nil, &result)
+	if result.IsValid() {
+		t.Error("expected error for invalid OCI policy ref")
+	}
+}
+
+func TestValidatePolicyFields_LocalRef(t *testing.T) {
+	c := validContract()
+	c.Policy = &contract.Policy{Ref: "file://../policy"}
+	var result ValidationResult
+	validatePolicyFields(c, nil, &result)
+	if !result.IsValid() {
+		t.Error("expected no error for local policy ref")
+	}
+}
+
+func TestValidatePolicyFields_BothSchemaAndRef(t *testing.T) {
+	c := validContract()
+	c.Policy = &contract.Policy{
+		Schema: "policy/schema.json",
+		Ref:    "oci://ghcr.io/acme/policy-pacto:1.0.0",
+	}
+	bundleFS := fstest.MapFS{
+		"policy/schema.json": &fstest.MapFile{Data: []byte("{}")},
+	}
+	var result ValidationResult
+	validatePolicyFields(c, bundleFS, &result)
+	if !result.IsValid() {
+		t.Errorf("expected no error for policy with both schema and ref, got %v", result.Errors)
+	}
+}

--- a/internal/validation/schema/pacto-v1.0.schema.json
+++ b/internal/validation/schema/pacto-v1.0.schema.json
@@ -137,19 +137,49 @@
     "configuration": {
       "type": "object",
       "description": "Declares the service's configuration model via a JSON Schema file that describes expected environment variables or config entries.",
-      "required": ["schema"],
       "additionalProperties": false,
       "properties": {
         "schema": {
           "type": "string",
           "minLength": 1,
-          "description": "Path to a JSON Schema file describing the service's configuration properties."
+          "description": "Path to a JSON Schema file describing the service's configuration properties (within the bundle)."
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1,
+          "description": "OCI or local reference to another Pacto contract whose bundle contains the configuration schema at the fixed path configuration/schema.json."
         },
         "values": {
           "type": "object",
           "description": "Configuration values to be validated against the configuration schema."
         }
-      }
+      },
+      "anyOf": [
+        { "required": ["schema"] },
+        { "required": ["ref"] }
+      ]
+    },
+
+    "policy": {
+      "type": "object",
+      "description": "Defines or references policy constraints for the contract. A policy is a JSON Schema that validates the contract itself, enabling platform teams to enforce organizational standards.",
+      "additionalProperties": false,
+      "properties": {
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path to a JSON Schema file within the bundle that defines policy constraints (fixed convention: policy/schema.json)."
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1,
+          "description": "OCI or local reference to another Pacto contract whose bundle contains the policy schema at the fixed path policy/schema.json."
+        }
+      },
+      "anyOf": [
+        { "required": ["schema"] },
+        { "required": ["ref"] }
+      ]
     },
 
     "dependencies": {

--- a/pkg/contract/contract.go
+++ b/pkg/contract/contract.go
@@ -6,6 +6,7 @@ type Contract struct {
 	Service       ServiceIdentity        `yaml:"service" json:"service"`
 	Interfaces    []Interface            `yaml:"interfaces" json:"interfaces"`
 	Configuration *Configuration         `yaml:"configuration,omitempty" json:"configuration,omitempty"`
+	Policy        *Policy                `yaml:"policy,omitempty" json:"policy,omitempty"`
 	Dependencies  []Dependency           `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
 	Runtime       *Runtime               `yaml:"runtime,omitempty" json:"runtime,omitempty"`
 	Scaling       *Scaling               `yaml:"scaling,omitempty" json:"scaling,omitempty"`
@@ -58,8 +59,16 @@ const (
 // Configuration describes the service's configuration model.
 // Required configuration keys are derived exclusively from JSON Schema.
 type Configuration struct {
-	Schema string                 `yaml:"schema" json:"schema"`
+	Schema string                 `yaml:"schema,omitempty" json:"schema,omitempty"`
+	Ref    string                 `yaml:"ref,omitempty" json:"ref,omitempty"`
 	Values map[string]interface{} `yaml:"values,omitempty" json:"values,omitempty"`
+}
+
+// Policy defines or references policy constraints for the contract.
+// A policy is a JSON Schema that validates the contract itself.
+type Policy struct {
+	Schema string `yaml:"schema,omitempty" json:"schema,omitempty"`
+	Ref    string `yaml:"ref,omitempty" json:"ref,omitempty"`
 }
 
 // Dependency represents a dependency on another service.

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1530,3 +1530,332 @@ scaling:
 		}
 	})
 }
+
+func TestPolicyAndConfigRef(t *testing.T) {
+	t.Run("validate contract with local policy schema", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "policy-svc")
+		contractYAML := `pactoVersion: "1.0"
+service:
+  name: policy-svc
+  version: 1.0.0
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+    visibility: internal
+    contract: interfaces/openapi.yaml
+policy:
+  schema: policy/schema.json
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+`
+		bundlePath := writeBundleDir(t, dir, contractYAML, map[string]string{
+			"openapi.yaml": fmt.Sprintf(openapiTemplate, "policy-svc", "1.0.0"),
+		})
+		// Write policy schema
+		policyDir := filepath.Join(bundlePath, "policy")
+		if err := os.MkdirAll(policyDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		policySchema := `{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}`
+		if err := os.WriteFile(filepath.Join(policyDir, "schema.json"), []byte(policySchema), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		output, err := runCommand(t, nil, "validate", bundlePath)
+		if err != nil {
+			t.Fatalf("validate failed: %v\noutput: %s", err, output)
+		}
+		assertContains(t, output, "is valid")
+	})
+
+	t.Run("validate contract with policy ref", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "policy-ref-svc")
+		contractYAML := `pactoVersion: "1.0"
+service:
+  name: policy-ref-svc
+  version: 1.0.0
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+    visibility: internal
+    contract: interfaces/openapi.yaml
+policy:
+  ref: oci://ghcr.io/acme/platform-policy:1.0.0
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+`
+		bundlePath := writeBundleDir(t, dir, contractYAML, map[string]string{
+			"openapi.yaml": fmt.Sprintf(openapiTemplate, "policy-ref-svc", "1.0.0"),
+		})
+
+		output, err := runCommand(t, nil, "validate", bundlePath)
+		if err != nil {
+			t.Fatalf("validate failed: %v\noutput: %s", err, output)
+		}
+		assertContains(t, output, "is valid")
+	})
+
+	t.Run("validate contract with config ref", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "config-ref-svc")
+		contractYAML := `pactoVersion: "1.0"
+service:
+  name: config-ref-svc
+  version: 1.0.0
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+    visibility: internal
+    contract: interfaces/openapi.yaml
+configuration:
+  ref: oci://ghcr.io/acme/platform-config:1.0.0
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+`
+		bundlePath := writeBundleDir(t, dir, contractYAML, map[string]string{
+			"openapi.yaml": fmt.Sprintf(openapiTemplate, "config-ref-svc", "1.0.0"),
+		})
+
+		output, err := runCommand(t, nil, "validate", bundlePath)
+		if err != nil {
+			t.Fatalf("validate failed: %v\noutput: %s", err, output)
+		}
+		assertContains(t, output, "is valid")
+	})
+
+	t.Run("validate rejects empty policy", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "empty-policy-svc")
+		contractYAML := `pactoVersion: "1.0"
+service:
+  name: empty-policy-svc
+  version: 1.0.0
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+    visibility: internal
+    contract: interfaces/openapi.yaml
+policy: {}
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+`
+		bundlePath := writeBundleDir(t, dir, contractYAML, map[string]string{
+			"openapi.yaml": fmt.Sprintf(openapiTemplate, "empty-policy-svc", "1.0.0"),
+		})
+
+		output, err := runCommand(t, nil, "validate", bundlePath)
+		if err == nil {
+			t.Fatalf("expected validation to fail for empty policy, output: %s", output)
+		}
+		assertContains(t, output, "SCHEMA_VIOLATION")
+	})
+
+	t.Run("validate rejects missing policy schema file", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "missing-policy-svc")
+		contractYAML := `pactoVersion: "1.0"
+service:
+  name: missing-policy-svc
+  version: 1.0.0
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+    visibility: internal
+    contract: interfaces/openapi.yaml
+policy:
+  schema: policy/schema.json
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+`
+		bundlePath := writeBundleDir(t, dir, contractYAML, map[string]string{
+			"openapi.yaml": fmt.Sprintf(openapiTemplate, "missing-policy-svc", "1.0.0"),
+		})
+
+		output, err := runCommand(t, nil, "validate", bundlePath)
+		if err == nil {
+			t.Fatalf("expected validation to fail for missing policy schema, output: %s", output)
+		}
+		assertContains(t, output, "FILE_NOT_FOUND")
+	})
+
+	t.Run("diff detects policy changes", func(t *testing.T) {
+		dir1 := filepath.Join(t.TempDir(), "svc-v1")
+		contract1 := `pactoVersion: "1.0"
+service:
+  name: diff-policy-svc
+  version: 1.0.0
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+    visibility: internal
+    contract: interfaces/openapi.yaml
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+`
+		dir2 := filepath.Join(t.TempDir(), "svc-v2")
+		contract2 := `pactoVersion: "1.0"
+service:
+  name: diff-policy-svc
+  version: 2.0.0
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+    visibility: internal
+    contract: interfaces/openapi.yaml
+policy:
+  ref: oci://ghcr.io/acme/policy:1.0.0
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+`
+		path1 := writeBundleDir(t, dir1, contract1, map[string]string{
+			"openapi.yaml": fmt.Sprintf(openapiTemplate, "diff-policy-svc", "1.0.0"),
+		})
+		path2 := writeBundleDir(t, dir2, contract2, map[string]string{
+			"openapi.yaml": fmt.Sprintf(openapiTemplate, "diff-policy-svc", "2.0.0"),
+		})
+
+		output, _ := runCommand(t, nil, "diff", path1, path2)
+		assertContains(t, output, "policy")
+	})
+
+	t.Run("push rejects local policy ref", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		dir := filepath.Join(t.TempDir(), "local-policy-svc")
+		contractYAML := `pactoVersion: "1.0"
+service:
+  name: local-policy-svc
+  version: 1.0.0
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+    visibility: internal
+    contract: interfaces/openapi.yaml
+policy:
+  ref: file://../platform-policy
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+`
+		bundlePath := writeBundleDir(t, dir, contractYAML, map[string]string{
+			"openapi.yaml": fmt.Sprintf(openapiTemplate, "local-policy-svc", "1.0.0"),
+		})
+
+		_, err := runCommand(t, reg, "push", "oci://"+reg.host+"/local-policy-svc:1.0.0", "-p", bundlePath)
+		if err == nil {
+			t.Fatal("expected push to reject local policy ref")
+		}
+	})
+
+	t.Run("push rejects local config ref", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		dir := filepath.Join(t.TempDir(), "local-config-svc")
+		contractYAML := `pactoVersion: "1.0"
+service:
+  name: local-config-svc
+  version: 1.0.0
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+    visibility: internal
+    contract: interfaces/openapi.yaml
+configuration:
+  ref: file://../platform-config
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+`
+		bundlePath := writeBundleDir(t, dir, contractYAML, map[string]string{
+			"openapi.yaml": fmt.Sprintf(openapiTemplate, "local-config-svc", "1.0.0"),
+		})
+
+		_, err := runCommand(t, reg, "push", "oci://"+reg.host+"/local-config-svc:1.0.0", "-p", bundlePath)
+		if err == nil {
+			t.Fatal("expected push to reject local config ref")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- **Policy enforcement**: New `policy` field in contracts lets platform teams enforce organizational standards (e.g., require health endpoints, mandate ports) via JSON Schema validation of the contract itself
- **External schema references**: Both `configuration.ref` and `policy.ref` support OCI references to centralize schema management, with recursive resolution and cycle detection
- **Push-time safety**: `pacto push` rejects local refs (`file://`, bare paths) for both `configuration.ref` and `policy.ref`
- **Full documentation update**: All docs (contract reference, developers, platform engineers, quickstart, architecture, CLI reference, GitHub Actions, README, index) updated with new features and clarified that only `pacto.yaml` is required in a bundle

## Implementation details

- Domain model: `Policy` struct, `Ref` field on `Configuration`
- JSON Schema: `policy` section with `anyOf` constraint, `ref` added to `configuration`
- Validation: `validateConfigRef()`, `validatePolicyFields()` in cross-field layer
- Diff: classification rules for `policy.*` and `configuration.ref` changes
- Push: `rejectLocalRefs()` for both config and policy refs
- Fixed path convention: external refs resolve schemas from `configuration/schema.json` and `policy/schema.json`

## Test plan

- [x] 100% unit test coverage across all packages
- [x] 15+ cross-field validation tests for config ref and policy
- [x] 15+ diff tests for policy and config ref changes
- [x] 7 push rejection tests for local refs
- [x] E2E test suite with 8 subtests (`TestPolicyAndConfigRef`)
- [x] `make ci` passes (format, vet, cyclomatic complexity, lint, unit tests, e2e tests)
- [x] All existing tests continue to pass (backwards compatibility)