### PR TITLE
fix: treat Go partial coverage lines as hits in Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,15 @@ coverage:
       default:
         target: 100%
         threshold: 0%
+
+ignore:
+  - "tests/**"
+  - "cmd/gendocs/**"
+  - "internal/testutil/**"
+
+# Go coverage emits "0 0" for empty select/case branches (no executable
+# statements). go tool cover treats these as 100% but Codecov misreads
+# them as uncovered. This flag fixes the discrepancy.
+parsers:
+  go:
+    partials_as_hits: true


### PR DESCRIPTION
## Summary

Go coverage emits `0 0` for empty `select`/`case` branches (no executable statements). `go tool cover` treats these as 100% covered, but Codecov misinterprets them as uncovered — causing `root.go` to show 98% instead of 100%.

Added `partials_as_hits: true` to `codecov.yml` to align Codecov with Go's behavior. Also added ignore patterns for test/tooling directories.

## Test plan

- [ ] Verify Codecov shows 100% after merge