### PR TITLE
fix(dashboard): improve autoreload UX, fix config schema, add version badge

### DIFF
--- a/docs/dashboard-docker.md
+++ b/docs/dashboard-docker.md
@@ -191,6 +191,6 @@ spec:
 
 ## Build and Release
 
-The dashboard image is built and published automatically when a new Pacto version is released. The dedicated pipeline (`.github/workflows/dashboard-image.yml`) builds multi-architecture images (`linux/amd64`, `linux/arm64`) and pushes to `ghcr.io/trianalab/pacto-dashboard` with the matching version tag.
+The dashboard image is built and published automatically when a new Pacto version is released. The `docker` job in the auto-release pipeline (`.github/workflows/auto-release.yml`) builds multi-architecture images (`linux/amd64`, `linux/arm64`) and pushes to `ghcr.io/trianalab/pacto-dashboard` with the matching version tag (without `v` prefix).
 
 The image version always matches the Pacto CLI version. There is no separate versioning scheme for the dashboard container.

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -8,15 +8,7 @@ nav_order: 11
 {: .no_toc }
 
 {: .warning }
-This page covers the operator's design and integration with Pacto core. For installation, configuration, and development instructions, see the [pacto-operator repository](https://github.com/TrianaLab/pacto-operator).
-
----
-
-<details open markdown="block">
-  <summary>Table of contents</summary>
-- TOC
-{:toc}
-</details>
+The operator is under active development. For up-to-date installation, configuration, and usage instructions, see the [pacto-operator repository](https://github.com/TrianaLab/pacto-operator).
 
 ---
 
@@ -25,43 +17,6 @@ This page covers the operator's design and integration with Pacto core. For inst
 The [Pacto Operator](https://github.com/TrianaLab/pacto-operator) is a Kubernetes controller that continuously reconciles Pacto contracts against live cluster state. It bridges the gap between **build-time contract validation** (what `pacto validate` does) and **runtime compliance** (whether the deployed service matches its contract).
 
 The operator watches for `Pacto` custom resources in the cluster, pulls the referenced contract from an OCI registry, and compares the contract's declared state against the actual Kubernetes resources.
-
----
-
-## CRDs
-
-The operator introduces two Custom Resource Definitions in the `pacto.trianalab.io` API group:
-
-| CRD | Description |
-|-----|-------------|
-| **Pacto** | Binds a contract (from OCI or inline) to a Kubernetes workload and continuously validates compliance |
-| **PactoRevision** | Immutable snapshot of a resolved contract version, created automatically by the operator |
-
----
-
-## What it checks
-
-The operator validates the following aspects of a deployed service against its contract:
-
-| Check | Description |
-|-------|-------------|
-| **Service existence** | A Kubernetes Service matching the contract name exists |
-| **Workload existence** | A Deployment or StatefulSet matching the contract name exists |
-| **Port matching** | Declared interface ports match the ports exposed by the Kubernetes Service |
-| **Endpoint health** | Health and metrics endpoints are reachable and return expected status codes |
-| **Contract validity** | The contract itself passes structural, cross-field, and semantic validation |
-
-### What it does NOT yet check
-
-The operator does not currently validate:
-
-- **State model compliance** — whether a stateful service is deployed as a StatefulSet with PVCs
-- **Scaling bounds** — whether HPA min/max matches contract scaling constraints
-- **Upgrade strategy** — whether the deployment strategy matches `runtime.lifecycle.upgradeStrategy`
-- **Configuration values** — whether environment variables satisfy the configuration schema
-- **Dependency availability** — whether declared dependencies are reachable
-
-These checks are planned for future releases.
 
 ---
 
@@ -80,35 +35,16 @@ Build time                          Runtime
 └──────────────────────┘            └────────────────────────────┘
 ```
 
-The operator produces structured status fields on the `Pacto` CRD:
-
-- **Phase** — `Healthy`, `Degraded`, `Invalid`, or `Reference` (contract-only, no workload target)
-- **Conditions** — standard Kubernetes conditions with transition timestamps
-- **Checks summary** — passed/total/failed check counts
-
 ---
 
 ## Dashboard integration
 
-When `pacto dashboard` detects a Kubernetes cluster with the Pacto CRD installed, it automatically uses the operator's status data as the **k8s** source. This provides:
-
-- **Live phase status** from operator reconciliation (Healthy, Degraded, Invalid)
-- **Conditions** with last transition times
-- **Endpoint health** results (HTTP status codes, latency, errors)
-- **Resource existence** checks (Service, Deployment/StatefulSet)
-- **Port matching** results (expected vs observed ports)
-
-Services with phase `Reference` (contracts without a workload target) appear as **Unmonitored** in the dashboard — they are valid contracts used as shared definitions or dependency references.
+When `pacto dashboard` detects a Kubernetes cluster with the Pacto CRD installed, it automatically uses the operator's status data as the **k8s** source. This provides live phase status, conditions, endpoint health results, and resource existence checks directly in the dashboard.
 
 ---
 
-## For platform engineers
+## Learn more
 
-The operator fits into the platform engineering workflow as the runtime enforcement layer:
+For CRD definitions, installation, configuration, and development instructions, see the [pacto-operator repository](https://github.com/TrianaLab/pacto-operator).
 
-1. **Developers** write contracts and push them to an OCI registry
-2. **Platform teams** create `Pacto` CRDs that bind contracts to workloads
-3. **The operator** continuously validates compliance and surfaces issues via CRD status
-4. **The dashboard** aggregates operator data with OCI and local sources for a unified view
-
-See [For Platform Engineers]({{ site.baseurl }}{% link platform-engineers.md %}) for the full platform workflow, and the [pacto-operator repository](https://github.com/TrianaLab/pacto-operator) for installation and configuration.
+See [For Platform Engineers]({{ site.baseurl }}{% link platform-engineers.md %}) for the full platform workflow.

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -16,7 +16,7 @@ import (
 	"github.com/trianalab/pacto/pkg/dashboard"
 )
 
-func newDashboardCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
+func newDashboardCommand(svc *app.Service, v *viper.Viper, version string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dashboard [dir]",
 		Short: "Start a local web dashboard for exploring service contracts",
@@ -99,6 +99,7 @@ Services are grouped by name across sources and merged using priority rules:
 				diag = detectResult.Diagnostics
 			}
 			server := dashboard.NewAggregatedServer(aggregated, uiFS, detectResult.Sources, diag)
+			server.SetVersion(version)
 			server.SetListenAddr(host, port)
 
 			// Enable lazy resolution of remote OCI dependencies when a BundleStore is available.

--- a/internal/cli/dashboard_internal_test.go
+++ b/internal/cli/dashboard_internal_test.go
@@ -56,7 +56,7 @@ func TestNewDashboardCommand_NoSources(t *testing.T) {
 
 	svc := app.NewService(nil, nil)
 	v := viper.New()
-	cmd := newDashboardCommand(svc, v)
+	cmd := newDashboardCommand(svc, v, "test")
 	cmd.SetArgs([]string{"/nonexistent/empty/dir"})
 	var errBuf bytes.Buffer
 	cmd.SetErr(&errBuf)
@@ -87,7 +87,7 @@ service:
 
 	svc := app.NewService(dummyStore{}, nil)
 	v := viper.New()
-	cmd := newDashboardCommand(svc, v)
+	cmd := newDashboardCommand(svc, v, "test")
 	cmd.SetArgs([]string{dir, "--port", "0", "--diagnostics"})
 
 	var outBuf, errBuf bytes.Buffer
@@ -134,7 +134,7 @@ service:
 
 	svc := app.NewService(nil, nil)
 	v := viper.New()
-	cmd := newDashboardCommand(svc, v)
+	cmd := newDashboardCommand(svc, v, "test")
 	cmd.SetArgs([]string{"--port", "0"}) // no dir arg
 
 	var errBuf bytes.Buffer
@@ -159,7 +159,7 @@ func TestNewDashboardCommand_NoSourcesDetails(t *testing.T) {
 
 	svc := app.NewService(nil, nil)
 	v := viper.New()
-	cmd := newDashboardCommand(svc, v)
+	cmd := newDashboardCommand(svc, v, "test")
 	cmd.SetArgs([]string{emptyDir})
 
 	// Ensure no K8s client can be created.
@@ -196,7 +196,7 @@ func TestNewDashboardCommand_RepoEnvVar(t *testing.T) {
 
 	svc := app.NewService(dummyStore{}, nil)
 	v := viper.New()
-	cmd := newDashboardCommand(svc, v)
+	cmd := newDashboardCommand(svc, v, "test")
 	cmd.SetArgs([]string{emptyDir, "--port", "0"})
 
 	var errBuf bytes.Buffer
@@ -224,7 +224,7 @@ func TestNewDashboardCommand_RepoFlagOverridesEnv(t *testing.T) {
 
 	svc := app.NewService(dummyStore{}, nil)
 	v := viper.New()
-	cmd := newDashboardCommand(svc, v)
+	cmd := newDashboardCommand(svc, v, "test")
 	cmd.SetArgs([]string{emptyDir, "--port", "0", "--repo", "ghcr.io/org/from-flag"})
 
 	var errBuf bytes.Buffer
@@ -257,7 +257,7 @@ service:
 
 	svc := app.NewService(dummyStore{}, nil)
 	v := viper.New()
-	cmd := newDashboardCommand(svc, v)
+	cmd := newDashboardCommand(svc, v, "test")
 	cmd.SetArgs([]string{dir, "--port", "0", "--host", "0.0.0.0"})
 
 	var errBuf bytes.Buffer
@@ -280,7 +280,7 @@ service:
 func TestNewDashboardCommand_DefaultFlags(t *testing.T) {
 	svc := app.NewService(nil, nil)
 	v := viper.New()
-	cmd := newDashboardCommand(svc, v)
+	cmd := newDashboardCommand(svc, v, "test")
 
 	// Verify default flag values
 	host, _ := cmd.Flags().GetString("host")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -120,7 +120,7 @@ func NewRootCommand(svc *app.Service, info VersionInfo) *cobra.Command {
 	root.AddCommand(newVersionCommand(info))
 	root.AddCommand(newUpdateCommand(info.Version))
 	root.AddCommand(newMCPCommand(svc, info.Version))
-	root.AddCommand(newDashboardCommand(svc, v))
+	root.AddCommand(newDashboardCommand(svc, v, info.Version))
 
 	return root
 }

--- a/pkg/dashboard/config.go
+++ b/pkg/dashboard/config.go
@@ -11,13 +11,16 @@ import (
 // the dashboard server. Huma's schema registry generates a JSON Schema from
 // this struct, including defaults and descriptions via struct tags.
 type DashboardConfig struct {
-	Host        string `json:"PACTO_DASHBOARD_HOST" default:"127.0.0.1" doc:"Bind address for the dashboard server"`
-	Port        int    `json:"PACTO_DASHBOARD_PORT" default:"3000" doc:"HTTP port for the dashboard server"`
-	Namespace   string `json:"PACTO_DASHBOARD_NAMESPACE" default:"" doc:"Kubernetes namespace filter (empty = all)"`
-	Repo        string `json:"PACTO_DASHBOARD_REPO" default:"" doc:"Comma-separated OCI repositories to scan"`
-	Diagnostics bool   `json:"PACTO_DASHBOARD_DIAGNOSTICS" default:"false" doc:"Enable diagnostics debug endpoints"`
-	NoCache     bool   `json:"PACTO_NO_CACHE" default:"false" doc:"Disable OCI bundle cache"`
-	Verbose     bool   `json:"PACTO_VERBOSE" default:"false" doc:"Enable verbose logging"`
+	Host             string `json:"PACTO_DASHBOARD_HOST" default:"127.0.0.1" doc:"Bind address for the server"`
+	Port             int    `json:"PACTO_DASHBOARD_PORT" default:"3000" doc:"HTTP server port"`
+	Namespace        string `json:"PACTO_DASHBOARD_NAMESPACE,omitempty" doc:"Kubernetes namespace filter (empty = all)"`
+	Repo             string `json:"PACTO_DASHBOARD_REPO,omitempty" doc:"Comma-separated OCI repositories to scan"`
+	Diagnostics      bool   `json:"PACTO_DASHBOARD_DIAGNOSTICS" default:"false" doc:"Enable source diagnostics panel"`
+	NoCache          bool   `json:"PACTO_NO_CACHE" default:"false" doc:"Disable OCI bundle caching"`
+	NoUpdateCheck    bool   `json:"PACTO_NO_UPDATE_CHECK" default:"false" doc:"Disable update checks"`
+	RegistryUsername string `json:"PACTO_REGISTRY_USERNAME,omitempty" doc:"Registry authentication username"`
+	RegistryPassword string `json:"PACTO_REGISTRY_PASSWORD,omitempty" doc:"Registry authentication password"`
+	RegistryToken    string `json:"PACTO_REGISTRY_TOKEN,omitempty" doc:"Registry authentication token"`
 }
 
 // ExportConfigSchema generates a JSON Schema for DashboardConfig using Huma's

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -26,6 +26,7 @@ type Server struct {
 	sourceInfo  []SourceInfo
 	diagnostics *SourceDiagnostics
 	listenAddr  string // optional: server URL for OpenAPI spec
+	version     string // optional: Pacto version to expose via /health
 
 	// Cached service index for scan-heavy endpoints (dependents, cross-refs, graph).
 	indexMu    sync.Mutex
@@ -319,7 +320,8 @@ func ExportOpenAPI() ([]byte, error) {
 
 type healthOutput struct {
 	Body struct {
-		Status string `json:"status" example:"ok" doc:"Health status"`
+		Status  string `json:"status" example:"ok" doc:"Health status"`
+		Version string `json:"version,omitempty" example:"1.2.3" doc:"Pacto version"`
 	}
 }
 
@@ -441,9 +443,15 @@ type debugServiceEntry struct {
 
 // ── Huma operation handlers ─────────────────────────────────────────
 
+// SetVersion sets the Pacto version exposed by the health endpoint.
+func (s *Server) SetVersion(v string) {
+	s.version = v
+}
+
 func (s *Server) health(_ context.Context, _ *struct{}) (*healthOutput, error) {
 	out := &healthOutput{}
 	out.Body.Status = "ok"
+	out.Body.Version = s.version
 	return out, nil
 }
 

--- a/pkg/dashboard/server_test.go
+++ b/pkg/dashboard/server_test.go
@@ -1340,7 +1340,18 @@ func TestServerDebugServices_PerSourceError(t *testing.T) {
 
 func TestServerHealth(t *testing.T) {
 	source := &mockSource{services: []Service{}}
-	base := startTestServer(t, source)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ui := fstest.MapFS{"index.html": &fstest.MapFile{Data: []byte("<html></html>")}}
+	srv := NewServer(source, ui)
+	srv.SetVersion("1.2.3")
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = srv.ServeOnListener(ctx, ln) }()
+	time.Sleep(50 * time.Millisecond)
+	base := "http://" + ln.Addr().String()
 
 	resp, err := http.Get(base + "/health")
 	if err != nil {
@@ -1358,6 +1369,9 @@ func TestServerHealth(t *testing.T) {
 	}
 	if body["status"] != "ok" {
 		t.Errorf("expected status 'ok', got %v", body["status"])
+	}
+	if body["version"] != "1.2.3" {
+		t.Errorf("expected version '1.2.3', got %v", body["version"])
 	}
 }
 
@@ -1474,7 +1488,7 @@ func TestExportConfigSchema(t *testing.T) {
 		t.Errorf("title = %v", schema["title"])
 	}
 	props, _ := schema["properties"].(map[string]any)
-	for _, key := range []string{"PACTO_DASHBOARD_HOST", "PACTO_DASHBOARD_PORT", "PACTO_DASHBOARD_NAMESPACE", "PACTO_DASHBOARD_REPO", "PACTO_DASHBOARD_DIAGNOSTICS", "PACTO_NO_CACHE", "PACTO_VERBOSE"} {
+	for _, key := range []string{"PACTO_DASHBOARD_HOST", "PACTO_DASHBOARD_PORT", "PACTO_DASHBOARD_NAMESPACE", "PACTO_DASHBOARD_REPO", "PACTO_DASHBOARD_DIAGNOSTICS", "PACTO_NO_CACHE", "PACTO_NO_UPDATE_CHECK", "PACTO_REGISTRY_USERNAME", "PACTO_REGISTRY_PASSWORD", "PACTO_REGISTRY_TOKEN"} {
 		if props[key] == nil {
 			t.Errorf("missing property %s", key)
 		}
@@ -1483,7 +1497,7 @@ func TestExportConfigSchema(t *testing.T) {
 	if port["default"] != float64(3000) {
 		t.Errorf("port default = %v", port["default"])
 	}
-	if port["description"] != "HTTP port for the dashboard server" {
+	if port["description"] != "HTTP server port" {
 		t.Errorf("port description = %v", port["description"])
 	}
 }

--- a/pkg/dashboard/ui/app.js
+++ b/pkg/dashboard/ui/app.js
@@ -4,6 +4,14 @@ var state = { view: 'list', service: null, tab: 'overview', services: [], detail
 // getSources extracts the sources array from a service entry.
 function getSources(svc) { return (svc.sources || [svc.source]).filter(Boolean); }
 
+/* ── Version badge ─── */
+fetch('/health').then(function(r) { return r.json(); }).then(function(d) {
+  if (d.version) {
+    var el = document.querySelector('.topbar-logo');
+    if (el) { var badge = document.createElement('span'); badge.className = 'version-badge'; badge.textContent = d.version; el.appendChild(badge); }
+  }
+}).catch(function() {});
+
 /* ── API ─── */
 var api = {
   get: function(p) { return fetch('/api' + p).then(function(r) { if (!r.ok) { var err = new Error('API ' + r.status); err.status = r.status; throw err; } return r.json(); }); },
@@ -195,11 +203,8 @@ function stopAutoReload() { if (autoReloadTimer) { clearInterval(autoReloadTimer
 function doRefresh() {
   var btn = document.getElementById('reload-btn');
   if (btn) { btn.classList.add('spinning'); setTimeout(function() { btn.classList.remove('spinning'); }, 600); }
-  // Clear cached state so all sources are re-fetched from the server.
-  overviewLoaded = false;
-  state.details = {};
-  state.versions = {};
-  state.aggregated = {};
+  // Re-render without clearing cached state — the render functions
+  // detect existing data and refresh in the background seamlessly.
   render();
 }
 updateAutoReloadUI();

--- a/pkg/dashboard/ui/styles.css
+++ b/pkg/dashboard/ui/styles.css
@@ -91,6 +91,7 @@ code{font-family:var(--font-mono);font-size:var(--text-xs);background:var(--bg-i
 .topbar-left{display:flex;align-items:center;gap:24px;flex-shrink:0;}
 .topbar-logo{font-size:15px;font-weight:700;letter-spacing:-0.03em;color:var(--text);display:flex;align-items:center;gap:6px;cursor:pointer;}
 .topbar-logo-icon{width:18px;height:18px;color:var(--accent);}
+.version-badge{font-size:var(--text-xs);font-weight:400;color:var(--text-dim);margin-left:4px;}
 .topbar-search{position:relative;flex:1;max-width:480px;}
 .topbar-search input{width:100%;padding:6px 12px 6px 34px;border-radius:var(--radius-sm);border:1px solid var(--border);background:var(--bg);color:var(--text);font-size:var(--text-sm);outline:none;transition:border-color var(--transition),box-shadow var(--transition),width var(--transition);}
 .topbar-search input:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-bg);}


### PR DESCRIPTION
## Summary

- **Autoreload UX**: Stop clearing cached state on auto-reload/manual refresh. The UI now renders existing data immediately and fetches updates in the background — no more disruptive Loading spinner every 10 seconds.
- **Config schema**: Update `DashboardConfig` struct (single source of truth) to include all actual runtime env vars (`PACTO_NO_UPDATE_CHECK`, `PACTO_REGISTRY_USERNAME`, `PACTO_REGISTRY_PASSWORD`, `PACTO_REGISTRY_TOKEN`), remove `PACTO_VERBOSE`, and fix descriptions to match docs.
- **Version badge**: Expose Pacto version via `/health` endpoint and display it in the dashboard header next to the logo.
- **Container docs**: Fix Build and Release section to reference `auto-release.yml` instead of non-existent `dashboard-image.yml`.
- **Operator docs**: Simplify to high-level description only, remove implementation details, add reference to the pacto-operator repository.

## Test plan

- [x] All tests pass (`go test ./...`)
- [x] 100.0% coverage maintained
- [x] `go run ./cmd/genbundle config-schema` produces correct schema with all env vars
- [ ] Manual: verify autoreload no longer shows Loading spinner
- [ ] Manual: verify version badge appears in dashboard header

🤖 Generated with [Claude Code](https://claude.com/claude-code)