### PR TITLE
docs: final polish

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -1,0 +1,80 @@
+# The Pacto Manifesto
+
+## The Problem
+
+Operational behavior is implicit. It shouldn't be.
+
+A service's API has a spec. Its container image has a registry. Its deployment has a chart. But the service itself — what it exposes, what it depends on, how it persists data, how it scales, what breaks when you change it — has no spec at all.
+
+That knowledge lives in six places that don't talk to each other:
+
+- OpenAPI describes the API surface. Not the runtime.
+- Helm charts encode deployment mechanics for one orchestrator. Not the service's intent.
+- Environment variables are documented in wikis, `.env.example` files, or nowhere.
+- Kubernetes manifests hardcode ports and health checks with no link to the service definition.
+- Dependencies live in Slack threads and team leads' heads.
+- README files go stale the day they're written.
+
+Platforms reverse-engineer services from these fragments. Developers ship code and hope someone figures out how to run it. Breaking changes surface in production. Dependency relationships are tribal knowledge.
+
+This is not a tooling problem. It's the absence of a contract layer between development and operations.
+
+## The Thesis
+
+Operational behavior must be explicit, declarative, and machine-readable.
+
+A service that exposes HTTP on port 8080, depends on auth-service ^2.0.0, persists data locally, and scales between 2 and 10 instances — that is its operational contract. It should be written down once, validated automatically, and consumed by every tool that needs to understand the service.
+
+Pacto is that contract.
+
+It is a single file (`pacto.yaml`) that captures what a service *is* operationally. Not how to deploy it. Not how to build it. What it is. The contract is the interface between developers who build services and platforms that run them.
+
+If a platform has to guess whether a service is stateful, the contract is incomplete. If a dependency relationship only exists in someone's head, the contract is incomplete. If a breaking change reaches production undetected, the contract is incomplete.
+
+## Principles
+
+**Operational behavior is a first-class artifact.** It deserves the same rigor as API specs and container images — authored, versioned, validated, distributed, and verified.
+
+**Declarative over procedural.** A contract describes *what*, not *how*. It is committed alongside source code, versioned with semver, and immutable once published. Platforms decide how to act on it.
+
+**Implementation-agnostic.** The contract describes service behavior independent of any orchestrator, deployment tool, or platform. A stateful service with an HTTP interface on port 8080 is that — whether it runs on Kubernetes, Nomad, or bare metal.
+
+**Distributed through existing infrastructure.** Contracts are OCI artifacts. They use the same registries, the same auth, and the same tooling as container images. No new infrastructure.
+
+**Runtime-aware.** If the contract doesn't capture state management, persistence, health checks, scaling bounds, and dependency relationships, it's just another API spec. Runtime semantics are what make it an operational contract.
+
+**Invalid contracts must not propagate.** Every contract passes structural, cross-field, and semantic validation before it can be published. If it's invalid, it doesn't reach the registry. If it introduces a breaking change, CI catches it.
+
+## What Pacto Is
+
+A standard for describing how a service behaves operationally.
+
+The contract captures interfaces, dependencies, runtime semantics, configuration, scaling, and policy. It can be validated, diffed, distributed as an OCI artifact, resolved into a dependency graph, verified against running workloads, and explored through a dashboard.
+
+It is the minimum viable description that lets a platform run a service correctly without guessing.
+
+## What Pacto Is NOT
+
+**Not a deployment tool.** Pacto describes services. It does not deploy, orchestrate, or manage infrastructure. Platforms consume contracts and decide how to act.
+
+**Not a service mesh.** No sidecars, no traffic interception. The operator watches custom resources and compares declared state to running workloads.
+
+**Not a replacement for OpenAPI or Helm.** Pacto references OpenAPI specs as interface contracts and complements deployment tools by providing the operational context they lack.
+
+**Not a service catalog.** The dashboard visualizes contracts and runtime state. It is not a developer portal. It can feed data into one.
+
+**Not a platform.** Pacto provides the contract layer. What you build on top — manifest generation, policy enforcement, automated provisioning — is up to you.
+
+## The Endgame
+
+Platforms should not reverse-engineer services. They should read a contract.
+
+**Contract-driven platforms.** Platforms consume contracts to generate manifests, provision infrastructure, and configure networking. The contract is the input. The platform is the function.
+
+**Policy as validation.** Organizations define policy schemas that contracts must satisfy. Non-compliant contracts fail validation before they reach a registry. Enforcement happens at authoring time, not after deployment.
+
+**Lifecycle-wide verification.** Contracts are validated when authored, diffed in CI, and verified at runtime. Breaking changes are caught before production. Runtime drift is detected continuously.
+
+**Machine-readable foundation.** A structured, validated contract is a natural integration point for any tool that needs to understand service behavior — CI systems, platform controllers, compliance tools, and AI agents that can read, generate, and reason about contracts.
+
+The contract is the API between developers and the platform.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ No sidecars. No new infrastructure. The CLI uses your existing OCI registry. The
 
 **[Documentation](https://trianalab.github.io/pacto)** · **[Quickstart](https://trianalab.github.io/pacto/quickstart)** · **[Specification](https://trianalab.github.io/pacto/contract-reference)** · **[Examples](https://trianalab.github.io/pacto/examples)** · **[Demo](https://github.com/TrianaLab/pacto-demo)**
 
+> **Why Pacto exists** — [MANIFEST.md](MANIFEST.md)
+
 ---
 
 ## The system
@@ -55,7 +57,7 @@ The lifecycle:
 
 ## What you get
 
-- **One contract per service** — a single `pacto.yaml` replaces scattered docs, wiki pages, and tribal knowledge
+- **One contract per service** — a single `pacto.yaml` captures interfaces, dependencies, runtime semantics, configuration, and scaling
 - **Versioned OCI artifacts** — contracts are pushed to the same registries you already use for container images
 - **Runtime state in Kubernetes** — the operator tracks every contract version and checks alignment against running workloads
 - **Dependency graph + version history** — the dashboard visualizes relationships, diffs, and compliance across all services
@@ -121,31 +123,7 @@ Run it locally with `pacto dashboard`, or deploy the [container image](https://t
 
 ---
 
-## The problem
-
-A cloud service is described across **six different places** — none of which talk to each other:
-
-```
-OpenAPI spec    → the API, but not the runtime
-Helm values     → deployment config, but not the service itself
-env vars        → documented in a wiki (maybe), validated never
-K8s manifests   → hardcoded ports, guessed health checks
-Dependencies    → tribal knowledge in Slack threads
-README.md       → outdated the day it was written
-```
-
-The result:
-
-- Platforms guess service behavior — *Is it stateful? What port? Does it need persistent storage?*
-- Developers ship code; platform engineers reverse-engineer how to run it
-- Breaking changes are detected in production, not CI
-- No one knows what depends on what until something breaks
-
----
-
-## What Pacto captures
-
-One file. Machine-validated. Versioned and distributed as an OCI artifact.
+## Contract example
 
 ```yaml
 pactoVersion: "1.0"
@@ -189,59 +167,6 @@ scaling:
 ```
 
 Only `pactoVersion` and `service` are required — everything else is opt-in, so a contract can be as minimal or as detailed as your service needs.
-
----
-
-## Before and after
-
-<table>
-<tr><th>Without Pacto</th><th>With Pacto</th></tr>
-<tr><td>
-
-```
-my-service/
-  src/
-  Dockerfile
-  helm/
-    values.yaml        ← ports, replicas
-  k8s/
-    deployment.yaml    ← health checks
-  docs/
-    README.md          ← maybe outdated
-  .env.example         ← config keys
-```
-
-*"Is it stateful?"* — Check the Helm chart.<br>
-*"What does it depend on?"* — Ask the team lead.<br>
-*"Did anything break?"* — Deploy and find out.
-
-</td><td>
-
-```
-my-service/
-  src/
-  Dockerfile
-  pacto.yaml             ← single source of truth
-  interfaces/            ← optional
-    openapi.yaml
-  configuration/         ← optional
-    schema.json
-  policy/                ← optional
-    schema.json
-  docs/                  ← optional
-    README.md
-  sbom/                  ← optional
-    sbom.spdx.json
-```
-
-```bash
-pacto validate .          # validates everything
-pacto diff old new        # detects breaking changes
-pacto dashboard           # explore in the browser
-```
-
-</td></tr>
-</table>
 
 ---
 
@@ -308,22 +233,6 @@ payments-api/
 ```
 
 The contract lives next to the code it describes. CI validates it on every push and publishes it to an OCI registry on release.
-
----
-
-## Why Pacto is different
-
-Most tools describe **how to deploy** a service. Pacto describes **what a service is** operationally.
-
-A Helm chart tells Kubernetes how many replicas to run and what image to pull. A Pacto contract tells *any* platform that the service is stateful, persists data locally, exposes an HTTP API on port 8080, depends on auth-service ^2.0.0, and should scale between 2 and 10 instances.
-
-This distinction matters because:
-
-- **Runtime state semantics** — the contract declares whether a service is stateless, stateful, or hybrid, and what that means for persistence and data criticality. Platforms use this to choose the right infrastructure without guessing.
-- **Typed dependencies** — dependencies are declared with version constraints and resolved from OCI registries. `pacto graph` shows the full tree; `pacto diff` shows what shifted between versions.
-- **Configuration schema** — environment variables and settings are defined with JSON Schema, so platforms can validate config before deployment.
-- **Scaling intent** — the contract declares whether scaling is fixed or elastic, giving platforms the information they need to configure autoscaling correctly.
-- **Machine-validated contracts** — every contract passes three validation layers before it can be pushed. Invalid contracts never reach the registry.
 
 ---
 
@@ -427,20 +336,11 @@ payments-api
 
 ## Why OCI?
 
-OCI registries are already the standard distribution layer for cloud-native artifacts. Your organization runs one for container images. Pacto uses the same infrastructure to distribute service contracts — no new systems to deploy or maintain.
-
-Pacto bundles are distributed as **OCI artifacts**, which means:
-
-- **Versioned and immutable** — every contract is content-addressed with a digest
-- **Works with existing registries** — GHCR, ECR, ACR, Docker Hub, Harbor — no new infrastructure
-- **Signable and scannable** — use cosign, Notary, or any OCI-compatible signing tool
-- **Pull from CI, platforms, or scripts** — standard tooling, no proprietary clients
+Pacto bundles are distributed as OCI artifacts — versioned, content-addressed, and compatible with GHCR, ECR, ACR, Docker Hub, and Harbor. Same registries, same auth, same tooling you already use for container images. Signable with cosign or Notary. No new infrastructure.
 
 ---
 
 ## How Pacto compares
-
-Pacto doesn't replace these tools — it fills the gap between them.
 
 | Concern | OpenAPI | Helm | Terraform | Backstage | Pacto |
 |---------|---------|------|-----------|-----------|-------|
@@ -454,25 +354,16 @@ Pacto doesn't replace these tools — it fills the gap between them.
 | OCI-native distribution | — | ✅ | — | — | ✅ |
 | Machine validation | ✅ | — | ✅ | — | ✅ |
 
-**Why not just OpenAPI + Helm?** OpenAPI describes your API surface. Helm describes how to deploy one particular way. Neither captures runtime behavior, dependency relationships, configuration schemas, or scaling intent — and there's no way to diff two versions across all of these dimensions. Pacto is the layer that ties them together.
+Pacto does not replace these tools. It provides the operational contract layer between them.
 
 ## What Pacto is NOT
 
-- **Not a deployment tool.** Pacto doesn't deploy anything. It describes *what* a service is — platforms decide *how* to run it.
-- **Not a runtime behavior validator.** The operator checks runtime alignment against the contract (ports, replicas, health endpoints). It does not perform deep API conformance testing or full live configuration validation.
-- **Not a service mesh or runtime agent.** No sidecars. The operator watches CRs and compares them to workloads — it doesn't intercept traffic.
-- **Not a service catalog.** The dashboard visualizes contracts and runtime state, but it's not a portal like Backstage. It can feed data into one.
-- **Not a replacement for OpenAPI or Helm.** It references your OpenAPI specs and complements deployment tools — it doesn't replace them.
+- Not a deployment tool — it describes services, not how to run them
+- Not a service mesh — no sidecars, no traffic interception
+- Not a replacement for OpenAPI or Helm — it complements them
+- Not a service catalog — the dashboard can feed data into one
 
----
-
-## Vision
-
-Pacto aims to become the standard operational contract for cloud-native services — a shared language between developers, platforms, and automation.
-
-Describe once. Validate early. Observe at runtime. Explore via dashboard.
-
-The contract is the API between developers and the platform. Pacto provides the format, the validation, the distribution, the runtime verification, and the visualization — what you build on top is up to you.
+See [MANIFEST.md](MANIFEST.md) for the full rationale.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `MANIFEST.md` — opinionated manifesto covering problem, thesis, principles, and endgame
- Refactor `README.md` — remove philosophical sections, keep practical usage, add pointer to manifesto
- Final wording polish: clarify comparison table positioning, consistent phrasing in manifesto

## Changes

- **MANIFEST.md** (new): The Pacto Manifesto — conceptual foundation separated from README
- **README.md** (modified):
  - Removed: "The problem", "Before and after", "Why Pacto is different", "Vision" sections (moved to manifesto)
  - Compressed: "Why OCI?", "What Pacto is NOT", "How Pacto compares"
  - Renamed: "What Pacto captures" → "Contract example"
  - Added: pointer to MANIFEST.md near the top

Small wording improvements to clarify positioning and tone.