### PR TITLE
fix(docs): add table of contents to dashboard container page

### DIFF
--- a/docs/dashboard-docker.md
+++ b/docs/dashboard-docker.md
@@ -1,10 +1,19 @@
 ---
 layout: default
 title: Dashboard Container
-nav_order: 8
+nav_order: 7.5
 ---
 
 # Dashboard Container
+{: .no_toc }
+
+---
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+- TOC
+{:toc}
+</details>
 
 The Pacto dashboard is published as a container image for production and Kubernetes deployments.
 


### PR DESCRIPTION
## Summary

- Add table of contents block to `docs/dashboard-docker.md` to align with other documentation pages
- Fix `nav_order` to avoid conflict with github-actions page (both were 8)

## Test plan

- [x] Docs page renders correctly with TOC