### PR TITLE
ci: enable verbose Codecov uploads to debug badge issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
+          fail_ci_if_error: true
+          verbose: true


### PR DESCRIPTION
## Summary
- Codecov API returns 100% coverage but badge shows "unknown"
- Enable `verbose: true` and `fail_ci_if_error: true` on the Codecov upload step to surface any hidden processing issues
- Recent commits show `totals: null` and `report: null` in Codecov API despite upload logs showing "Process Upload complete"

## Test plan
- [ ] Check verbose CI logs after merge to identify why Codecov isn't processing uploads