### PR TITLE
fix(dashboard): don't activate local source from hidden/vendor subdirs (fixes indefinite 'Loading services…')

### DIFF
--- a/pkg/dashboard/detect.go
+++ b/pkg/dashboard/detect.go
@@ -167,6 +167,13 @@ func (r *DetectResult) detectLocal(dir string) {
 		if !entry.IsDir() {
 			continue
 		}
+		// Skip hidden / vendor directories so a stray pacto.yaml (e.g. under
+		// ~/.Trash) cannot root the local source at a large directory like $HOME,
+		// whose recursive scan would block ListServices indefinitely. Mirrors the
+		// rules used by the recursive walk (skipScanDir).
+		if skipScanDir(entry.Name()) {
+			continue
+		}
 		if _, err := os.Stat(filepath.Join(dir, entry.Name(), contractFile)); err == nil {
 			info.Enabled = true
 			info.Reason = "pacto.yaml found in subdirectory " + entry.Name()

--- a/pkg/dashboard/detect_test.go
+++ b/pkg/dashboard/detect_test.go
@@ -150,6 +150,34 @@ func TestDetectLocal_SubdirPactoYAML(t *testing.T) {
 	}
 }
 
+func TestDetectLocal_IgnoresHiddenAndVendorSubdirs(t *testing.T) {
+	// A pacto.yaml inside a hidden / node_modules / vendor immediate subdir must
+	// NOT activate the local source. Otherwise running `pacto dashboard` from a
+	// large root (e.g. $HOME, where ~/.Trash may contain a pacto.yaml) roots the
+	// local source at that directory and LocalSource.ListServices recursively
+	// walks the entire tree, blocking /api/services indefinitely. detection must
+	// use the same skip rules as the recursive walk (collectBundleDirs).
+	for _, sub := range []string{".Trash", ".git", "node_modules", "vendor"} {
+		t.Run(sub, func(t *testing.T) {
+			root := t.TempDir()
+			writeLocalPactoYAML(t, filepath.Join(root, sub), "svc", "1.0.0")
+
+			result := &DetectResult{Diagnostics: &SourceDiagnostics{}}
+			result.detectLocal(root)
+
+			if result.Local != nil {
+				t.Fatalf("expected local source NOT detected from %q subdir", sub)
+			}
+			if len(result.Sources) != 1 {
+				t.Fatalf("expected 1 source info, got %d", len(result.Sources))
+			}
+			if result.Sources[0].Enabled {
+				t.Errorf("expected local source disabled for %q subdir", sub)
+			}
+		})
+	}
+}
+
 func TestDetectLocal_NoPactoYAML(t *testing.T) {
 	root := t.TempDir()
 

--- a/pkg/dashboard/source_local.go
+++ b/pkg/dashboard/source_local.go
@@ -30,6 +30,16 @@ func localBundleDirs(root string) []string {
 	return dirs
 }
 
+// skipScanDir reports whether a directory name must be excluded from local
+// bundle discovery. Hidden directories (e.g. .git, .Trash, .cache) and dependency
+// vendoring directories are never project bundle roots, and descending into them
+// from a large root (such as $HOME) makes discovery walk an enormous tree. Both
+// the recursive walk (collectBundleDirs) and source detection (detectLocal) use
+// this so a pacto.yaml under such a directory neither activates nor is scanned.
+func skipScanDir(name string) bool {
+	return strings.HasPrefix(name, ".") || name == "node_modules" || name == "vendor"
+}
+
 func collectBundleDirs(dir string, depth int, out *[]string) {
 	if depth > maxLocalScanDepth {
 		return
@@ -45,11 +55,10 @@ func collectBundleDirs(dir string, depth int, out *[]string) {
 		if !e.IsDir() {
 			continue
 		}
-		name := e.Name()
-		if strings.HasPrefix(name, ".") || name == "node_modules" || name == "vendor" {
+		if skipScanDir(e.Name()) {
 			continue
 		}
-		collectBundleDirs(filepath.Join(dir, name), depth+1, out)
+		collectBundleDirs(filepath.Join(dir, e.Name()), depth+1, out)
 	}
 }
 

--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -56,6 +57,48 @@ func TestDashboardCommand(t *testing.T) {
 
 		assertContains(t, output, "local")
 		assertContains(t, output, "enabled")
+	})
+
+	t.Run("hidden subdir does not activate local source", func(t *testing.T) {
+		// Regression: a pacto.yaml inside a hidden directory (e.g. ~/.Trash) must
+		// NOT activate the local source. Before the fix, running `pacto dashboard`
+		// from such a root (notably $HOME) rooted the local source there and
+		// LocalSource.ListServices recursively walked the entire tree, blocking
+		// /api/services indefinitely so the dashboard sat on "Loading services…".
+		//
+		// Not parallel: modifies process-wide KUBECONFIG and uses inDir.
+		origKC := os.Getenv("KUBECONFIG")
+		os.Setenv("KUBECONFIG", "/nonexistent/kubeconfig")
+		defer func() {
+			if origKC == "" {
+				os.Unsetenv("KUBECONFIG")
+			} else {
+				os.Setenv("KUBECONFIG", origKC)
+			}
+		}()
+
+		// Mirror ~/.Trash/pacto.yaml: a pacto.yaml directly inside a hidden
+		// immediate subdir of the working directory.
+		root := t.TempDir()
+		hidden := filepath.Join(root, ".Trash")
+		if err := os.MkdirAll(hidden, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		contractYAML := "pactoVersion: \"1.0\"\nservice:\n  name: trashed\n  version: 1.0.0\n"
+		if err := os.WriteFile(filepath.Join(hidden, "pacto.yaml"), []byte(contractYAML), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		inDir(t, root)
+
+		// With local (hidden-only bundle), k8s (invalid kubeconfig), oci (no ref)
+		// and cache (--no-cache) all unavailable, detection must report no sources
+		// rather than activating local off the hidden bundle.
+		output, err := runCommandWithCancelledCtx(t, nil, "dashboard", "--no-cache")
+		if err == nil {
+			t.Fatal("expected error: a pacto.yaml in a hidden subdir must not activate any source")
+		}
+		assertContains(t, output, "local")
+		assertContains(t, output, "no pacto.yaml found")
 	})
 
 	t.Run("custom port flag", func(t *testing.T) {


### PR DESCRIPTION
## Summary

`pacto dashboard oci://…` could hang forever on **"Loading services…"** (blank skeleton, never populates) depending on the directory it was launched from. The page shell rendered fine, but `/api/services` never returned — so the frontend's initial load never resolved.

Root cause: a `pacto.yaml` inside a **hidden** directory (e.g. `~/.Trash/pacto.yaml`) activated the **local** source rooted at the working directory. Launched from a large root such as `$HOME`, `LocalSource.ListServices` then **recursively walked the entire tree** (depth 5: Library, cloud-synced folders, …) and never returned. Since `resolver.ListServices` waits for *all* sources, `/api/services` blocked indefinitely.

The recursive walk (`collectBundleDirs`) already skipped hidden/`node_modules`/`vendor` directories — but `detectLocal` did **not**, so detection rooted the local source at a directory the walk would then grind through. This is a regression from #177 (which introduced recursive local discovery; before it, the local source scanned only one level).

### Proof (exact demo command, run from `$HOME`)

| Build | `/api/services` |
|---|---|
| Parent `caa3de4` | `200 in 1.4s` |
| Feature `e6e6444` (#177) | **hang — HTTP 000 at 60s** |
| This PR | `200 in 1.7s`, local correctly disabled |

## Changes

- Extract a shared `skipScanDir(name)` helper (hidden / `node_modules` / `vendor`) in `source_local.go`.
- Use it in **both** `collectBundleDirs` (the recursive walk) **and** `detectLocal`'s immediate-subdir scan, so a `pacto.yaml` under such a directory neither **activates** nor is **scanned**. The local source can no longer root at `$HOME` off `~/.Trash`.
- Unit test (`detect_test.go`): `detectLocal` ignores `.Trash` / `.git` / `node_modules` / `vendor` subdirs.
- E2E regression test (`dashboard_test.go`): running `dashboard` from a dir whose only `pacto.yaml` is in a hidden subdir activates no source (guards against the hang).

## Related Issues

Regression introduced by #177.

## Checklist

- [x] Code compiles without errors
- [x] All tests pass (`make test && make e2e`)
- [x] Linter passes (`make lint`)
- [x] Tests added/updated for new functionality or bug fixes
- [ ] Documentation updated (if applicable) — N/A (internal behavior fix)
- [x] Commit messages follow the `<type>: <description>` convention

## Testing

- New unit test verified **RED → GREEN** (failed before the fix for the right reason).
- New e2e test verified **RED → GREEN** (temporarily reverted the `detectLocal` change to confirm it catches the regression).
- `pkg/dashboard` coverage holds at **100.0%**; `skipScanDir` / `detectLocal` / `collectBundleDirs` all 100%.
- `make lint`, `make test`, and the e2e dashboard suite all pass.
- Manually reproduced from `$HOME`: `/api/services` went from a 60s hang to `200 in 1.7s`.
