### PR TITLE
docs: align documentation with current code

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -319,10 +319,12 @@ Key API operations:
 | `/api/services/{name}/versions` | GET | Version history |
 | `/api/services/{name}/sources` | GET | Per-source breakdown |
 | `/api/services/{name}/dependents` | GET | Reverse dependency lookup |
+| `/api/services/{name}/refs` | GET | Config/policy cross-references |
 | `/api/services/{name}/graph` | GET | Per-service dependency tree |
 | `/api/graph` | GET | Global D3-ready dependency graph |
 | `/api/diff` | GET | Classified diff between two versions |
 | `/api/sources` | GET | Detected source status and discovery state |
+| `/api/refresh` | POST | Force-refresh all sources |
 | `/api/resolve` | POST | Lazy-resolve a remote dependency |
 | `/api/versions` | POST | List registry tags, optionally fetch all |
 | `/api/debug/*` | GET | Diagnostics (requires `--diagnostics` flag) |

--- a/docs/dashboard-docker.md
+++ b/docs/dashboard-docker.md
@@ -111,7 +111,7 @@ docker run -p 3000:3000 \
 
 | Endpoint | Description |
 |---|---|
-| `GET /health` | Returns `{"status": "ok"}`. Use for liveness and readiness probes. |
+| `GET /health` | Returns `{"status": "ok", "version": "..."}`. Use for liveness and readiness probes. |
 | `GET /metrics` | Returns `{"serviceCount": N, "sourceCount": N}`. |
 | `GET /openapi` | OpenAPI 3.1 specification (includes server URL matching the bind address). |
 | `GET /docs` | Interactive API documentation. |

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -77,6 +77,7 @@ Each check produces a structured condition on the CRD status with a type, status
 - **Warning** — some checks fail (warnings or errors)
 - **NonCompliant** — the contract itself has validation errors
 - **Reference** — no target workload (the contract is a shared definition, not a deployed service)
+- **Unknown** — contract status has not been determined yet
 
 {: .note }
 > Contract status reflects whether the service contract is valid and compliant, not whether the service is healthy at runtime.
@@ -106,7 +107,7 @@ Each check produces a structured condition on the CRD status with a type, status
 
 When `pacto dashboard` detects a Kubernetes cluster with the Pacto CRD installed, it uses the operator's status data as the **k8s** runtime source. This provides:
 
-- Live contract status (Compliant / Warning / Non-Compliant / Reference)
+- Live contract status (Compliant / Warning / NonCompliant / Reference / Unknown)
 - Reconciliation conditions with timestamps
 - Endpoint health and metrics reachability results
 - Resource existence checks (Service, Workload)

--- a/docs/platform-engineers.md
+++ b/docs/platform-engineers.md
@@ -374,11 +374,12 @@ Sources are auto-detected at startup:
 | **local** | `pacto.yaml` found in the working directory | In-progress contract changes |
 | **k8s** | Valid kubeconfig found and cluster reachable | Runtime state: contract status, conditions, endpoints, resources |
 | **oci** | `--repo` flags provided, or auto-discovered from K8s `imageRef` fields | Full contract bundles, registry versions, and diffs |
-| **cache** | `~/.cache/pacto/oci` contains cached bundles | Offline baseline from previously pulled contracts |
+
+Materialized bundles on disk (`~/.cache/pacto/oci`) are used internally by the OCI source to enrich version data (hash, classification, timestamps) without appearing as a separate source.
 
 When running alongside the Kubernetes operator, the dashboard automatically discovers OCI repositories from the `imageRef` fields in Pacto CRD statuses. This means a K8s deployment of the dashboard provides the full contract experience — version history, interface details, configuration schemas, and diffs — without explicit `--repo` flags.
 
-Pass `--no-cache` to disable the cache source entirely (useful when cached data is stale).
+Pass `--no-cache` to skip pre-existing cached bundles at startup (cold-start mode). Bundles materialized during the current session (via fetch-all-versions, dependency resolution, or OCI pulls) are still cached to disk and reused for enrichment within the same session.
 
 ### Merge priority
 
@@ -387,7 +388,6 @@ When a service appears in multiple sources, fields are merged using priority rul
 1. **Kubernetes** — runtime state (contract status, resources, ports, conditions, endpoints)
 2. **Local** — in-progress contract edits
 3. **OCI** — published contract baseline
-4. **Cache** — offline fallback from previously pulled bundles
 
 The merged view is used for the service list and detail pages. Per-source data is available via the `/api/services/{name}/sources` endpoint.
 
@@ -396,7 +396,7 @@ The merged view is used for the service list and detail pages. Per-source data i
 The dashboard provides a layered filter pipeline:
 
 1. **Source filter** — click source pills in the header to show/hide services from specific sources
-2. **Status filter** — click status pills (Compliant, Warning, Non-Compliant, Unknown) to filter by contract status
+2. **Status filter** — click status pills (Compliant, Warning, Non-Compliant, Reference, Unknown) to filter by contract status
 3. **Search** — type in the search bar to filter by name, owner, version, or source
 
 All three filters compose: a service must pass all active filters to appear in both the table and graph views.
@@ -408,7 +408,6 @@ The built-in D3 force-directed graph shows:
 - **Dependency edges** (solid lines) — declared `dependencies[].ref` relationships
 - **Reference edges** (dashed lines) — `configuration.ref` and `policy.ref` cross-references
 - **External nodes** — dependencies that don't resolve to any known service
-- **Unmonitored nodes** — contracts without a runtime target (e.g. shared definitions)
 
 Hover over a node to highlight its impact chain. Click a node to navigate to its detail page.
 


### PR DESCRIPTION
## Summary

- **architecture.md**: add missing `/api/services/{name}/refs` and `/api/refresh` endpoints to the API table
- **dashboard-docker.md**: add `version` field to health endpoint response example
- **operator.md**: add `Unknown` to contract status list, fix `Non-Compliant` → `NonCompliant` for consistency with code
- **platform-engineers.md**: remove `cache` as a public source (internal to OCI), fix `--no-cache` semantics description, add `Reference` to status filter pill list, remove nonexistent "Unmonitored nodes" concept

## Test plan

- [x] `make ci` passes (all tests, linting, formatting, CLI docs freshness check, generated artifacts)
- [x] Verified all fixes against actual code implementation
- [x] Grep sweep confirms no remaining stale terminology