### PR TITLE
fix(dashboard): detach shallowScan context from HTTP request

### DIFF
--- a/pkg/dashboard/source_oci.go
+++ b/pkg/dashboard/source_oci.go
@@ -91,7 +91,9 @@ func (s *OCISource) ListServices(ctx context.Context) ([]Service, error) {
 		s.started = true
 		s.mu.Unlock()
 		// Run synchronous shallow scan of configured repos (fast: 1 pull per repo).
-		s.shallowScan(ctx)
+		// Use a detached context so the scan isn't cancelled by the triggering
+		// HTTP request's timeout (e.g. readiness probe, browser fetch).
+		s.shallowScan(context.WithoutCancel(ctx))
 		// Kick off background deep discovery of dependencies + version prefetch.
 		// Runs continuously: first cycle closes s.done (ending "discovering" state),
 		// then re-runs periodically to pick up new services and versions.


### PR DESCRIPTION
## Summary

- **Root cause**: `shallowScan` used the triggering HTTP request's context, which got cancelled by K8s readiness probes or browser timeouts before OCI repo pulls completed
- **Symptom**: dashboard reported "OCI client configured with N repositories" but all `ListTags`/`Pull` calls failed with `context canceled`, leaving OCI source with 0 services — no version history, no diffs
- **Fix**: use `context.WithoutCancel(ctx)` for `shallowScan`, matching the existing pattern used by `backgroundLoop`

## Test plan

- [ ] Deploy to K8s and verify OCI services appear (sources include `oci`)
- [ ] Verify version history shows all versions (not just latest from k8s)
- [ ] Verify diff works between versions
- [ ] Check logs for absence of `context canceled` errors during startup