### PR TITLE
fix(dashboard): parse CRD endpoints map format for endpoint probes

### DIFF
--- a/pkg/dashboard/source_k8s.go
+++ b/pkg/dashboard/source_k8s.go
@@ -65,7 +65,7 @@ type pactoStatus struct {
 	Metadata           map[string]string        `json:"metadata,omitempty"`
 	Summary            *k8sSummary              `json:"summary,omitempty"`
 	Conditions         flexSlice[k8sCondition]  `json:"conditions,omitempty"`
-	Endpoints          flexSlice[k8sEndpoint]   `json:"endpoints,omitempty"`
+	Endpoints          k8sEndpoints             `json:"endpoints,omitempty"`
 	Insights           flexSlice[k8sInsight]    `json:"insights,omitempty"`
 	ObservedRuntime    *k8sObservedRuntime      `json:"observedRuntime,omitempty"`
 	LastReconciledAt   string                   `json:"lastReconciledAt,omitempty"`
@@ -212,6 +212,61 @@ type k8sEndpoint struct {
 	LatencyMs  *int64 `json:"latencyMs,omitempty"`
 	Error      string `json:"error,omitempty"`
 	Message    string `json:"message,omitempty"`
+}
+
+// k8sEndpoints unmarshals the CRD endpoints field which may be:
+//   - an array of k8sEndpoint objects: [{"interface":"health","url":"..."}]
+//   - a single k8sEndpoint object:    {"interface":"health","url":"..."}
+//   - a map keyed by name:            {"health":{"url":"...","reachable":true,...}}
+type k8sEndpoints []k8sEndpoint
+
+// k8sEndpointMapValue represents the per-endpoint value when the CRD writes
+// endpoints as a map (e.g. {"health": {"url":"...","reachable":true}}).
+type k8sEndpointMapValue struct {
+	URL        string `json:"url,omitempty"`
+	Reachable  *bool  `json:"reachable,omitempty"`
+	StatusCode *int   `json:"statusCode,omitempty"`
+	LatencyMs  *int64 `json:"latencyMs,omitempty"`
+	Error      string `json:"error,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+func (e *k8sEndpoints) UnmarshalJSON(data []byte) error {
+	// Try array first.
+	var arr []k8sEndpoint
+	if err := json.Unmarshal(data, &arr); err == nil {
+		*e = arr
+		return nil
+	}
+
+	// Try map keyed by endpoint name (operator format).
+	var m map[string]k8sEndpointMapValue
+	if err := json.Unmarshal(data, &m); err == nil {
+		out := make([]k8sEndpoint, 0, len(m))
+		for name, v := range m {
+			out = append(out, k8sEndpoint{
+				Interface:  name,
+				Type:       name,
+				URL:        v.URL,
+				Healthy:    v.Reachable,
+				StatusCode: v.StatusCode,
+				LatencyMs:  v.LatencyMs,
+				Error:      v.Error,
+				Message:    v.Message,
+			})
+		}
+		sort.Slice(out, func(i, j int) bool { return out[i].Interface < out[j].Interface })
+		*e = out
+		return nil
+	}
+
+	// Fall back to single object.
+	var single k8sEndpoint
+	if err := json.Unmarshal(data, &single); err != nil {
+		return err
+	}
+	*e = []k8sEndpoint{single}
+	return nil
 }
 
 type k8sInsight struct {
@@ -629,7 +684,7 @@ func observedRuntimeFromK8s(obs *k8sObservedRuntime) *ObservedRuntime {
 	}
 }
 
-func endpointsFromK8s(endpoints flexSlice[k8sEndpoint]) []EndpointStatus {
+func endpointsFromK8s(endpoints k8sEndpoints) []EndpointStatus {
 	var out []EndpointStatus
 	for _, ep := range endpoints {
 		out = append(out, EndpointStatus(ep))

--- a/pkg/dashboard/source_k8s_test.go
+++ b/pkg/dashboard/source_k8s_test.go
@@ -322,7 +322,7 @@ func buildComprehensiveK8sDetails(t *testing.T) *ServiceDetails {
 	r.Status.Ports = &k8sPorts{Expected: []int{8080}, Observed: []int{8080, 9090}, Missing: nil, Unexpected: []int{9090}}
 	condTime := time.Now().Add(-2 * time.Hour).Format(time.RFC3339)
 	r.Status.Conditions = flexSlice[k8sCondition]{{Type: "Ready", Status: "True", Reason: "AllChecks", Message: "all good", LastTransitionTime: condTime}}
-	r.Status.Endpoints = flexSlice[k8sEndpoint]{{Interface: "http", Type: "health", URL: "http://billing:8080/healthz", Healthy: &healthy, StatusCode: &statusCode, LatencyMs: &latency, Error: "", Message: "OK"}}
+	r.Status.Endpoints = k8sEndpoints{{Interface: "http", Type: "health", URL: "http://billing:8080/healthz", Healthy: &healthy, StatusCode: &statusCode, LatencyMs: &latency, Error: "", Message: "OK"}}
 	r.Status.Insights = flexSlice[k8sInsight]{{Severity: "warning", Title: "High latency", Description: "p99 > 500ms"}}
 	r.Status.Summary = &k8sSummary{Total: 10, Passed: 8, Failed: 2}
 
@@ -432,6 +432,80 @@ func TestK8s_flexSlice_InvalidJSON_ViaStatus(t *testing.T) {
 	var status pactoStatus
 	if err := json.Unmarshal([]byte(input), &status); err == nil {
 		t.Error("expected error for invalid interfaces value")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// k8sEndpoints unmarshal tests
+// ---------------------------------------------------------------------------
+
+func TestK8s_k8sEndpoints_Array(t *testing.T) {
+	input := `[{"interface":"http","url":"http://svc:8080/health","statusCode":200}]`
+	var ep k8sEndpoints
+	if err := json.Unmarshal([]byte(input), &ep); err != nil {
+		t.Fatal(err)
+	}
+	if len(ep) != 1 || ep[0].Interface != "http" || ep[0].URL != "http://svc:8080/health" {
+		t.Errorf("unexpected: %+v", ep)
+	}
+}
+
+func TestK8s_k8sEndpoints_SingleObject(t *testing.T) {
+	input := `{"interface":"http","url":"http://svc:8080/health"}`
+	var ep k8sEndpoints
+	if err := json.Unmarshal([]byte(input), &ep); err != nil {
+		t.Fatal(err)
+	}
+	if len(ep) != 1 || ep[0].Interface != "http" {
+		t.Errorf("unexpected: %+v", ep)
+	}
+}
+
+func TestK8s_k8sEndpoints_Map(t *testing.T) {
+	input := `{"health":{"url":"http://svc:8080/health","reachable":true,"statusCode":200,"latencyMs":5}}`
+	var ep k8sEndpoints
+	if err := json.Unmarshal([]byte(input), &ep); err != nil {
+		t.Fatal(err)
+	}
+	if len(ep) != 1 {
+		t.Fatalf("expected 1 endpoint, got %d", len(ep))
+	}
+	if ep[0].Interface != "health" {
+		t.Errorf("expected interface 'health', got %q", ep[0].Interface)
+	}
+	if ep[0].URL != "http://svc:8080/health" {
+		t.Errorf("expected url, got %q", ep[0].URL)
+	}
+	if ep[0].Healthy == nil || !*ep[0].Healthy {
+		t.Error("expected healthy=true")
+	}
+	if ep[0].StatusCode == nil || *ep[0].StatusCode != 200 {
+		t.Error("expected statusCode=200")
+	}
+	if ep[0].LatencyMs == nil || *ep[0].LatencyMs != 5 {
+		t.Error("expected latencyMs=5")
+	}
+}
+
+func TestK8s_k8sEndpoints_MapMultiple(t *testing.T) {
+	input := `{"health":{"url":"http://svc:8080/health"},"metrics":{"url":"http://svc:9090/metrics"}}`
+	var ep k8sEndpoints
+	if err := json.Unmarshal([]byte(input), &ep); err != nil {
+		t.Fatal(err)
+	}
+	if len(ep) != 2 {
+		t.Fatalf("expected 2 endpoints, got %d", len(ep))
+	}
+	// Should be sorted alphabetically.
+	if ep[0].Interface != "health" || ep[1].Interface != "metrics" {
+		t.Errorf("expected sorted [health, metrics], got [%s, %s]", ep[0].Interface, ep[1].Interface)
+	}
+}
+
+func TestK8s_k8sEndpoints_InvalidJSON(t *testing.T) {
+	var ep k8sEndpoints
+	if err := json.Unmarshal([]byte(`not json`), &ep); err == nil {
+		t.Error("expected error for invalid JSON")
 	}
 }
 


### PR DESCRIPTION
## Summary
- The operator writes `status.endpoints` as a map (`{"health": {"url":"...","reachable":true,...}}`), but the dashboard expected an array of objects with an `interface` field
- The `flexSlice` fallback silently deserialized the map into an empty `k8sEndpoint` struct (no fields matched), resulting in `[{"interface":""}]` — causing the **Endpoint Probes** section to render blank
- Introduces `k8sEndpoints` custom unmarshaler that handles array, single-object, and **map** formats, mapping the map key → `Interface`/`Type` and CRD's `reachable` → `Healthy`

## Test plan
- [x] Unit tests for all three unmarshal formats (array, single object, map)
- [x] Multi-entry map test with sort verification
- [x] Invalid JSON error test
- [x] Full test suite passes