### PR TITLE
fix(ci): remove branches filter blocking contract publish

### DIFF
--- a/.github/workflows/pacto.yml
+++ b/.github/workflows/pacto.yml
@@ -15,7 +15,6 @@ on:
   workflow_run:
     workflows: ['Auto release']
     types: [completed]
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- The `workflow_run` trigger's `branches: [main]` filter evaluates against the PR's **head branch**, not `main`, so it never matched and the publish job never ran
- Removing the filter allows `pacto.yml` to trigger when `auto-release.yml` completes