### PR TITLE
fix: use mem:// URI for in-memory JSON Schema compilation

### DIFF
--- a/pkg/validation/crossfield.go
+++ b/pkg/validation/crossfield.go
@@ -411,8 +411,8 @@ func compileConfigSchema(data []byte) (*jsonschema.Schema, error) {
 	if err := json.Unmarshal(data, &schemaDoc); err != nil {
 		return nil, fmt.Errorf("failed to parse: %v", err)
 	}
-	compiler.AddResource("config-schema.json", schemaDoc) //nolint:errcheck // AddResource does not fail for valid JSON
-	return compiler.Compile("config-schema.json")
+	compiler.AddResource("mem:///config-schema.json", schemaDoc) //nolint:errcheck // AddResource does not fail for valid JSON
+	return compiler.Compile("mem:///config-schema.json")
 }
 
 func validateStatePersistenceInvariants(c *contract.Contract, result *ValidationResult) {


### PR DESCRIPTION
## Summary
- Fix flaky `TestOverrideConfigValues/valid_config_values_via_set` e2e test
- The jsonschema compiler resolves relative resource names (`config-schema.json`) against the current working directory
- When parallel e2e tests change cwd via `inDir()`, the compiler tries to load from the wrong directory
- Using a `mem:///` URI scheme prevents filesystem resolution entirely