### PR TITLE
fix(dashboard): prevent graph double-reset on reload

### DIFF
--- a/pkg/dashboard/ui/app.js
+++ b/pkg/dashboard/ui/app.js
@@ -64,7 +64,7 @@ var api = {
 // Lightweight DOM patching: updates target to match newHTML without destroying
 // scroll position, focus, input values, or other interactive state.
 // Skips D3-managed containers (graph-container) and preserves form elements.
-var MORPH_SKIP_IDS = { 'graph-container': true, 'graph-connections': true, 'diff-result': true, 'debug-panel-slot': true };
+var MORPH_SKIP_IDS = { 'graph-container': true, 'graph-connections': true, 'service-graph-container': true, 'diff-result': true, 'debug-panel-slot': true };
 
 function patchDOM(target, newHTML) {
   var tmp = document.createElement(target.tagName || 'div');


### PR DESCRIPTION
## Summary
- Add `service-graph-container` to `MORPH_SKIP_IDS` so the DOM morph preserves the D3-managed service dependency graph on the detail page

## Root cause
The detail page's dependency graph container was not in the morph skip list. Every `patchDOM` call destroyed the SVG inside it, then `maybeInitServiceGraph()` recreated it. Since `renderDetail()` calls `renderDetailPage()` twice per refresh cycle (once from cache, once from the API callback), the graph reset twice.
