### PR TITLE
feat(dashboard): K8s-driven OCI discovery and docs overhaul

### DIFF
--- a/cmd/gendocs/main.go
+++ b/cmd/gendocs/main.go
@@ -57,6 +57,7 @@ const footer = `---
 
 | Variable | Description |
 |----------|-------------|
+| ` + "`PACTO_CACHE_DIR`" + ` | Override the OCI bundle cache directory (default: ` + "`~/.cache/pacto/oci`" + `) |
 | ` + "`PACTO_NO_CACHE`" + ` | Set to ` + "`1`" + ` to disable OCI bundle caching (equivalent to ` + "`--no-cache`" + `) |
 | ` + "`PACTO_NO_UPDATE_CHECK`" + ` | Set to ` + "`1`" + ` to disable automatic update checks |
 | ` + "`PACTO_REGISTRY_USERNAME`" + ` | Registry username for authentication |
@@ -133,9 +134,25 @@ Sibling dependencies are resolved in parallel. OCI bundles are cached locally in
 		"- Using `--output-format json`\n" +
 		"- The `PACTO_NO_UPDATE_CHECK=1` environment variable is set",
 
-	"dashboard": "Sources are auto-detected at startup and resolved using a contract-first model. " +
+	"dashboard": "The dashboard is the exploration and observability layer of the Pacto system. " +
+		"It visualizes the same contracts the CLI manages and the operator verifies — " +
+		"making dependency graphs, version history, interfaces, configuration schemas, and diffs accessible in one place.\n\n" +
+		"### What the dashboard shows\n\n" +
+		"- **Dependency graphs** — interactive D3 visualization of service relationships, with impact chain highlighting\n" +
+		"- **Version history** — all available versions from OCI, with the ability to fetch and cache every version\n" +
+		"- **Interface details** — OpenAPI endpoints, gRPC definitions, event schemas extracted from contract bundles\n" +
+		"- **Configuration schemas** — JSON Schema properties for environment variables and settings\n" +
+		"- **Policy references** — organizational standards enforcement via referenced policy contracts\n" +
+		"- **Diffs between versions** — classified changes (breaking, non-breaking, potential) between any two versions\n" +
+		"- **Runtime compliance** — when Kubernetes is available, live phase, conditions, endpoint health, and contract-vs-runtime comparison\n\n" +
+		"### Contract-first resolution\n\n" +
+		"Sources are resolved using a contract-first model. " +
 		"Contract sources (`local`, `oci`) provide the authoritative service definition — exactly one contract snapshot wins per service, with `local` taking priority over `oci`. " +
 		"The runtime source (`k8s`) enriches the contract with live cluster state (phase, conditions, endpoints) but never overrides contract content.\n\n" +
+		"### Kubernetes + OCI hybrid view\n\n" +
+		"When running alongside the Kubernetes operator (no `--repo` flags needed), the dashboard automatically discovers OCI repositories from the `imageRef` fields in Pacto CRD statuses. " +
+		"This means a K8s-only dashboard deployment gets the full contract experience: version history, interface details, configuration schemas, and diffs — " +
+		"all loaded from OCI and merged with runtime state from the operator.\n\n" +
 		"### Dependency resolution\n\n" +
 		"When OCI repository names differ from contract service names (e.g., repo `my-service-pacto` but contract has `service.name: my-service`), " +
 		"the dashboard automatically builds a ref-alias map from `imageRef` and `chartRef` fields so that dependency links, graph edges, " +

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,18 +143,19 @@ Out-of-process plugin execution via JSON stdin/stdout. Discovers plugin binaries
 
 ### `pkg/dashboard` -- Dashboard server
 
-Provides a web-based dashboard for visualizing and exploring service contracts. Auto-detects available data sources (Kubernetes, OCI cache, local filesystem) and aggregates them into a unified view.
+The exploration and observability layer of the Pacto system. Provides a web-based dashboard for navigating contracts, dependency graphs, version history, interface details, configuration schemas, and diffs. Auto-detects available data sources and merges them into a unified view.
 
 - Multi-source architecture: `DataSource` interface implemented by `K8sSource`, `CacheSource`, `LocalSource`, `OCISource`
-- `AggregatedSource` merges sources with priority: Kubernetes (runtime) > local (contract) > OCI/cache (baseline)
+- Contract-first resolution: `ResolvedSource` separates contract sources (local, OCI) from runtime sources (k8s). Contract sources provide the authoritative service definition; runtime sources enrich with live cluster state but never override contract content
+- K8s-driven OCI discovery: when running alongside the Kubernetes operator, `EnrichFromK8s()` automatically discovers OCI repositories from CRD `imageRef` fields — enabling full contract bundles, version history, and diffs without explicit `--repo` flags
 - `CachedDataSource` wraps any source with in-memory TTL caching (source-type-prefixed keys to prevent cross-source collision)
 - Phase normalization: `NormalizePhase()` maps non-standard operator phases (e.g. `Progressing`) to the five canonical dashboard phases (`Healthy`, `Degraded`, `Invalid`, `Unknown`, `Reference`)
 - Graph building: `buildGlobalGraph()` constructs a flat D3-ready graph from the service index; `buildGraph()` builds a per-service dependency tree. Ref-alias mapping resolves OCI repo names (e.g. `my-service-pacto`) to contract service names (e.g. `my-service`)
 - Cross-references: config/policy OCI refs are surfaced as reference edges (dashed lines) distinct from dependency edges (solid lines)
-- Compliance engine: `ComputeCompliance()` derives OK/WARNING/ERROR/REFERENCE status and percentage score from phase and conditions; `ComputeRuntimeDiff()` builds semantic contract-vs-runtime comparison rows; `LookupValidation()` enriches condition types with category, label, and default severity from a 12-entry catalog
+- Compliance engine: `ComputeCompliance()` derives OK/WARNING/ERROR/REFERENCE status and percentage score from phase and conditions; `ComputeRuntimeDiff()` builds semantic contract-vs-runtime comparison rows
 - REST API built on [Huma v2](https://huma.rocks/) with typed I/O structs, OpenAPI 3.1 spec generation, and `/docs` endpoint; static files and CORS remain on the raw mux
 - Embedded SPA with D3.js force-directed graph, source/status/search filtering, service detail pages with tabs (Interfaces, Config, Policy, Validations, Contract vs Runtime, Observed Runtime), compliance badges/scores, and diff view
-- REST API: `/api/services`, `/api/services/{name}`, `/api/services/{name}/versions`, `/api/services/{name}/sources`, `/api/services/{name}/dependents`, `/api/services/{name}/graph`, `/api/graph`, `/api/diff`, `/api/sources`, `/health`, `/metrics`
+- REST API: `/api/services`, `/api/services/{name}`, `/api/services/{name}/versions`, `/api/services/{name}/sources`, `/api/services/{name}/dependents`, `/api/services/{name}/graph`, `/api/graph`, `/api/diff`, `/api/sources`, `/api/resolve`, `/api/versions`, `/health`, `/metrics`
 
 ### `internal/app` -- Application services
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -45,18 +45,29 @@ Non-semver tags (e.g. `latest`, `main`) are ignored during resolution. Digest-pi
 
 ## `pacto dashboard`
 
-Launches a read-only web dashboard on localhost that aggregates data from
-all available sources (local filesystem, Kubernetes, OCI registries, disk cache).
+Launches a contract exploration dashboard that aggregates data from all
+available sources (local filesystem, Kubernetes, OCI registries, disk cache).
+
+The dashboard is the exploration and observability layer of the Pacto system.
+It visualizes the same contracts the CLI manages and the operator verifies —
+dependency graphs, version history, interfaces, configuration schemas, diffs,
+and runtime compliance — in a single unified view.
 
 Sources are auto-detected at startup:
   - local: enabled if pacto.yaml is found in the working directory
   - k8s:   enabled if a valid kubeconfig is found and the cluster is reachable
-  - oci:   enabled if --repo is specified and the OCI client is configured
+  - oci:   enabled if --repo is specified, or auto-discovered from K8s imageRefs
   - cache: enabled if ~/.cache/pacto/oci contains cached bundles
 
+When running alongside the Kubernetes operator, OCI repositories are automatically
+discovered from the imageRef fields of Pacto CRD resources. This provides full
+contract bundles, version history, interfaces, and diffs — without needing
+explicit --repo flags. The result is a hybrid view: runtime truth from the
+operator combined with contract truth from OCI.
+
 Services are grouped by name across sources and merged using priority rules:
-  - Kubernetes for runtime state (phase, resources, ports)
-  - OCI/cache for version history
+  - Kubernetes for runtime state (phase, checks, endpoints)
+  - OCI/cache for contract content and version history
   - Local for in-progress contract changes
 
 ```
@@ -93,7 +104,25 @@ pacto dashboard [dir] [flags]
       --repo stringArray   OCI repository to scan (can be repeated)
 ```
 
-Sources are auto-detected at startup and resolved using a contract-first model. Contract sources (`local`, `oci`) provide the authoritative service definition — exactly one contract snapshot wins per service, with `local` taking priority over `oci`. The runtime source (`k8s`) enriches the contract with live cluster state (phase, conditions, endpoints) but never overrides contract content.
+The dashboard is the exploration and observability layer of the Pacto system. It visualizes the same contracts the CLI manages and the operator verifies — making dependency graphs, version history, interfaces, configuration schemas, and diffs accessible in one place.
+
+### What the dashboard shows
+
+- **Dependency graphs** — interactive D3 visualization of service relationships, with impact chain highlighting
+- **Version history** — all available versions from OCI, with the ability to fetch and cache every version
+- **Interface details** — OpenAPI endpoints, gRPC definitions, event schemas extracted from contract bundles
+- **Configuration schemas** — JSON Schema properties for environment variables and settings
+- **Policy references** — organizational standards enforcement via referenced policy contracts
+- **Diffs between versions** — classified changes (breaking, non-breaking, potential) between any two versions
+- **Runtime compliance** — when Kubernetes is available, live phase, conditions, endpoint health, and contract-vs-runtime comparison
+
+### Contract-first resolution
+
+Sources are resolved using a contract-first model. Contract sources (`local`, `oci`) provide the authoritative service definition — exactly one contract snapshot wins per service, with `local` taking priority over `oci`. The runtime source (`k8s`) enriches the contract with live cluster state (phase, conditions, endpoints) but never overrides contract content.
+
+### Kubernetes + OCI hybrid view
+
+When running alongside the Kubernetes operator (no `--repo` flags needed), the dashboard automatically discovers OCI repositories from the `imageRef` fields in Pacto CRD statuses. This means a K8s-only dashboard deployment gets the full contract experience: version history, interface details, configuration schemas, and diffs — all loaded from OCI and merged with runtime state from the operator.
 
 ### Dependency resolution
 
@@ -625,6 +654,7 @@ pacto version [flags]
 
 | Variable | Description |
 |----------|-------------|
+| `PACTO_CACHE_DIR` | Override the OCI bundle cache directory (default: `~/.cache/pacto/oci`) |
 | `PACTO_NO_CACHE` | Set to `1` to disable OCI bundle caching (equivalent to `--no-cache`) |
 | `PACTO_NO_UPDATE_CHECK` | Set to `1` to disable automatic update checks |
 | `PACTO_REGISTRY_USERNAME` | Registry username for authentication |

--- a/docs/dashboard-docker.md
+++ b/docs/dashboard-docker.md
@@ -15,7 +15,7 @@ nav_order: 7.5
 {:toc}
 </details>
 
-The Pacto dashboard is published as a container image for production and Kubernetes deployments.
+The Pacto dashboard is published as a container image for production and Kubernetes deployments. It provides the same contract exploration experience as the CLI's `pacto dashboard` command — dependency graphs, version history, interfaces, configuration schemas, and diffs — in a deployable container.
 
 ## Image
 
@@ -61,6 +61,7 @@ make docker-run
 | `PACTO_DASHBOARD_NAMESPACE` | Kubernetes namespace filter (empty = all) | `""` |
 | `PACTO_DASHBOARD_REPO` | Comma-separated OCI repositories to scan | `""` |
 | `PACTO_DASHBOARD_DIAGNOSTICS` | Enable source diagnostics panel (`true`) | `false` |
+| `PACTO_CACHE_DIR` | OCI bundle cache directory | `/home/pacto/.cache/pacto/oci` |
 | `PACTO_NO_CACHE` | Disable OCI bundle caching (`1`) | `0` |
 | `PACTO_NO_UPDATE_CHECK` | Disable update checks (`1`) | `1` (set in image) |
 | `PACTO_REGISTRY_USERNAME` | Registry authentication username | `""` |
@@ -73,10 +74,14 @@ All `PACTO_DASHBOARD_*` variables map to the corresponding `--host`, `--port`, `
 
 The dashboard auto-detects available data sources at startup:
 
-- **oci**: Enabled when `PACTO_DASHBOARD_REPO` is set. Scans OCI registries for published contracts.
-- **cache**: Enabled when `~/.cache/pacto/oci/` contains cached bundles. The cache directory is writable inside the container at `/home/pacto/.cache/pacto/oci/`.
-- **k8s**: Enabled when a valid kubeconfig is mounted or when running inside a Kubernetes cluster (in-cluster config).
+- **oci**: Enabled when `PACTO_DASHBOARD_REPO` is set, or **automatically discovered from K8s `imageRef` fields** when the Kubernetes source is active. Scans OCI registries for published contracts — providing full contract bundles, version history, interfaces, and diffs.
+- **cache**: Enabled when the cache directory contains previously pulled bundles. The cache directory is writable inside the container at `/home/pacto/.cache/pacto/oci/` (configurable via `PACTO_CACHE_DIR`).
+- **k8s**: Enabled when a valid kubeconfig is mounted or when running inside a Kubernetes cluster (in-cluster config). Provides runtime state from the [Pacto operator]({{ site.baseurl }}{% link operator.md %}).
 - **local**: Enabled when a `pacto.yaml` is found in the working directory (mount via volume).
+
+### Kubernetes + OCI hybrid mode
+
+When deployed alongside the Pacto operator in Kubernetes, the dashboard automatically discovers OCI repositories from the `imageRef` fields in Pacto CRD statuses — no `PACTO_DASHBOARD_REPO` needed. This creates a hybrid view: **runtime truth from the operator + contract truth from OCI**, giving you version history, interface details, configuration schemas, and diffs for every service the operator manages.
 
 ### Kubernetes Source
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -479,4 +479,4 @@ No contract-level field references the SBOM. Pacto discovers it automatically by
 - **Leverage caching.** OCI bundles are cached locally in `~/.cache/pacto/oci/` and tag listings are cached in memory per command, so repeated `graph`, `doc`, and `diff` commands resolve instantly. Use `--no-cache` to force a fresh pull.
 - **Use `--verbose` for debugging.** Pass `-v` to any command to see debug-level logs (OCI operations, resolution steps, cache hits/misses) on stderr.
 - **Use metadata for organizational context.** Team ownership, on-call channels, and service tiers go in `metadata`.
-- **Explore contracts visually.** Run `pacto dashboard` to launch a local web UI that auto-detects contracts from Kubernetes, OCI cache, and local directories, with an interactive dependency graph, status filtering, and diff viewer.
+- **Explore contracts visually.** Run `pacto dashboard` to launch the contract exploration dashboard — navigate dependency graphs, inspect interfaces, browse version history, compare diffs, and review configuration schemas. It auto-detects contracts from local directories, OCI registries, and Kubernetes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,13 @@ nav_order: 1
 
 Pacto (/ˈpak.to/ — Spanish for *pact*) captures everything a platform needs to know about a service — interfaces, runtime behavior, dependencies, configuration, and scaling — in one YAML file that machines can validate and tooling can consume.
 
-No runtime agents. No sidecars. No new infrastructure. Pacto is a **build-time and CI-time tool** — it produces a validated, immutable description of your service that platforms, pipelines, and AI agents can consume downstream.
+Pacto is a **runtime contract system** made of three complementary pieces:
+
+- **CLI** — author, validate, diff, explain, and publish contracts
+- **Dashboard** — explore contracts, dependency graphs, versions, and diffs visually
+- **Kubernetes Operator** — verify that live runtime remains faithful to the contract
+
+No runtime agents. No sidecars. No new infrastructure. The CLI runs at build time and CI time. The dashboard and operator extend the same contracts into exploration and runtime verification — without duplicating logic or adding moving parts.
 
 ---
 
@@ -140,9 +146,11 @@ Instead of filing tickets, attending meetings, and writing wiki pages, a develop
 1. Developer writes a pacto.yaml alongside their code
 2. pacto validate checks it (structure, cross-references, semantics)
 3. pacto push ships the contract to an OCI registry as a versioned artifact
-4. Platform tooling pulls the contract and uses it to generate manifests,
-   enforce policies, resolve dependency graphs, or detect breaking changes
+4. pacto dashboard explores contracts, graphs, versions, and diffs visually
+5. The Kubernetes operator verifies runtime stays faithful to the contract
 ```
+
+The real value of Pacto appears across the full loop: **author → validate → publish → explore → verify at runtime**. Each piece has a clear responsibility — the CLI manages the contract lifecycle, the dashboard makes contracts observable, and the operator closes the gap between declaration and reality.
 
 ---
 
@@ -197,7 +205,8 @@ Only `pacto.yaml` is required. All other directories are optional — include th
 - **Plugin-based generation** — `pacto generate` invokes out-of-process plugins to produce deployment artifacts from a contract
 - **Rich documentation** — `pacto doc` generates Markdown with architecture diagrams, interface tables, and configuration details
 - **SBOM diffing** — optional SPDX or CycloneDX SBOM inclusion with automatic package-level change detection on `pacto diff`
-- **Web dashboard** — `pacto dashboard` launches a local web UI that auto-detects contracts from Kubernetes, OCI cache, and local directories, with an interactive D3.js dependency graph and diff viewer
+- **Contract exploration dashboard** — `pacto dashboard` launches a web UI for navigating contracts, dependency graphs, version history, interface details, configuration schemas, and diffs across local, OCI, and Kubernetes sources
+- **Runtime fidelity verification** — the optional [Kubernetes Operator]({{ site.baseurl }}{% link operator.md %}) continuously checks that deployed services match their contracts — port alignment, workload existence, health endpoint reachability, and more
 - **AI assistant integration** — `pacto mcp` exposes all contract operations as [MCP](https://modelcontextprotocol.io) tools for Claude, Cursor, and GitHub Copilot
 
 ---
@@ -252,9 +261,11 @@ Consume contracts to generate deployment manifests, enforce policies, detect bre
 ## What Pacto is not
 
 - **Not a deployment tool** — it describes *what* to deploy, not *how*
+- **Not a generic policy engine** — policies validate contract structure, not arbitrary infrastructure rules
+- **Not just a Kubernetes linter** — the operator is one part of the system, not the whole product
 - **Not a registry** — it uses existing OCI registries (GHCR, ECR, ACR, Docker Hub)
-- **Not a service mesh or runtime agent** — the core CLI runs at build time and CI time; the optional [Kubernetes Operator]({{ site.baseurl }}{% link operator.md %}) adds runtime compliance without sidecars
+- **Not a service mesh or runtime agent** — no sidecars, no proxies; the operator watches CRDs, not traffic
 - **Not a replacement for Helm or Terraform** — it complements them as input
 - **Not a service catalog** — it produces the structured data that a catalog (Backstage, Port, Cortex) could consume
 
-Pacto is a **contract standard**. It tells platforms, pipelines, and AI agents what a service *is* so they can decide how to work with it.
+Pacto is a **runtime contract system**. The CLI manages contracts. The dashboard makes them explorable. The operator verifies them at runtime. Together, they tell platforms, pipelines, and AI agents what a service *is* — and whether it still matches what was declared.

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -7,38 +7,128 @@ nav_order: 11
 # Kubernetes Operator
 {: .no_toc }
 
-For installation, configuration, and usage instructions, see the [pacto-operator repository](https://github.com/trianalab/pacto-operator).
+The Pacto Operator is the runtime verification piece of the Pacto system. It continuously checks that deployed services in Kubernetes remain faithful to their contracts.
+
+For installation, configuration, and CRD reference, see the [pacto-operator repository](https://github.com/trianalab/pacto-operator).
 
 ---
 
-## What the operator does
-
-The [Pacto Operator](https://github.com/trianalab/pacto-operator) is a Kubernetes controller that continuously reconciles Pacto contracts against live cluster state. It bridges the gap between **build-time contract validation** (what `pacto validate` does) and **runtime compliance** (whether the deployed service matches its contract).
-
-The operator watches for `Pacto` custom resources in the cluster, pulls the referenced contract from an OCI registry, and compares the contract's declared state against the actual Kubernetes resources.
+<details open markdown="block">
+  <summary>Table of contents</summary>
+- TOC
+{:toc}
+</details>
 
 ---
 
-## How it complements Pacto core
+## Where the operator fits
 
-Pacto core (`pacto validate`, `pacto diff`, `pacto graph`) operates at **build time and CI time** — it validates contracts before they are deployed. The operator extends this to **runtime**:
+Pacto is a system made of three complementary pieces:
+
+| Piece | Responsibility | When it runs |
+|-------|---------------|--------------|
+| **CLI** | Author, validate, diff, explain, publish contracts | Build time / CI |
+| **Dashboard** | Explore contracts, graphs, versions, diffs, interfaces | Any time |
+| **Operator** | Verify runtime matches the contract | Continuously in-cluster |
+
+The CLI and dashboard work with contracts as **declared artifacts** — what a service *should* be. The operator compares those declarations against **observed reality** — what the service *actually is* in a running cluster.
 
 ```
-Build time                          Runtime
-┌──────────────────────┐            ┌────────────────────────────┐
-│  pacto validate      │            │  Pacto Operator            │
-│  pacto diff          │   push     │  - Watches Pacto CRDs      │
-│  pacto push          │ ────────>  │  - Pulls contracts from OCI│
-│  pacto graph         │            │  - Validates against live   │
-│                      │            │    cluster state            │
-└──────────────────────┘            └────────────────────────────┘
+author → validate → publish → explore → verify at runtime
+  CLI      CLI        CLI    dashboard     operator
 ```
+
+---
+
+## What "runtime fidelity" means
+
+Runtime fidelity is the degree to which a deployed service matches its Pacto contract. The operator measures this by:
+
+1. Loading the contract from OCI (or inline in the CRD)
+2. Associating it with a target workload in the cluster
+3. Comparing declared contract fields against observed Kubernetes state
+4. Reporting the result as structured status on the `Pacto` CRD
+
+The operator does **not** modify workloads, restart pods, or change any cluster state. It is purely observational — it tells you whether reality matches the contract, and where it diverges.
+
+---
+
+## What the operator validates today
+
+The operator checks runtime alignment across these dimensions:
+
+| Check | What it compares |
+|-------|-----------------|
+| **Service existence** | Does a Kubernetes Service exist for the declared service? |
+| **Workload existence** | Does a Deployment, StatefulSet, or Job exist matching the declared workload type? |
+| **Port alignment** | Do the ports exposed by the Kubernetes Service match the ports declared in the contract's interfaces? Reports missing and unexpected ports. |
+| **Workload kind** | Does the observed workload kind (Deployment/StatefulSet) match the declared `runtime.workload` + `runtime.state.type`? |
+| **Container image** | Does the running container image match the contract's `imageRef`? |
+| **Upgrade strategy** | Does the Deployment/StatefulSet strategy match `runtime.lifecycle.upgradeStrategy`? |
+| **Graceful shutdown** | Does `terminationGracePeriodSeconds` match `runtime.lifecycle.gracefulShutdownSeconds`? |
+| **State model** | Does the observed storage (PVCs, emptyDir) align with `runtime.state.persistence`? |
+| **Health endpoint** | Is the declared `runtime.health.path` reachable and returning a healthy response? |
+| **Metrics endpoint** | Is the declared `runtime.metrics.path` reachable? |
+| **Scaling** | Do actual replica counts align with declared `scaling.min` / `scaling.max` / `scaling.replicas`? |
+
+Each check produces a structured condition on the CRD status with a type, status, reason, and severity. The operator aggregates these into a phase:
+
+- **Healthy** — all checks pass
+- **Degraded** — some checks fail (warnings or errors)
+- **Invalid** — the contract itself has validation errors
+- **Reference** — no target workload (the contract is a shared definition, not a deployed service)
+
+{: .warning }
+> The operator does **not** currently validate:
+> - Full OpenAPI conformance of live endpoints (it checks reachability, not response schemas)
+> - JSON Schema validation of live configuration values
+> - Dependency compatibility semantics (whether transitive deps satisfy version constraints)
+> - Policy schema enforcement at runtime
+>
+> These are potential future directions. Today, contract-level validation of these fields happens at build time via `pacto validate`.
+
+---
+
+## What the operator is NOT
+
+- **Not the authoring surface** — contracts are authored with the CLI (`pacto init`, `pacto validate`, `pacto push`). The operator consumes them.
+- **Not the diff engine** — version comparison and breaking change detection happen in the CLI and dashboard. The operator reports current state, not historical changes.
+- **Not the whole system** — the operator is valuable because it closes the loop. But without the CLI to author and publish contracts, and without the dashboard to explore them, it is just one piece.
+- **Not a deployment tool** — it never creates, modifies, or deletes workloads. It observes.
+- **Not a generic Kubernetes drift detector** — it specifically checks contract-declared fields. It does not monitor arbitrary resource drift.
 
 ---
 
 ## Dashboard integration
 
-When `pacto dashboard` detects a Kubernetes cluster with the Pacto CRD installed, it automatically uses the operator's status data as the **k8s** source. This provides live phase status, conditions, endpoint health results, and resource existence checks directly in the dashboard.
+When `pacto dashboard` detects a Kubernetes cluster with the Pacto CRD installed, it uses the operator's status data as the **k8s** runtime source. This provides:
+
+- Live phase status (Healthy / Degraded / Invalid / Reference)
+- Reconciliation conditions with timestamps
+- Endpoint health and metrics reachability results
+- Resource existence checks (Service, Workload)
+- Port alignment details (expected vs. observed)
+- Observed runtime state (workload kind, strategy, images, storage)
+- Contract-vs-runtime comparison rows
+
+The dashboard also **automatically discovers OCI repositories** from the `imageRef` fields in Pacto CRD statuses. This means when the dashboard runs in Kubernetes (e.g., as a Deployment alongside the operator), it can load full contract bundles from OCI — providing version history, interface details, configuration schemas, and diffs — without needing explicit `--repo` flags.
+
+The result is a hybrid view: **runtime truth from the operator + contract truth from OCI**, merged in one place.
+
+See [Dashboard Container]({{ site.baseurl }}{% link dashboard-docker.md %}) for deployment instructions.
+
+---
+
+## PactoRevision CRDs
+
+The operator creates `PactoRevision` resources to track version history. Each revision records:
+
+- Service name and version
+- OCI source reference
+- Contract hash
+- Timestamp
+
+The dashboard uses these revisions as one input for version history. However, the authoritative source for available versions is the OCI registry — the dashboard queries it directly for the full list of semver tags.
 
 ---
 
@@ -55,5 +145,6 @@ The operator is distributed as a Helm chart:
 
 - **CRD API reference:** [api-reference.md](https://github.com/TrianaLab/pacto-operator/blob/main/docs/api-reference.md)
 - **Repository:** [pacto-operator on GitHub](https://github.com/trianalab/pacto-operator)
-
-See [For Platform Engineers]({{ site.baseurl }}{% link platform-engineers.md %}) for the full platform workflow.
+- **CLI reference:** [CLI Reference]({{ site.baseurl }}{% link cli-reference.md %}) — author and validate contracts before deploying
+- **Dashboard:** [Dashboard Container]({{ site.baseurl }}{% link dashboard-docker.md %}) — explore contracts alongside runtime state
+- **Platform guide:** [For Platform Engineers]({{ site.baseurl }}{% link platform-engineers.md %}) — the full platform workflow

--- a/docs/platform-engineers.md
+++ b/docs/platform-engineers.md
@@ -355,7 +355,15 @@ See [pacto-actions](https://github.com/trianalab/pacto-actions) for full documen
 
 ## Dashboard
 
-`pacto dashboard` launches a local web UI that aggregates contracts from all available data sources into a single view.
+`pacto dashboard` launches the contract exploration dashboard — the same contracts the CLI manages and the operator verifies, visualized as dependency graphs, version history, interface details, configuration schemas, and diffs.
+
+The dashboard is not a separate product with a different model. It is a visualization layer over the same Pacto contracts, designed for:
+
+- Navigating service dependency chains and understanding blast radius
+- Inspecting interfaces (OpenAPI endpoints, gRPC definitions, event schemas)
+- Comparing versions and reviewing classified changes (breaking / non-breaking)
+- Exploring configuration schemas and policy references
+- Monitoring runtime compliance alongside contract content
 
 ### Sources and auto-detection
 
@@ -365,8 +373,10 @@ Sources are auto-detected at startup:
 |--------|--------------|----------|
 | **local** | `pacto.yaml` found in the working directory | In-progress contract changes |
 | **k8s** | Valid kubeconfig found and cluster reachable | Runtime state: phase, conditions, endpoints, resources |
-| **oci** | `--repo` flags provided | Registry versions and contracts |
+| **oci** | `--repo` flags provided, or auto-discovered from K8s `imageRef` fields | Full contract bundles, registry versions, and diffs |
 | **cache** | `~/.cache/pacto/oci` contains cached bundles | Offline baseline from previously pulled contracts |
+
+When running alongside the Kubernetes operator, the dashboard automatically discovers OCI repositories from the `imageRef` fields in Pacto CRD statuses. This means a K8s deployment of the dashboard provides the full contract experience — version history, interface details, configuration schemas, and diffs — without explicit `--repo` flags.
 
 Pass `--no-cache` to disable the cache source entirely (useful when cached data is stale).
 
@@ -421,4 +431,5 @@ Pass `--diagnostics` to enable debug endpoints (`/api/debug/sources`, `/api/debu
 - **Enforce policies.** Publish a policy contract with a JSON Schema that validates contracts against your organizational standards. Services reference it via `policy.ref` — see [policy]({{ site.baseurl }}{% link contract-reference.md %}#policy) in the Contract Reference.
 - **Centralize configuration schemas.** Publish a configuration contract and have services reference it via `configuration.ref` instead of vendoring schemas. See [Configuration Schema Ownership Models]({{ site.baseurl }}{% link contract-reference.md %}#configuration-schema-ownership-models).
 - **Leverage AI assistants.** Pacto contracts are machine-consumable. In addition to CI pipelines and platform controllers, AI assistants can interact with contracts directly through the [MCP interface]({{ site.baseurl }}{% link mcp-integration.md %}) — useful for ad-hoc inspection, dependency analysis, and contract generation.
-- **Deploy the operator for runtime compliance.** The [Kubernetes Operator]({{ site.baseurl }}{% link operator.md %}) continuously reconciles contracts against live cluster state — port mismatches, missing workloads, and endpoint failures are detected automatically and surfaced via structured CRD status fields.
+- **Close the loop with the operator.** The [Kubernetes Operator]({{ site.baseurl }}{% link operator.md %}) continuously verifies that deployed services match their contracts — port alignment, workload existence, health endpoint reachability, and more. Combined with the dashboard, you get a complete view: contract truth from OCI + runtime truth from the operator.
+- **Use the dashboard for contract observability.** Run `pacto dashboard` to explore contracts, dependency graphs, version history, interface details, and diffs. Deploy the [Dashboard Container]({{ site.baseurl }}{% link dashboard-docker.md %}) alongside the operator for a production-ready contract exploration UI.

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -19,18 +19,29 @@ func newDashboardCommand(svc *app.Service, v *viper.Viper, version string) *cobr
 	cmd := &cobra.Command{
 		Use:   "dashboard [dir]",
 		Short: "Start a local web dashboard for exploring service contracts",
-		Long: `Launches a read-only web dashboard on localhost that aggregates data from
-all available sources (local filesystem, Kubernetes, OCI registries, disk cache).
+		Long: `Launches a contract exploration dashboard that aggregates data from all
+available sources (local filesystem, Kubernetes, OCI registries, disk cache).
+
+The dashboard is the exploration and observability layer of the Pacto system.
+It visualizes the same contracts the CLI manages and the operator verifies —
+dependency graphs, version history, interfaces, configuration schemas, diffs,
+and runtime compliance — in a single unified view.
 
 Sources are auto-detected at startup:
   - local: enabled if pacto.yaml is found in the working directory
   - k8s:   enabled if a valid kubeconfig is found and the cluster is reachable
-  - oci:   enabled if --repo is specified and the OCI client is configured
+  - oci:   enabled if --repo is specified, or auto-discovered from K8s imageRefs
   - cache: enabled if ~/.cache/pacto/oci contains cached bundles
 
+When running alongside the Kubernetes operator, OCI repositories are automatically
+discovered from the imageRef fields of Pacto CRD resources. This provides full
+contract bundles, version history, interfaces, and diffs — without needing
+explicit --repo flags. The result is a hybrid view: runtime truth from the
+operator combined with contract truth from OCI.
+
 Services are grouped by name across sources and merged using priority rules:
-  - Kubernetes for runtime state (phase, resources, ports)
-  - OCI/cache for version history
+  - Kubernetes for runtime state (phase, checks, endpoints)
+  - OCI/cache for contract content and version history
   - Local for in-progress contract changes`,
 		Example: `  # Start dashboard with auto-detected sources
   pacto dashboard
@@ -60,14 +71,24 @@ Services are grouped by name across sources and merged using priority rules:
 				dir = "."
 			}
 
+			cacheDir := v.GetString("cache-dir")
+
 			// Auto-detect available sources.
 			detectResult := dashboard.DetectSources(cmd.Context(), dashboard.DetectOptions{
 				Dir:       dir,
 				Namespace: namespace,
 				Repos:     repos,
 				Store:     svc.BundleStore,
+				CacheDir:  cacheDir,
 				NoCache:   noCache,
 			})
+
+			// Auto-discover OCI repos from K8s services when no explicit
+			// repos are specified. This enriches the K8s-only dashboard
+			// with full contract bundles, version history, and diffs.
+			if len(repos) == 0 && svc.BundleStore != nil {
+				detectResult.EnrichFromK8s(cmd.Context(), svc.BundleStore, cacheDir)
+			}
 
 			activeSources := detectResult.ActiveSources()
 			if len(activeSources) == 0 {

--- a/pkg/dashboard/config.go
+++ b/pkg/dashboard/config.go
@@ -16,6 +16,7 @@ type DashboardConfig struct {
 	Namespace        string `json:"PACTO_DASHBOARD_NAMESPACE,omitempty" doc:"Kubernetes namespace filter (empty = all)"`
 	Repo             string `json:"PACTO_DASHBOARD_REPO,omitempty" doc:"Comma-separated OCI repositories to scan"`
 	Diagnostics      bool   `json:"PACTO_DASHBOARD_DIAGNOSTICS" default:"false" doc:"Enable source diagnostics panel"`
+	CacheDir         string `json:"PACTO_CACHE_DIR,omitempty" doc:"OCI bundle cache directory (default: ~/.cache/pacto/oci)"`
 	NoCache          bool   `json:"PACTO_NO_CACHE" default:"false" doc:"Disable OCI bundle caching"`
 	NoUpdateCheck    bool   `json:"PACTO_NO_UPDATE_CHECK" default:"false" doc:"Disable update checks"`
 	RegistryUsername string `json:"PACTO_REGISTRY_USERNAME,omitempty" doc:"Registry authentication username"`

--- a/pkg/dashboard/detect.go
+++ b/pkg/dashboard/detect.go
@@ -338,6 +338,83 @@ func (r *DetectResult) detectCache(cacheDir string) {
 	r.Cache = src
 }
 
+// EnrichFromK8s discovers OCI repository references from K8s service statuses
+// and creates an OCI source when no explicit OCI repos were configured.
+// This enables the dashboard to load full contract bundles from OCI even when
+// started in K8s-only mode (e.g. operator-served dashboard).
+//
+// It also ensures a CacheSource exists so that OCI-pulled bundles can be
+// rescanned at runtime (post-resolve, post-fetch-all).
+func (r *DetectResult) EnrichFromK8s(ctx context.Context, store oci.BundleStore, cacheDir string) {
+	if r.K8s == nil || r.OCI != nil || store == nil {
+		return
+	}
+
+	repos := r.discoverOCIReposFromK8s(ctx)
+	if len(repos) == 0 {
+		return
+	}
+
+	r.detectOCI(store, repos)
+
+	// Ensure a CacheSource exists for post-resolve rescan, even if the cache
+	// directory was empty at detection time.
+	if r.OCI != nil && r.Cache == nil {
+		r.ensureCacheSource(cacheDir)
+	}
+}
+
+// discoverOCIReposFromK8s queries K8s services and extracts unique OCI
+// repository references from their imageRef fields.
+func (r *DetectResult) discoverOCIReposFromK8s(ctx context.Context) []string {
+	services, err := r.K8s.ListServices(ctx)
+	if err != nil {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var repos []string
+
+	for _, svc := range services {
+		d, err := r.K8s.GetService(ctx, svc.Name)
+		if err != nil || d == nil || d.ImageRef == "" {
+			continue
+		}
+		repo := stripTag(d.ImageRef)
+		if repo != "" && !seen[repo] {
+			seen[repo] = true
+			repos = append(repos, repo)
+		}
+	}
+	return repos
+}
+
+// ensureCacheSource creates a CacheSource if one doesn't exist, creating the
+// cache directory if needed. This is required so that bundles pulled by the
+// OCI source can be rescanned at runtime.
+func (r *DetectResult) ensureCacheSource(cacheDir string) {
+	if cacheDir == "" {
+		home, err := userHomeDir()
+		if err != nil {
+			return
+		}
+		xdg := os.Getenv("XDG_CACHE_HOME")
+		if xdg != "" {
+			cacheDir = filepath.Join(xdg, "pacto", "oci")
+		} else {
+			cacheDir = filepath.Join(home, ".cache", "pacto", "oci")
+		}
+	}
+	_ = os.MkdirAll(cacheDir, 0o755)
+	r.Cache = NewCacheSource(cacheDir)
+
+	if r.Diagnostics != nil {
+		r.Diagnostics.Cache.CacheDir = cacheDir
+		r.Diagnostics.Cache.Exists = true
+		r.Diagnostics.Cache.OCIDirExists = true
+	}
+}
+
 // splitNonEmpty splits a string by newlines and returns non-empty trimmed lines.
 func splitNonEmpty(s string) []string {
 	var result []string

--- a/pkg/dashboard/detect_test.go
+++ b/pkg/dashboard/detect_test.go
@@ -669,3 +669,209 @@ func TestDetectCache_DefaultDirNoXDG(t *testing.T) {
 		t.Errorf("expected cache dir %q, got %q", expected, result.Diagnostics.Cache.CacheDir)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// EnrichFromK8s tests
+// ---------------------------------------------------------------------------
+
+func TestEnrichFromK8s_NoK8sSource(t *testing.T) {
+	r := &DetectResult{Diagnostics: &SourceDiagnostics{}}
+	r.EnrichFromK8s(context.Background(), newMockBundleStore(), "")
+	if r.OCI != nil {
+		t.Error("expected nil OCI without K8s source")
+	}
+}
+
+func TestEnrichFromK8s_AlreadyHasOCI(t *testing.T) {
+	r := &DetectResult{
+		Diagnostics: &SourceDiagnostics{},
+		K8s:         NewK8sSource(&mockK8sClient{}, "default", "pactos"),
+		OCI:         NewOCISource(newMockBundleStore(), []string{"ghcr.io/org/svc"}),
+	}
+	r.EnrichFromK8s(context.Background(), newMockBundleStore(), "")
+	// OCI should still be the original one, not overwritten.
+	if len(r.OCI.repos) != 1 || r.OCI.repos[0] != "ghcr.io/org/svc" {
+		t.Error("OCI repos should not change when OCI source already exists")
+	}
+}
+
+func TestEnrichFromK8s_NilStore(t *testing.T) {
+	r := &DetectResult{
+		Diagnostics: &SourceDiagnostics{},
+		K8s:         NewK8sSource(&mockK8sClient{}, "default", "pactos"),
+	}
+	r.EnrichFromK8s(context.Background(), nil, "")
+	if r.OCI != nil {
+		t.Error("expected nil OCI without store")
+	}
+}
+
+func TestEnrichFromK8s_DiscoverRepos(t *testing.T) {
+	// K8s source with services that have imageRefs.
+	k8sData := `{"items": [
+		{"metadata": {"name": "order-svc", "namespace": "default"},
+		 "status": {"phase": "Healthy", "contract": {"serviceName": "order-service", "version": "1.0.0", "imageRef": "ghcr.io/org/order-pacto:1.0.0"}}},
+		{"metadata": {"name": "pay-svc", "namespace": "default"},
+		 "status": {"phase": "Healthy", "contract": {"serviceName": "payment-service", "version": "2.0.0", "imageRef": "ghcr.io/org/payment-pacto:2.0.0"}}},
+		{"metadata": {"name": "no-image", "namespace": "default"},
+		 "status": {"phase": "Healthy", "contract": {"serviceName": "no-image-svc", "version": "1.0.0"}}}
+	]}`
+
+	client := &mockK8sClient{listJSON: []byte(k8sData)}
+	r := &DetectResult{
+		Diagnostics: &SourceDiagnostics{},
+		K8s:         NewK8sSource(client, "", "pactos"),
+	}
+
+	store := newMockBundleStore()
+	cacheDir := t.TempDir()
+	r.EnrichFromK8s(context.Background(), store, cacheDir)
+
+	if r.OCI == nil {
+		t.Fatal("expected OCI source to be created from K8s imageRefs")
+	}
+	// Should have discovered 2 repos (the service without imageRef is skipped).
+	if len(r.OCI.repos) != 2 {
+		t.Errorf("expected 2 repos, got %d: %v", len(r.OCI.repos), r.OCI.repos)
+	}
+	// Cache source should have been created.
+	if r.Cache == nil {
+		t.Error("expected CacheSource to be created")
+	}
+}
+
+func TestEnrichFromK8s_DeduplicatesRepos(t *testing.T) {
+	k8sData := `{"items": [
+		{"metadata": {"name": "svc-a", "namespace": "default"},
+		 "status": {"contract": {"serviceName": "svc-a", "imageRef": "ghcr.io/org/svc-pacto:1.0.0"}}},
+		{"metadata": {"name": "svc-b", "namespace": "default"},
+		 "status": {"contract": {"serviceName": "svc-b", "imageRef": "ghcr.io/org/svc-pacto:2.0.0"}}}
+	]}`
+
+	client := &mockK8sClient{listJSON: []byte(k8sData)}
+	r := &DetectResult{
+		Diagnostics: &SourceDiagnostics{},
+		K8s:         NewK8sSource(client, "", "pactos"),
+	}
+
+	r.EnrichFromK8s(context.Background(), newMockBundleStore(), t.TempDir())
+
+	if r.OCI == nil {
+		t.Fatal("expected OCI source")
+	}
+	// Same repo, different tags — should be deduplicated.
+	if len(r.OCI.repos) != 1 {
+		t.Errorf("expected 1 deduplicated repo, got %d: %v", len(r.OCI.repos), r.OCI.repos)
+	}
+}
+
+func TestEnrichFromK8s_K8sListError(t *testing.T) {
+	client := &mockK8sClient{listErr: fmt.Errorf("k8s unavailable")}
+	r := &DetectResult{
+		Diagnostics: &SourceDiagnostics{},
+		K8s:         NewK8sSource(client, "", "pactos"),
+	}
+
+	r.EnrichFromK8s(context.Background(), newMockBundleStore(), "")
+	if r.OCI != nil {
+		t.Error("expected nil OCI when K8s list fails")
+	}
+}
+
+func TestEnrichFromK8s_NoImageRefs(t *testing.T) {
+	k8sData := `{"items": [
+		{"metadata": {"name": "svc", "namespace": "default"},
+		 "status": {"phase": "Healthy", "contract": {"serviceName": "svc", "version": "1.0.0"}}}
+	]}`
+
+	client := &mockK8sClient{listJSON: []byte(k8sData)}
+	r := &DetectResult{
+		Diagnostics: &SourceDiagnostics{},
+		K8s:         NewK8sSource(client, "", "pactos"),
+	}
+
+	r.EnrichFromK8s(context.Background(), newMockBundleStore(), "")
+	if r.OCI != nil {
+		t.Error("expected nil OCI when no services have imageRefs")
+	}
+}
+
+func TestEnrichFromK8s_CacheSourceAlreadyExists(t *testing.T) {
+	k8sData := `{"items": [
+		{"metadata": {"name": "svc", "namespace": "default"},
+		 "status": {"contract": {"serviceName": "svc", "imageRef": "ghcr.io/org/svc:1.0.0"}}}
+	]}`
+
+	client := &mockK8sClient{listJSON: []byte(k8sData)}
+	existingCache := NewCacheSource(t.TempDir())
+	r := &DetectResult{
+		Diagnostics: &SourceDiagnostics{},
+		K8s:         NewK8sSource(client, "", "pactos"),
+		Cache:       existingCache,
+	}
+
+	r.EnrichFromK8s(context.Background(), newMockBundleStore(), "")
+	// Cache source should remain the existing one, not overwritten.
+	if r.Cache != existingCache {
+		t.Error("expected existing CacheSource to be preserved")
+	}
+}
+
+func TestEnsureCacheSource_DefaultDir(t *testing.T) {
+	home := t.TempDir()
+	orig := userHomeDir
+	userHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { userHomeDir = orig })
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	r := &DetectResult{Diagnostics: &SourceDiagnostics{}}
+	r.ensureCacheSource("")
+
+	if r.Cache == nil {
+		t.Fatal("expected CacheSource to be created")
+	}
+	expected := filepath.Join(home, ".cache", "pacto", "oci")
+	if r.Diagnostics.Cache.CacheDir != expected {
+		t.Errorf("expected cache dir %q, got %q", expected, r.Diagnostics.Cache.CacheDir)
+	}
+}
+
+func TestEnsureCacheSource_XDGDir(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", xdg)
+
+	r := &DetectResult{Diagnostics: &SourceDiagnostics{}}
+	r.ensureCacheSource("")
+
+	expected := filepath.Join(xdg, "pacto", "oci")
+	if r.Diagnostics.Cache.CacheDir != expected {
+		t.Errorf("expected cache dir %q, got %q", expected, r.Diagnostics.Cache.CacheDir)
+	}
+}
+
+func TestEnsureCacheSource_ExplicitDir(t *testing.T) {
+	dir := t.TempDir()
+	r := &DetectResult{Diagnostics: &SourceDiagnostics{}}
+	r.ensureCacheSource(dir)
+
+	if r.Cache == nil {
+		t.Fatal("expected CacheSource to be created")
+	}
+	if r.Diagnostics.Cache.CacheDir != dir {
+		t.Errorf("expected cache dir %q, got %q", dir, r.Diagnostics.Cache.CacheDir)
+	}
+}
+
+func TestEnsureCacheSource_HomeDirError(t *testing.T) {
+	orig := userHomeDir
+	userHomeDir = func() (string, error) { return "", fmt.Errorf("no home") }
+	t.Cleanup(func() { userHomeDir = orig })
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	r := &DetectResult{Diagnostics: &SourceDiagnostics{}}
+	r.ensureCacheSource("")
+
+	if r.Cache != nil {
+		t.Error("expected nil CacheSource when home dir fails")
+	}
+}


### PR DESCRIPTION
## Summary

- **K8s-driven OCI enrichment**: When running alongside the Pacto operator, the dashboard now auto-discovers OCI repositories from K8s CRD `imageRef` fields — enabling full contract bundles, version history, interfaces, config schemas, and diffs without explicit `--repo` flags
- **`PACTO_CACHE_DIR` support**: Configurable cache directory for OCI bundles via env var or CLI flag
- **Documentation overhaul**: Unified three-piece system narrative (CLI + Dashboard + Operator) across all docs, with honest operator capability table and updated cross-links

## Code changes

| File | Change |
|------|--------|
| `pkg/dashboard/detect.go` | `EnrichFromK8s()`, `discoverOCIReposFromK8s()`, `ensureCacheSource()` |
| `pkg/dashboard/detect_test.go` | 12 new tests (happy path, dedup, error cases, cache dir resolution) |
| `internal/cli/dashboard.go` | Wire enrichment + cache-dir flag |
| `pkg/dashboard/config.go` | `PACTO_CACHE_DIR` env var |

## Documentation changes

| File | Change |
|------|--------|
| `docs/operator.md` | Full rewrite — system positioning, capability table, "what it does NOT validate" |
| `docs/index.md` | Three-piece system intro |
| `docs/architecture.md` | ResolvedSource fix, K8s-driven discovery |
| `docs/dashboard-docker.md` | Hybrid mode section, `PACTO_CACHE_DIR` |
| `docs/platform-engineers.md` | Dashboard/operator positioning |
| `docs/developers.md` | Dashboard tip |
| `cmd/gendocs/main.go` | Dashboard command notes with hybrid view |
| `docs/cli-reference.md` | Regenerated |

## Test plan

- [x] All existing tests pass
- [x] 12 new tests for `EnrichFromK8s` covering: no K8s source, already has OCI, nil store, happy path discovery, deduplication, K8s list error, no imageRefs, cache source already exists, default/XDG/explicit cache dirs, home dir error