### PR TITLE
fix(ci): avoid race condition with auto-release and fix contract publishing

### DIFF
--- a/.github/workflows/pacto.yml
+++ b/.github/workflows/pacto.yml
@@ -12,6 +12,10 @@ on:
       - 'pkg/dashboard/**'
   release:
     types: [published]
+  workflow_run:
+    workflows: ['Auto release']
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: read
@@ -28,8 +32,28 @@ jobs:
         with:
           go-version: '1.25'
 
-      # Setup Pacto CLI and plugins
+      # On push-to-main, build pacto from source to avoid a race condition
+      # with the auto-release workflow that creates the release concurrently.
+      # On PRs and releases, download the latest published release instead.
+      - name: Build pacto from source
+        if: github.event_name == 'push'
+        run: go install ./cmd/pacto
+
+      - name: Install official plugins
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG=$(gh release view --repo TrianaLab/pacto-plugins --json tagName -q .tagName)
+          GOBIN=$(go env GOPATH)/bin
+          for plugin in pacto-plugin-schema-infer pacto-plugin-openapi-infer; do
+            gh release download "$TAG" --repo TrianaLab/pacto-plugins \
+              --pattern "${plugin}_linux_amd64" --output "${GOBIN}/${plugin}"
+            chmod +x "${GOBIN}/${plugin}"
+          done
+
       - uses: trianalab/pacto-actions@v1
+        if: github.event_name != 'push'
         with:
           command: setup
 
@@ -79,7 +103,9 @@ jobs:
           comment-on-pr: 'true'
 
   publish:
-    if: github.event_name == 'release'
+    if: >-
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     needs: bundle
     runs-on: ubuntu-latest
     steps:
@@ -88,6 +114,20 @@ jobs:
       - uses: trianalab/pacto-actions@v1
         with:
           command: setup
+
+      # Resolve the release tag: use the release event tag if available,
+      # otherwise fetch the latest release tag (workflow_run trigger).
+      - name: Resolve release tag
+        id: tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            TAG=$(gh release view --json tagName -q .tagName)
+            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Download bundle artifact
         uses: actions/download-artifact@v4.3.0
@@ -98,7 +138,7 @@ jobs:
       - uses: trianalab/pacto-actions@v1
         with:
           command: push
-          ref: oci://ghcr.io/trianalab/pactos/pacto-dashboard:${{ github.event.release.tag_name }}
+          ref: oci://ghcr.io/trianalab/pactos/pacto-dashboard:${{ steps.tag.outputs.tag }}
           path: ./pactos/pacto-dashboard
           set: |
-            service.version=${{ github.event.release.tag_name }}
+            service.version=${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
## Summary

- **Race condition fix**: On push-to-main, build pacto from source (`go install ./cmd/pacto`) instead of downloading from releases, since the auto-release workflow creates the release concurrently and binaries may not be uploaded yet (the original failure: binary download attempted 6s after release creation, but binaries weren't uploaded until 63s later). Plugins are downloaded from `TrianaLab/pacto-plugins` releases (independent release cycle, no race).

- **Contract publishing fix**: Add `workflow_run` trigger so the `publish` job fires when auto-release completes. Previously, the `release: published` event from auto-release never reached this workflow because GitHub prevents `GITHUB_TOKEN`-triggered events from firing other workflows (infinite loop prevention). The publish job now resolves the release tag dynamically via `gh release view`.

- **`v1.7.0` → `v1` pin**: Use the major version tag for `pacto-actions` to automatically pick up patch/minor updates.

## Root cause analysis

1. PR merge → push to main triggers **both** `Auto release` and `Pacto Contract CI` concurrently
2. `Auto release` creates the GitHub release (tag + release page) first, then builds binaries in a separate job
3. `Pacto Contract CI` calls `pacto-actions@v1 setup` which runs `get-pacto.sh`, detects the new release tag, and tries to download the binary — but it doesn't exist yet (uploaded ~60s later)
4. Rerun worked because by then the binaries had been uploaded
5. Publishing was skipped because `publish` only ran on `release` events, which never fire from `GITHUB_TOKEN`-triggered releases