### PR TITLE
docs(readme): reposition as a system (CLI + Dashboard + Operator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@ No sidecars. No new infrastructure. The CLI uses your existing OCI registry. The
 Pacto connects design-time authoring to runtime verification to human exploration:
 
 ```
-CLI                        Operator                   Dashboard
- │                          │                          │
- ├─ define contracts        ├─ watch Pacto CRs         ├─ auto-detect sources
- ├─ validate (3 layers)     ├─ resolve OCI refs         │  (K8s, OCI, local, cache)
- ├─ diff versions           ├─ track versions           ├─ dependency graph
- ├─ publish to OCI          │  (PactoRevision per ver)  ├─ version history + diffs
- └─ resolve dep graphs      ├─ link to workloads        ├─ service details
-                            └─ check runtime alignment  │  (interfaces, config, docs)
-                               (ports, replicas, health)├─ runtime status
-                                                        └─ compliance insights
+CLI                        Operator                      Dashboard
+ │                          │                             │
+ ├─ define contracts        ├─ watch Pacto CRs            ├─ auto-detect sources
+ ├─ validate (3 layers)     ├─ resolve OCI refs           │  (K8s, OCI, local, cache)
+ ├─ diff versions           ├─ track versions             ├─ dependency graph
+ ├─ publish to OCI          │  (PactoRevision per ver)    ├─ version history + diffs
+ └─ resolve dep graphs      ├─ link to workloads          ├─ service details
+                            └─ check runtime alignment    │  (interfaces, config, docs)
+                               (ports, replicas, health)  ├─ runtime status
+                                                          └─ compliance insights
 ```
 
 The lifecycle:


### PR DESCRIPTION
## Summary

- Introduce CLI, Dashboard, and Operator as three equal components in the opening paragraph
- Add dedicated **Dashboard** section after "How it works" with capabilities list
- Restructure **Key capabilities** into CLI / Dashboard / Operator subsections
- Frame operator honestly: consistency verification (ports, replicas, health endpoints), explicitly noting it does not validate API behavior or deep config correctness
- Update **"What Pacto is NOT"** with runtime behavior validator and catalog clarifications
- Add Dashboard and Operator rows to documentation table
- Tighten Vision section to four words: describe, validate, observe, explore

## Test plan

- [x] No code changes — documentation only
- [x] All links point to existing docs pages