### PR TITLE
ci: add automated version bumping based on conventional PR titles

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,80 @@
+name: Auto release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine version bump
+        id: bump
+        run: |
+          title="${{ github.event.pull_request.title }}"
+
+          # Check for breaking change indicator
+          if [[ "$title" =~ ^[a-z]+(\(.+\))?\!: ]]; then
+            echo "type=major" >> "$GITHUB_OUTPUT"
+          elif [[ "$title" =~ ^feat(\(.+\))?: ]]; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+          elif [[ "$title" =~ ^(fix|perf|refactor)(\(.+\))?\!?: ]]; then
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+          else
+            echo "Skipping release for: $title"
+            echo "type=skip" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v6.0.2
+        if: steps.bump.outputs.type != 'skip'
+        with:
+          fetch-depth: 0
+
+      - name: Calculate next version
+        if: steps.bump.outputs.type != 'skip'
+        id: version
+        run: |
+          # Get the latest semver tag
+          latest=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+          if [ -z "$latest" ]; then
+            latest="v0.0.0"
+          fi
+
+          # Strip the 'v' prefix and split
+          version="${latest#v}"
+          IFS='.' read -r major minor patch <<< "$version"
+
+          case "${{ steps.bump.outputs.type }}" in
+            major)
+              major=$((major + 1))
+              minor=0
+              patch=0
+              ;;
+            minor)
+              minor=$((minor + 1))
+              patch=0
+              ;;
+            patch)
+              patch=$((patch + 1))
+              ;;
+          esac
+
+          next="v${major}.${minor}.${patch}"
+          echo "tag=$next" >> "$GITHUB_OUTPUT"
+          echo "Bumping ${{ steps.bump.outputs.type }}: $latest -> $next"
+
+      - name: Create GitHub release
+        if: steps.bump.outputs.type != 'skip'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --generate-notes \
+            --target main

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,28 @@
+name: Validate PR title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check conventional commit format
+        run: |
+          title="${{ github.event.pull_request.title }}"
+          pattern='^(feat|fix|docs|chore|refactor|test|ci|perf|build|style)(\(.+\))?\!?: .+'
+          if [[ ! "$title" =~ $pattern ]]; then
+            echo "::error::PR title must follow conventional commit format:"
+            echo "::error::  <type>[optional scope][!]: <description>"
+            echo "::error::Allowed types: feat, fix, docs, chore, refactor, test, ci, perf, build, style"
+            echo "::error::Add '!' before ':' for breaking changes (e.g., 'feat!: redesign API')"
+            echo "::error::Got: '$title'"
+            exit 1
+          fi
+          echo "PR title is valid: $title"


### PR DESCRIPTION
## Summary
- **pr-title.yml**: validates that PR titles follow conventional commit format (`feat:`, `fix:`, `docs:`, etc.) — runs on PR open/edit
- **auto-release.yml**: on merge to main, reads the PR title to determine version bump type and creates a GitHub release automatically
  - `feat!:` / `fix!:` / any `!:` → **major**
  - `feat:` → **minor**
  - `fix:`, `perf:`, `refactor:` → **patch**
  - `docs:`, `chore:`, `ci:`, `test:`, `build:`, `style:` → **no release**
- The created release triggers the existing `release.yml` to build and publish binaries

## Test plan
- [ ] Open a PR with an invalid title (e.g., "update stuff") and verify it fails validation
- [ ] Open a PR with a valid title (e.g., "fix: something") and verify it passes
- [ ] Merge a `fix:` PR and verify a patch release is created
- [ ] Merge a `feat:` PR and verify a minor release is created
- [ ] Merge a `docs:` PR and verify no release is created