### PR TITLE
docs(operator): remove under-development warning

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -7,14 +7,13 @@ nav_order: 11
 # Kubernetes Operator
 {: .no_toc }
 
-{: .warning }
-The operator is under active development. For up-to-date installation, configuration, and usage instructions, see the [pacto-operator repository](https://github.com/TrianaLab/pacto-operator).
+For installation, configuration, and usage instructions, see the [pacto-operator repository](https://github.com/trianalab/pacto-operator).
 
 ---
 
 ## What the operator does
 
-The [Pacto Operator](https://github.com/TrianaLab/pacto-operator) is a Kubernetes controller that continuously reconciles Pacto contracts against live cluster state. It bridges the gap between **build-time contract validation** (what `pacto validate` does) and **runtime compliance** (whether the deployed service matches its contract).
+The [Pacto Operator](https://github.com/trianalab/pacto-operator) is a Kubernetes controller that continuously reconciles Pacto contracts against live cluster state. It bridges the gap between **build-time contract validation** (what `pacto validate` does) and **runtime compliance** (whether the deployed service matches its contract).
 
 The operator watches for `Pacto` custom resources in the cluster, pulls the referenced contract from an OCI registry, and compares the contract's declared state against the actual Kubernetes resources.
 
@@ -45,6 +44,6 @@ When `pacto dashboard` detects a Kubernetes cluster with the Pacto CRD installed
 
 ## Learn more
 
-For CRD definitions, installation, configuration, and development instructions, see the [pacto-operator repository](https://github.com/TrianaLab/pacto-operator).
+For CRD definitions, installation, configuration, and development instructions, see the [pacto-operator repository](https://github.com/trianalab/pacto-operator).
 
 See [For Platform Engineers]({{ site.baseurl }}{% link platform-engineers.md %}) for the full platform workflow.


### PR DESCRIPTION
## Summary
- Remove the "under active development" warning banner from the operator docs — the operator is ready at https://github.com/trianalab/pacto-operator
- Fix GitHub URL casing (`TrianaLab` → `trianalab`) across all links in the page