### PR TITLE
fix: persist --set and --values overrides in pushed/packed bundle FS

### DIFF
--- a/internal/app/push_test.go
+++ b/internal/app/push_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/trianalab/pacto/internal/oci"
 	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/pkg/override"
 )
 
 func TestPush_Success(t *testing.T) {
@@ -320,6 +322,48 @@ func TestPush_ExplicitTagKept(t *testing.T) {
 	}
 	if pushedRef != "ghcr.io/acme/svc:custom" {
 		t.Errorf("expected store to receive ref ghcr.io/acme/svc:custom, got %s", pushedRef)
+	}
+}
+
+func TestPush_OverridesPersistInBundle(t *testing.T) {
+	dir := writeTestBundle(t)
+	var pushedBundle *contract.Bundle
+	store := &mockBundleStore{
+		ResolveFn: func(_ context.Context, _ string) (string, error) {
+			return "", &oci.ArtifactNotFoundError{Ref: "ghcr.io/acme/svc:2.0.0"}
+		},
+		PushFn: func(_ context.Context, _ string, b *contract.Bundle) (string, error) {
+			pushedBundle = b
+			return "sha256:abc123", nil
+		},
+	}
+	svc := NewService(store, nil)
+	result, err := svc.Push(context.Background(), PushOptions{
+		Ref:  "oci://ghcr.io/acme/svc",
+		Path: dir,
+		Overrides: override.Overrides{
+			SetValues: []string{"service.version=2.0.0"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "2.0.0" {
+		t.Errorf("expected Version=2.0.0, got %s", result.Version)
+	}
+
+	// Verify the bundle FS contains the overridden pacto.yaml
+	data, err := fs.ReadFile(pushedBundle.FS, "pacto.yaml")
+	if err != nil {
+		t.Fatalf("failed to read pacto.yaml from pushed bundle: %v", err)
+	}
+	if !strings.Contains(string(data), "version: 2.0.0") && !strings.Contains(string(data), `version: "2.0.0"`) {
+		t.Errorf("pushed bundle pacto.yaml should contain overridden version, got:\n%s", string(data))
+	}
+
+	// Verify non-overridden files are still accessible
+	if _, err := fs.ReadFile(pushedBundle.FS, "openapi.yaml"); err != nil {
+		t.Errorf("non-overridden file should still be accessible: %v", err)
 	}
 }
 

--- a/internal/app/resolve.go
+++ b/internal/app/resolve.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"testing/fstest"
 
 	"github.com/trianalab/pacto/internal/oci"
 	"github.com/trianalab/pacto/pkg/contract"
@@ -135,11 +136,45 @@ func applyOverrides(bundle *contract.Bundle, overrides override.Overrides) (*con
 		return nil, fmt.Errorf("overrides produce an invalid contract: %s", result.Errors[0].Message)
 	}
 
+	mergedFS, err := copyFSWithReplace(bundle.FS, DefaultContractPath, merged)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build overridden bundle FS: %w", err)
+	}
+
 	return &contract.Bundle{
 		Contract: c,
 		RawYAML:  merged,
-		FS:       bundle.FS,
+		FS:       mergedFS,
 	}, nil
+}
+
+// copyFSWithReplace copies all files from src into a fstest.MapFS, replacing
+// the file at replaceName with replaceData.
+func copyFSWithReplace(src fs.FS, replaceName string, replaceData []byte) (fstest.MapFS, error) {
+	m := fstest.MapFS{}
+	err := fs.WalkDir(src, ".", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == "." {
+			return nil
+		}
+		if d.IsDir() {
+			m[path] = &fstest.MapFile{Mode: fs.ModeDir | 0755}
+			return nil
+		}
+		if path == replaceName {
+			m[path] = &fstest.MapFile{Data: replaceData, Mode: 0644}
+			return nil
+		}
+		data, err := fs.ReadFile(src, path)
+		if err != nil {
+			return err
+		}
+		m[path] = &fstest.MapFile{Data: data, Mode: 0644}
+		return nil
+	})
+	return m, err
 }
 
 // loadAndValidateLocal reads a local contract directory, parses pacto.yaml,

--- a/internal/app/resolve_test.go
+++ b/internal/app/resolve_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -450,5 +451,69 @@ func TestLoadAndValidateLocal_ValidationFails(t *testing.T) {
 	_, _, _, err := loadAndValidateLocal(dir, override.Overrides{})
 	if err == nil {
 		t.Error("expected error for invalid bundle")
+	}
+}
+
+func TestCopyFSWithReplace_ErrorFS(t *testing.T) {
+	_, err := copyFSWithReplace(errFS{}, "pacto.yaml", []byte("data"))
+	if err == nil {
+		t.Error("expected error for errFS")
+	}
+}
+
+func TestCopyFSWithReplace_ReadFileError(t *testing.T) {
+	base := readFailFS{fstest.MapFS{
+		"other.yaml": &fstest.MapFile{Data: []byte("data")},
+	}}
+	_, err := copyFSWithReplace(base, "pacto.yaml", []byte("data"))
+	if err == nil {
+		t.Error("expected error when ReadFile fails")
+	}
+}
+
+func TestApplyOverrides_CopyFSError(t *testing.T) {
+	b := testBundle()
+	b.FS = errFS{}
+	_, err := applyOverrides(b, override.Overrides{SetValues: []string{"service.version=9.9.9"}})
+	if err == nil {
+		t.Error("expected error when FS walk fails")
+	}
+}
+
+func TestCopyFSWithReplace(t *testing.T) {
+	base := fstest.MapFS{
+		"pacto.yaml":   &fstest.MapFile{Data: []byte("original")},
+		"openapi.yaml": &fstest.MapFile{Data: []byte("openapi content")},
+		"docs":         &fstest.MapFile{Mode: fs.ModeDir | 0755},
+		"docs/README":  &fstest.MapFile{Data: []byte("readme")},
+	}
+	replaced := []byte("overridden content")
+	result, err := copyFSWithReplace(base, "pacto.yaml", replaced)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := fs.ReadFile(result, "pacto.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "overridden content" {
+		t.Errorf("expected replaced content, got %q", string(data))
+	}
+
+	data, err = fs.ReadFile(result, "openapi.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "openapi content" {
+		t.Errorf("expected original content, got %q", string(data))
+	}
+
+	data, err = fs.ReadFile(result, "docs/README")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "readme" {
+		t.Errorf("expected readme, got %q", string(data))
 	}
 }


### PR DESCRIPTION
## Summary

- `--set` and `--values` overrides were applied to the in-memory `Contract` struct but **not** to the bundle `FS`, causing the OCI artifact to contain the original `pacto.yaml` from disk
- `push` and `pack` both exhibited this bug — e.g. `pacto push --set service.version=2.0.0` would tag as `2.0.0` but the artifact content still had the original version
- Fix: rebuild the bundle FS with the merged `pacto.yaml` in `applyOverrides` via `copyFSWithReplace`, ensuring `Contract`, `RawYAML`, and `FS` are all consistent

## Test plan

- [x] Added `TestPush_OverridesPersistInBundle` — verifies the pushed bundle FS contains overridden values
- [x] Added `TestCopyFSWithReplace` — unit tests for the new helper
- [x] Added error-path coverage tests for `copyFSWithReplace` and `applyOverrides`
- [x] All existing unit tests pass (100% coverage)
- [x] All E2E tests pass including `TestPackCommand/with_set_override` and `TestPackCommand/with_values_file`
- [x] `make ci` passes