### PR TITLE
feat: validate content of referenced bundle files

### DIFF
--- a/pkg/validation/crossfield.go
+++ b/pkg/validation/crossfield.go
@@ -4,11 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"path/filepath"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/trianalab/pacto/pkg/contract"
 	"github.com/trianalab/pacto/pkg/graph"
+	"gopkg.in/yaml.v3"
 )
 
 // ValidateCrossField performs Layer 2 validation: cross-field consistency,
@@ -24,9 +27,12 @@ func ValidateCrossField(c *contract.Contract, bundleFS fs.FS) ValidationResult {
 	validateHealthInterface(c, &result)
 	validateMetricsInterface(c, &result)
 	validateInterfaceFiles(c, bundleFS, &result)
+	validateInterfaceFileContent(c, bundleFS, &result)
 	validateConfigFiles(c, bundleFS, &result)
+	validateConfigSchemaContent(c, bundleFS, &result)
 	validateConfigRef(c, &result)
 	validatePolicyFields(c, bundleFS, &result)
+	validatePolicySchemaContent(c, bundleFS, &result)
 	validateDependencyRefs(c, &result)
 	validateImageRef(c, &result)
 	validateChartRef(c, &result)
@@ -382,11 +388,7 @@ func validateConfigValues(c *contract.Contract, bundleFS fs.FS, result *Validati
 
 	schema, err := compileConfigSchema(schemaData)
 	if err != nil {
-		result.AddError(
-			"configuration.schema",
-			"INVALID_CONFIG_SCHEMA",
-			fmt.Sprintf("invalid configuration schema: %v", err),
-		)
+		// Schema compilation errors are already caught by validateConfigSchemaContent.
 		return
 	}
 
@@ -413,6 +415,78 @@ func compileConfigSchema(data []byte) (*jsonschema.Schema, error) {
 	}
 	compiler.AddResource("mem:///config-schema.json", schemaDoc) //nolint:errcheck // AddResource does not fail for valid JSON
 	return compiler.Compile("mem:///config-schema.json")
+}
+
+// isYAMLFile reports whether the file path has a YAML extension.
+func isYAMLFile(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	return ext == ".yaml" || ext == ".yml"
+}
+
+func validateInterfaceFileContent(c *contract.Contract, bundleFS fs.FS, result *ValidationResult) {
+	if bundleFS == nil {
+		return
+	}
+	for i, iface := range c.Interfaces {
+		if iface.Contract == "" {
+			continue
+		}
+		data, err := fs.ReadFile(bundleFS, iface.Contract)
+		if err != nil {
+			// File-not-found is already caught by validateInterfaceFiles.
+			continue
+		}
+		if !isYAMLFile(iface.Contract) {
+			continue
+		}
+		var parsed interface{}
+		if err := yaml.Unmarshal(data, &parsed); err != nil {
+			result.AddError(
+				fmt.Sprintf("interfaces[%d].contract", i),
+				"INVALID_CONTRACT_FILE",
+				fmt.Sprintf("interface contract file %q is not valid YAML: %v", iface.Contract, err),
+			)
+		}
+	}
+}
+
+// validateJSONSchemaFile reads a JSON file from the bundle, validates it is
+// valid JSON, and compiles it as a JSON Schema. It reports errors at the given
+// field path using the given error codes.
+func validateJSONSchemaFile(bundleFS fs.FS, path, field, invalidJSONCode, invalidSchemaCode string, result *ValidationResult) {
+	if bundleFS == nil || path == "" {
+		return
+	}
+	data, err := fs.ReadFile(bundleFS, path)
+	if err != nil {
+		// File-not-found is already caught by other validators.
+		return
+	}
+	if !json.Valid(data) {
+		result.AddError(field, invalidJSONCode,
+			fmt.Sprintf("file %q is not valid JSON", path))
+		return
+	}
+	if _, err := compileConfigSchema(data); err != nil {
+		result.AddError(field, invalidSchemaCode,
+			fmt.Sprintf("file %q is not a valid JSON Schema: %v", path, err))
+	}
+}
+
+func validateConfigSchemaContent(c *contract.Contract, bundleFS fs.FS, result *ValidationResult) {
+	if c.Configuration == nil || c.Configuration.Schema == "" {
+		return
+	}
+	validateJSONSchemaFile(bundleFS, c.Configuration.Schema,
+		"configuration.schema", "INVALID_CONFIG_JSON", "INVALID_CONFIG_SCHEMA", result)
+}
+
+func validatePolicySchemaContent(c *contract.Contract, bundleFS fs.FS, result *ValidationResult) {
+	if c.Policy == nil || c.Policy.Schema == "" {
+		return
+	}
+	validateJSONSchemaFile(bundleFS, c.Policy.Schema,
+		"policy.schema", "INVALID_POLICY_JSON", "INVALID_POLICY_SCHEMA", result)
 }
 
 func validateStatePersistenceInvariants(c *contract.Contract, result *ValidationResult) {

--- a/pkg/validation/crossfield_test.go
+++ b/pkg/validation/crossfield_test.go
@@ -591,9 +591,11 @@ func TestValidateConfigValues_InvalidSchemaJSON(t *testing.T) {
 		"bad-schema.json": &fstest.MapFile{Data: []byte("not valid json")},
 	}
 	var result ValidationResult
+	// Invalid schema JSON is now caught by validateConfigSchemaContent;
+	// validateConfigValues silently skips when compilation fails.
 	validateConfigValues(c, bundleFS, &result)
-	if result.IsValid() {
-		t.Error("expected error for invalid schema JSON")
+	if !result.IsValid() {
+		t.Error("expected no error from validateConfigValues (caught by validateConfigSchemaContent)")
 	}
 }
 
@@ -613,9 +615,11 @@ func TestValidateConfigValues_InvalidSchemaCompile(t *testing.T) {
 		}`)},
 	}
 	var result ValidationResult
+	// Schema compilation errors are now caught by validateConfigSchemaContent;
+	// validateConfigValues silently skips when compilation fails.
 	validateConfigValues(c, bundleFS, &result)
-	if result.IsValid() {
-		t.Error("expected error for schema that fails compilation")
+	if !result.IsValid() {
+		t.Error("expected no error from validateConfigValues (caught by validateConfigSchemaContent)")
 	}
 }
 
@@ -800,5 +804,269 @@ func TestValidatePolicyFields_BothSchemaAndRef(t *testing.T) {
 	validatePolicyFields(c, bundleFS, &result)
 	if !result.IsValid() {
 		t.Errorf("expected no error for policy with both schema and ref, got %v", result.Errors)
+	}
+}
+
+// --- Interface file content validation ---
+
+func TestValidateInterfaceFileContent_ValidYAML(t *testing.T) {
+	c := validContract()
+	c.Interfaces[0].Contract = "interfaces/openapi.yaml"
+	bundleFS := fstest.MapFS{
+		"interfaces/openapi.yaml": &fstest.MapFile{Data: []byte("openapi: '3.0.0'\ninfo:\n  title: test\n  version: '1.0'\n")},
+	}
+	var result ValidationResult
+	validateInterfaceFileContent(c, bundleFS, &result)
+	if !result.IsValid() {
+		t.Errorf("expected no error for valid YAML, got %v", result.Errors)
+	}
+}
+
+func TestValidateInterfaceFileContent_InvalidYAML(t *testing.T) {
+	c := validContract()
+	c.Interfaces[0].Contract = "interfaces/openapi.yaml"
+	bundleFS := fstest.MapFS{
+		"interfaces/openapi.yaml": &fstest.MapFile{Data: []byte(":\ninvalid:\n  - [yaml\n")},
+	}
+	var result ValidationResult
+	validateInterfaceFileContent(c, bundleFS, &result)
+	if result.IsValid() {
+		t.Error("expected INVALID_CONTRACT_FILE error for invalid YAML")
+	}
+	if result.Errors[0].Code != "INVALID_CONTRACT_FILE" {
+		t.Errorf("expected code INVALID_CONTRACT_FILE, got %s", result.Errors[0].Code)
+	}
+}
+
+func TestValidateInterfaceFileContent_NonYAMLSkipped(t *testing.T) {
+	c := validContract()
+	c.Interfaces[0].Contract = "interfaces/service.proto"
+	bundleFS := fstest.MapFS{
+		"interfaces/service.proto": &fstest.MapFile{Data: []byte("not yaml content")},
+	}
+	var result ValidationResult
+	validateInterfaceFileContent(c, bundleFS, &result)
+	if !result.IsValid() {
+		t.Error("expected no error for non-YAML file")
+	}
+}
+
+func TestValidateInterfaceFileContent_NilBundleFS(t *testing.T) {
+	c := validContract()
+	c.Interfaces[0].Contract = "interfaces/openapi.yaml"
+	var result ValidationResult
+	validateInterfaceFileContent(c, nil, &result)
+	if !result.IsValid() {
+		t.Error("expected no error when bundleFS is nil")
+	}
+}
+
+func TestValidateInterfaceFileContent_EmptyContract(t *testing.T) {
+	c := validContract()
+	c.Interfaces[0].Contract = ""
+	var result ValidationResult
+	validateInterfaceFileContent(c, fstest.MapFS{}, &result)
+	if !result.IsValid() {
+		t.Error("expected no error for empty contract path")
+	}
+}
+
+func TestValidateInterfaceFileContent_MissingFileSkipped(t *testing.T) {
+	c := validContract()
+	c.Interfaces[0].Contract = "interfaces/openapi.yaml"
+	bundleFS := fstest.MapFS{}
+	var result ValidationResult
+	validateInterfaceFileContent(c, bundleFS, &result)
+	if !result.IsValid() {
+		t.Error("expected no error for missing file (handled by validateInterfaceFiles)")
+	}
+}
+
+// --- Config schema content validation ---
+
+func TestValidateConfigSchemaContent_ValidJSON(t *testing.T) {
+	c := validContract()
+	c.Configuration = &contract.Configuration{Schema: "config/schema.json"}
+	bundleFS := fstest.MapFS{
+		"config/schema.json": &fstest.MapFile{Data: []byte(`{"type":"object"}`)},
+	}
+	var result ValidationResult
+	validateConfigSchemaContent(c, bundleFS, &result)
+	if !result.IsValid() {
+		t.Errorf("expected no error for valid JSON Schema, got %v", result.Errors)
+	}
+}
+
+func TestValidateConfigSchemaContent_InvalidJSON(t *testing.T) {
+	c := validContract()
+	c.Configuration = &contract.Configuration{Schema: "config/schema.json"}
+	bundleFS := fstest.MapFS{
+		"config/schema.json": &fstest.MapFile{Data: []byte("not json")},
+	}
+	var result ValidationResult
+	validateConfigSchemaContent(c, bundleFS, &result)
+	if result.IsValid() {
+		t.Error("expected INVALID_CONFIG_JSON error")
+	}
+	if result.Errors[0].Code != "INVALID_CONFIG_JSON" {
+		t.Errorf("expected code INVALID_CONFIG_JSON, got %s", result.Errors[0].Code)
+	}
+}
+
+func TestValidateConfigSchemaContent_InvalidSchema(t *testing.T) {
+	c := validContract()
+	c.Configuration = &contract.Configuration{Schema: "config/schema.json"}
+	bundleFS := fstest.MapFS{
+		"config/schema.json": &fstest.MapFile{Data: []byte(`{"type":"object","properties":{"k":{"$ref":"nonexistent://bad"}}}`)},
+	}
+	var result ValidationResult
+	validateConfigSchemaContent(c, bundleFS, &result)
+	if result.IsValid() {
+		t.Error("expected INVALID_CONFIG_SCHEMA error")
+	}
+	if result.Errors[0].Code != "INVALID_CONFIG_SCHEMA" {
+		t.Errorf("expected code INVALID_CONFIG_SCHEMA, got %s", result.Errors[0].Code)
+	}
+}
+
+func TestValidateConfigSchemaContent_NilConfig(t *testing.T) {
+	c := validContract()
+	c.Configuration = nil
+	var result ValidationResult
+	validateConfigSchemaContent(c, nil, &result)
+	if !result.IsValid() {
+		t.Error("expected no error for nil config")
+	}
+}
+
+func TestValidateConfigSchemaContent_EmptySchema(t *testing.T) {
+	c := validContract()
+	c.Configuration = &contract.Configuration{Schema: ""}
+	var result ValidationResult
+	validateConfigSchemaContent(c, nil, &result)
+	if !result.IsValid() {
+		t.Error("expected no error for empty schema")
+	}
+}
+
+func TestValidateConfigSchemaContent_MissingFileSkipped(t *testing.T) {
+	c := validContract()
+	c.Configuration = &contract.Configuration{Schema: "missing.json"}
+	bundleFS := fstest.MapFS{}
+	var result ValidationResult
+	validateConfigSchemaContent(c, bundleFS, &result)
+	if !result.IsValid() {
+		t.Error("expected no error for missing file (handled by validateConfigFiles)")
+	}
+}
+
+func TestValidateConfigSchemaContent_WithoutValues(t *testing.T) {
+	c := validContract()
+	c.Configuration = &contract.Configuration{Schema: "config/schema.json"}
+	bundleFS := fstest.MapFS{
+		"config/schema.json": &fstest.MapFile{Data: []byte("not json")},
+	}
+	var result ValidationResult
+	validateConfigSchemaContent(c, bundleFS, &result)
+	if result.IsValid() {
+		t.Error("expected error even without values — schema must always be valid")
+	}
+}
+
+// --- Policy schema content validation ---
+
+func TestValidatePolicySchemaContent_ValidJSON(t *testing.T) {
+	c := validContract()
+	c.Policy = &contract.Policy{Schema: "policy/schema.json"}
+	bundleFS := fstest.MapFS{
+		"policy/schema.json": &fstest.MapFile{Data: []byte(`{"type":"object"}`)},
+	}
+	var result ValidationResult
+	validatePolicySchemaContent(c, bundleFS, &result)
+	if !result.IsValid() {
+		t.Errorf("expected no error for valid policy JSON Schema, got %v", result.Errors)
+	}
+}
+
+func TestValidatePolicySchemaContent_InvalidJSON(t *testing.T) {
+	c := validContract()
+	c.Policy = &contract.Policy{Schema: "policy/schema.json"}
+	bundleFS := fstest.MapFS{
+		"policy/schema.json": &fstest.MapFile{Data: []byte("not json")},
+	}
+	var result ValidationResult
+	validatePolicySchemaContent(c, bundleFS, &result)
+	if result.IsValid() {
+		t.Error("expected INVALID_POLICY_JSON error")
+	}
+	if result.Errors[0].Code != "INVALID_POLICY_JSON" {
+		t.Errorf("expected code INVALID_POLICY_JSON, got %s", result.Errors[0].Code)
+	}
+}
+
+func TestValidatePolicySchemaContent_InvalidSchema(t *testing.T) {
+	c := validContract()
+	c.Policy = &contract.Policy{Schema: "policy/schema.json"}
+	bundleFS := fstest.MapFS{
+		"policy/schema.json": &fstest.MapFile{Data: []byte(`{"type":"object","properties":{"k":{"$ref":"nonexistent://bad"}}}`)},
+	}
+	var result ValidationResult
+	validatePolicySchemaContent(c, bundleFS, &result)
+	if result.IsValid() {
+		t.Error("expected INVALID_POLICY_SCHEMA error")
+	}
+	if result.Errors[0].Code != "INVALID_POLICY_SCHEMA" {
+		t.Errorf("expected code INVALID_POLICY_SCHEMA, got %s", result.Errors[0].Code)
+	}
+}
+
+func TestValidatePolicySchemaContent_NilPolicy(t *testing.T) {
+	c := validContract()
+	c.Policy = nil
+	var result ValidationResult
+	validatePolicySchemaContent(c, nil, &result)
+	if !result.IsValid() {
+		t.Error("expected no error for nil policy")
+	}
+}
+
+func TestValidatePolicySchemaContent_EmptySchema(t *testing.T) {
+	c := validContract()
+	c.Policy = &contract.Policy{Ref: "oci://ghcr.io/acme/policy:1.0.0"}
+	var result ValidationResult
+	validatePolicySchemaContent(c, nil, &result)
+	if !result.IsValid() {
+		t.Error("expected no error for policy with ref only")
+	}
+}
+
+// --- validateJSONSchemaFile guard ---
+
+func TestValidateJSONSchemaFile_NilBundleFS(t *testing.T) {
+	var result ValidationResult
+	validateJSONSchemaFile(nil, "schema.json", "field", "CODE1", "CODE2", &result)
+	if !result.IsValid() {
+		t.Error("expected no error when bundleFS is nil")
+	}
+}
+
+// --- isYAMLFile helper ---
+
+func TestIsYAMLFile(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"openapi.yaml", true},
+		{"openapi.yml", true},
+		{"openapi.YAML", true},
+		{"schema.json", false},
+		{"service.proto", false},
+		{"noext", false},
+	}
+	for _, tt := range tests {
+		if got := isYAMLFile(tt.path); got != tt.want {
+			t.Errorf("isYAMLFile(%q) = %v, want %v", tt.path, got, tt.want)
+		}
 	}
 }

--- a/tests/e2e/fixtures_test.go
+++ b/tests/e2e/fixtures_test.go
@@ -697,6 +697,55 @@ func writeZeroInterfaceBundle(t *testing.T) string {
 	return dir
 }
 
+// writeBundleDirRaw writes a contract YAML, optional interface files, and a
+// custom configuration schema string. It allows testing with invalid schema content.
+func writeBundleDirRaw(t *testing.T, dir, contractYAML string, ifaceFiles map[string]string, configSchema string) string {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Join(dir, "interfaces"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "configuration"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "pacto.yaml"), []byte(contractYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, content := range ifaceFiles {
+		p := filepath.Join(dir, "interfaces", name)
+		if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "configuration", "schema.json"), []byte(configSchema), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	return dir
+}
+
+// writeBundleDirWithPolicy writes a contract YAML and a custom policy schema.
+func writeBundleDirWithPolicy(t *testing.T, dir, contractYAML string, policySchema string) string {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Join(dir, "policy"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "pacto.yaml"), []byte(contractYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "policy", "schema.json"), []byte(policySchema), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	return dir
+}
+
 // writeOpenAPIDiffBundleV1 creates a bundle with the v1 OpenAPI spec.
 func writeOpenAPIDiffBundleV1(t *testing.T) string {
 	t.Helper()

--- a/tests/e2e/validate_test.go
+++ b/tests/e2e/validate_test.go
@@ -125,4 +125,162 @@ func TestValidateCommand(t *testing.T) {
 		assertContains(t, output, "validate")
 		assertContains(t, output, "Usage")
 	})
+
+}
+
+func TestValidateFileContent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects invalid YAML in interface contract", func(t *testing.T) {
+		t.Parallel()
+		dir := filepath.Join(t.TempDir(), "bad-yaml-svc")
+		contractYAML := `pactoVersion: "1.0"
+service:
+  name: bad-yaml-svc
+  version: 1.0.0
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+    visibility: internal
+    contract: interfaces/openapi.yaml
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+`
+		bundlePath := writeBundleDir(t, dir, contractYAML, map[string]string{
+			"openapi.yaml": ":\n  invalid:\n  - [yaml\n",
+		})
+
+		output, err := runCommand(t, nil, "validate", bundlePath)
+		if err == nil {
+			t.Fatalf("expected validation to fail for invalid YAML interface contract, output: %s", output)
+		}
+		assertContains(t, output, "INVALID_CONTRACT_FILE")
+	})
+
+	t.Run("rejects invalid JSON in config schema", func(t *testing.T) {
+		t.Parallel()
+		dir := filepath.Join(t.TempDir(), "bad-config-svc")
+		contractYAML := `pactoVersion: "1.0"
+service:
+  name: bad-config-svc
+  version: 1.0.0
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+    visibility: internal
+configuration:
+  schema: configuration/schema.json
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+`
+		bundlePath := writeBundleDirRaw(t, dir, contractYAML, nil, "not valid json")
+
+		output, err := runCommand(t, nil, "validate", bundlePath)
+		if err == nil {
+			t.Fatalf("expected validation to fail for invalid JSON config schema, output: %s", output)
+		}
+		assertContains(t, output, "INVALID_CONFIG_JSON")
+	})
+
+	t.Run("rejects invalid JSON in policy schema", func(t *testing.T) {
+		t.Parallel()
+		dir := filepath.Join(t.TempDir(), "bad-policy-svc")
+		contractYAML := `pactoVersion: "1.0"
+service:
+  name: bad-policy-svc
+  version: 1.0.0
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+    visibility: internal
+policy:
+  schema: policy/schema.json
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+`
+		bundlePath := writeBundleDirWithPolicy(t, dir, contractYAML, "not valid json")
+
+		output, err := runCommand(t, nil, "validate", bundlePath)
+		if err == nil {
+			t.Fatalf("expected validation to fail for invalid JSON policy schema, output: %s", output)
+		}
+		assertContains(t, output, "INVALID_POLICY_JSON")
+	})
+
+	t.Run("rejects uncompilable config schema", func(t *testing.T) {
+		t.Parallel()
+		dir := filepath.Join(t.TempDir(), "bad-schema-compile-svc")
+		contractYAML := `pactoVersion: "1.0"
+service:
+  name: bad-schema-compile-svc
+  version: 1.0.0
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+    visibility: internal
+configuration:
+  schema: configuration/schema.json
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+`
+		bundlePath := writeBundleDirRaw(t, dir, contractYAML, nil,
+			`{"type":"object","properties":{"k":{"$ref":"nonexistent://bad"}}}`)
+
+		output, err := runCommand(t, nil, "validate", bundlePath)
+		if err == nil {
+			t.Fatalf("expected validation to fail for uncompilable config schema, output: %s", output)
+		}
+		assertContains(t, output, "INVALID_CONFIG_SCHEMA")
+	})
+
+	t.Run("accepts valid bundle with all referenced files", func(t *testing.T) {
+		t.Parallel()
+		postgresPath := writePostgresBundle(t)
+
+		output, err := runCommand(t, nil, "validate", postgresPath)
+		if err != nil {
+			t.Fatalf("validate failed for valid bundle: %v\noutput: %s", err, output)
+		}
+		assertContains(t, output, "is valid")
+	})
 }


### PR DESCRIPTION
## Summary
- Validates that interface contract YAML files (`.yaml`/`.yml`) contain valid YAML
- Validates that config and policy schema files are valid JSON and compile as JSON Schema (even without `values` present)
- Extracts a shared `validateJSONSchemaFile` helper to keep config/policy validation DRY
- Adds new error codes: `INVALID_CONTRACT_FILE`, `INVALID_CONFIG_JSON`, `INVALID_CONFIG_SCHEMA`, `INVALID_POLICY_JSON`, `INVALID_POLICY_SCHEMA`

## Test plan
- [x] 18 new unit tests covering all validation paths and edge cases
- [x] 5 new e2e tests: invalid YAML interface, invalid JSON config/policy, uncompilable schema, valid bundle still passes
- [x] 100% unit test coverage maintained
- [x] `make ci` passes locally (static checks, unit tests, e2e tests)