### PR TITLE
feat(demo): in-browser WASM dashboard demo at /pacto/demo/

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,8 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
       - 'examples/demo/**'
+      # The demo embeds the dashboard UI + engine, so redeploy when they change.
+      - 'pkg/dashboard/**'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'examples/demo/**'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
@@ -30,6 +31,23 @@ jobs:
           cache-dependency-path: docs/requirements.txt
       - run: pip install -r docs/requirements.txt
       - run: mkdocs build
+      # Build the in-browser (WebAssembly) dashboard demo and fold it into the
+      # same Pages artifact at /pacto/demo/ (two Pages deploys in one repo
+      # conflict; one upload below publishes both docs and demo).
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Build the WASM dashboard demo
+        run: make -C examples/demo build BASE=/pacto/demo/
+      - name: Smoke test the wasm engine
+        run: make -C examples/demo smoke
+      - name: Fold the demo into the docs site
+        run: |
+          mkdir -p site/demo
+          cp -r examples/demo/dist/. site/demo/
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ e2e:
 	go test -tags e2e ./tests/e2e/ -v -count=1 -parallel 16 -timeout 120s
 
 coverage:
-	go test -race $(shell go list ./... | grep -v /tests/ | grep -v /testutil | grep -v /cmd/gendocs | grep -v /cmd/genbundle) -coverprofile=coverage.out
+	go test -race $(shell go list ./... | grep -v /tests/ | grep -v /testutil | grep -v /cmd/gendocs | grep -v /cmd/genbundle | grep -v /examples/) -coverprofile=coverage.out
 	go tool cover -html=coverage.out -o coverage.html
 	@go tool cover -func=coverage.out | tail -1
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A service's operational behavior — interfaces, dependencies, runtime semantics
 
 Pacto (/ˈpak.to/ — Spanish for *pact*) is not a replacement for OpenAPI, Helm, Terraform, Backstage, or Kubernetes. It adds the operational contract layer between them.
 
-**[Documentation](https://trianalab.github.io/pacto)** · **[Quickstart](https://trianalab.github.io/pacto/quickstart)** · **[Specification](https://trianalab.github.io/pacto/contract-reference)** · **[Examples](https://trianalab.github.io/pacto/examples)** · **[Demo](https://github.com/TrianaLab/pacto-demo)**
+**[Documentation](https://trianalab.github.io/pacto)** · **[Quickstart](https://trianalab.github.io/pacto/quickstart)** · **[Specification](https://trianalab.github.io/pacto/contract-reference)** · **[Examples](https://trianalab.github.io/pacto/examples)** · **[Live demo](https://trianalab.github.io/pacto/demo/)**
 
 > **Why Pacto exists** — [MANIFEST.md](MANIFEST.md)
 

--- a/ci.mk
+++ b/ci.mk
@@ -13,7 +13,7 @@ ci-static: ci-fmt ci-vet ci-cyclo ci-lint ci-docs ci-ui-drift
 
 ci-test: ci-ui
 	@echo "==> Running unit tests with race detector and coverage..."
-	@go test -race $$(go list ./... | grep -v /tests/ | grep -v /testutil | grep -v /cmd/gendocs | grep -v /cmd/genbundle) -coverprofile=coverage.out
+	@go test -race $$(go list ./... | grep -v /tests/ | grep -v /testutil | grep -v /cmd/gendocs | grep -v /cmd/genbundle | grep -v /examples/) -coverprofile=coverage.out
 	@total=$$(go tool cover -func=coverage.out | grep '^total:' | awk '{print $$NF}'); \
 	if [ "$$total" != "100.0%" ]; then \
 		echo "FAIL: total coverage is $$total, expected 100.0%"; \
@@ -21,6 +21,8 @@ ci-test: ci-ui
 		exit 1; \
 	fi
 	@echo "    total coverage: 100.0%"
+	@echo "==> Running example tests (no coverage gate)..."
+	@go test -race ./examples/...
 
 ci-ui:
 	@echo "==> Running frontend lint & tests..."

--- a/docs/examples/dashboard-demo.md
+++ b/docs/examples/dashboard-demo.md
@@ -1,0 +1,22 @@
+# Live dashboard demo
+
+The Pacto dashboard runs entirely in your browser as a static WebAssembly build —
+the Pacto engine and a curated set of demo contracts are compiled to WASM and
+served with no backend.
+
+**[Open the live dashboard demo →](/pacto/demo/)**
+
+It showcases the full UI against a realistic fleet:
+
+- **Fleet & compliance** — a dozen services across edge, domain, infra and
+  external tiers.
+- **Dependency graph** — resolved from each contract's declared dependencies,
+  with blast-radius highlighting.
+- **Version history & diff** — `payments-service` spans five versions; the
+  `v1.2.0 → v2.0.0` step is a breaking change that removes the `/charges` API.
+- **Readiness** — `payments-service` 2.1.0 declares a readiness gate that fails
+  (an expired evaluation drops its score to 70, below the required 80), while
+  `orders-service` 1.2.0 passes.
+
+The source and build harness live in
+[`examples/demo`](https://github.com/TrianaLab/pacto/tree/main/examples/demo).

--- a/examples/demo/.gitignore
+++ b/examples/demo/.gitignore
@@ -1,0 +1,7 @@
+# Generated build artifacts
+/dist/
+/.serve/
+/.ui-build/
+
+# Host build binary (named after the package dir)
+/demo

--- a/examples/demo/Makefile
+++ b/examples/demo/Makefile
@@ -1,0 +1,112 @@
+# Pacto dashboard — WebAssembly demo build.
+#
+# Produces a fully static site in $(DIST): the Pacto engine compiled to wasm, the
+# dashboard UI rebuilt for the target base path, and the glue that routes the
+# UI's API calls into wasm. No backend, no live OCI.
+#
+#   make build                 # build at the default base (/pacto/demo/)
+#   make build BASE=/          # build at site root (local preview)
+#   make serve                 # preview at the project base path
+#
+# Bundles live in ./bundles and are embedded directly (no copy step). The UI is
+# built from this repo's frontend source into a scratch dir and copied into
+# $(DIST) — the committed pkg/dashboard/ui build is never touched.
+
+BASE        ?= /pacto/demo/
+DIST        ?= dist
+GOROOT      := $(shell go env GOROOT)
+SERVE_PORT  ?= 8088
+FRONTEND    := $(abspath ../../pkg/dashboard/frontend)
+UI_BUILD    := $(abspath .ui-build)
+
+.PHONY: build preflight ui wasm wasmexec inject serve test smoke clean diff breaking-change evolution explain
+
+build: preflight ui wasm wasmexec inject
+	@echo "==> Built '$(DIST)' (base $(BASE))"
+
+## Fail fast with clear guidance if a previous `sudo make` left root-owned
+## artifacts a normal-user build can't overwrite. This build never needs root.
+preflight:
+	@bad=$$(find $(DIST) $(UI_BUILD) -user root 2>/dev/null | head -1); \
+	if [ -n "$$bad" ]; then \
+	  echo "ERROR: root-owned build artifacts found (from a previous 'sudo make')."; \
+	  echo "       This build does NOT need root. Remove them once with:"; \
+	  echo "         sudo rm -rf examples/demo/dist examples/demo/.ui-build"; \
+	  echo "       then re-run 'make build' WITHOUT sudo."; \
+	  exit 1; \
+	fi
+
+## Rebuild the dashboard UI from this repo's frontend source with the correct
+## base path, into a scratch dir, then copy into $(DIST). NEVER writes to
+## pkg/dashboard/ui (the committed base-/ build used by the real server).
+ui:
+	@rm -rf $(DIST) $(UI_BUILD) && mkdir -p $(DIST)
+	cd $(FRONTEND) && npm ci --no-audit --no-fund && npx vite build --base=$(BASE) --emptyOutDir --outDir $(UI_BUILD)
+	@cp -r $(UI_BUILD)/. $(DIST)/
+	@echo "==> Built UI (base $(BASE))"
+
+## Compile the engine to wasm. Bundles are embedded via //go:embed bundles.
+wasm:
+	@mkdir -p $(DIST)
+	GOOS=js GOARCH=wasm go build -ldflags="-s -w" -o $(DIST)/app.wasm .
+	@echo "==> Built $(DIST)/app.wasm ($$(du -h $(DIST)/app.wasm | cut -f1))"
+
+## Copy Go's wasm runtime glue (Go 1.24+ lib/wasm location).
+wasmexec:
+	@mkdir -p $(DIST)
+	@cp "$(GOROOT)/lib/wasm/wasm_exec.js" $(DIST)/wasm_exec.js
+	@echo "==> Copied wasm_exec.js"
+
+## Inject the wasm loader before the app's module script, add the SPA 404
+## fallback, and stamp the build. Idempotent: skips if already done.
+inject:
+	@cp boot.js $(DIST)/boot.js
+	@grep -q 'boot.js' $(DIST)/index.html || awk -v base="$(BASE)" '\
+	  /<script type="module"/ && !done { \
+	    print "  <script src=\"" base "wasm_exec.js\"></script>"; \
+	    print "  <script src=\"" base "boot.js\"></script>"; \
+	    done=1 \
+	  } { print }' $(DIST)/index.html > $(DIST)/index.html.tmp && mv -f $(DIST)/index.html.tmp $(DIST)/index.html
+	@cp $(DIST)/index.html $(DIST)/404.html
+	@printf '{"base":"%s"}\n' "$(BASE)" > $(DIST)/version.json
+	@echo "==> Injected loader, 404.html, version.json"
+
+## Run the EmbedSource host tests.
+test:
+	go test ./...
+
+## Exercise the built wasm engine end-to-end in Node (needs `make build` first).
+smoke:
+	node smoke.mjs
+
+## Preview locally under the same base path the site is deployed at.
+serve:
+	@rm -rf .serve && mkdir -p ".serve$(BASE)" && cp -r $(DIST)/. ".serve$(BASE)"
+	@echo "==> Open http://localhost:$(SERVE_PORT)$(BASE)"
+	@cd .serve && python3 -m http.server $(SERVE_PORT)
+
+## -- Offline CLI demo narrative (local bundles, no live OCI) ---------------
+## These use the locally built `pacto` (run `make build` at the repo root first).
+## `pacto validate` and `pacto graph` are intentionally omitted: they resolve
+## refs over the network and the demo publishes nothing. See the live dashboard
+## for the graph view.
+
+## Compare two contract versions: make diff OLD=<path> NEW=<path>
+diff:
+	@pacto diff $(OLD) $(NEW)
+
+## Show the payments-service breaking change (v1.2.0 -> v2.0.0).
+breaking-change:
+	@pacto diff bundles/payments-service/v1.2.0 bundles/payments-service/v2.0.0 --output-format markdown || true
+
+## Show a non-breaking evolution (v1.0.0 -> v1.1.0).
+evolution:
+	@pacto diff bundles/payments-service/v1.0.0 bundles/payments-service/v1.1.0 --output-format markdown || true
+
+## Print a human-readable summary of a contract: make explain REF=<path>
+explain:
+	@pacto explain $(REF)
+
+clean:
+	@rm -rf $(DIST) .serve $(UI_BUILD)
+	@echo "==> Cleaned"

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -1,0 +1,78 @@
+# Pacto dashboard — WebAssembly demo
+
+A static, browser-only build of `pacto dashboard`. The Pacto engine and a curated
+set of demo contracts are compiled to WebAssembly and baked in, so the whole
+dashboard — fleet, dependency graph, version history, version diff, readiness —
+runs client-side with no backend and no live registry.
+
+**Live site:** https://trianalab.github.io/pacto/demo/
+
+## How it works
+
+```
+index.html ─► assets/*          the dashboard's Svelte UI, rebuilt with base=/pacto/demo/
+   ├─ wasm_exec.js              Go's wasm runtime glue
+   └─ boot.js                   loads app.wasm; routes /api,/health,/metrics into wasm
+                                     │
+   app fetch('/api/services') ──────┘  (a fetch shim intercepts only those paths)
+                                     ▼
+                                app.wasm: httptest → Pacto's Huma handlers
+                                     │
+                                EmbedSource  (dashboard.DataSource over //go:embed bundles)
+```
+
+- `source_embed.go` — indexes the embedded bundles and implements `dashboard.DataSource`.
+- `main_wasm.go` — builds the dashboard's Huma API in memory and exposes `__pactoServe`.
+- `boot.js` — loads the wasm engine and shims `fetch` for `/api`, `/health`, `/metrics`.
+
+The graph, dependents and cross-reference views derive from each contract's
+declared dependencies (every referenced service is embedded), so no OCI resolver
+is needed.
+
+## Build
+
+Requirements: Go 1.26+, Node 22+, make.
+
+```bash
+make build                 # builds dist/ at base /pacto/demo/
+make build BASE=/          # build at site root for local preview
+make smoke                 # exercise the built wasm engine in Node
+make serve                 # preview at http://localhost:8088/pacto/demo/
+```
+
+`make build` rebuilds the dashboard UI from `../../pkg/dashboard/frontend` into a
+scratch dir and copies it into `dist/`; it never modifies the committed
+`pkg/dashboard/ui` (which the real `pacto dashboard` server uses).
+
+## Explore the contracts on the CLI (offline)
+
+These work on the local bundles with no registry. Build the CLI first with
+`make build` at the repo root.
+
+```bash
+# A breaking change: payments-service v1.2.0 -> v2.0.0 (drops /charges).
+make breaking-change
+
+# A non-breaking evolution: v1.0.0 -> v1.1.0.
+make evolution
+
+# Inspect any contract.
+make explain REF=bundles/payments-service/v2.1.0
+```
+
+Full contract validation (`pacto validate`) and live graph resolution
+(`pacto graph`) resolve refs over the network and require the contracts to be
+published to a registry; this demo publishes nothing, so use the live dashboard
+above for the dependency graph.
+
+## Size
+
+`app.wasm` is ≈52 MB raw / ~9.6 MB gzipped: it links Kubernetes and OCI client
+init code that the demo never calls, which dead-code elimination can't drop.
+Acceptable for a cached static asset.
+
+## Don't use sudo
+
+This build never needs root. A single `sudo make` leaves root-owned artifacts
+that wedge later non-sudo builds; the Makefile's preflight detects this and
+prints a one-time fix.

--- a/examples/demo/boot.js
+++ b/examples/demo/boot.js
@@ -1,0 +1,65 @@
+// boot.js — loads the Pacto engine (app.wasm) and routes the dashboard's API
+// calls into it, so the whole dashboard runs client-side with no backend.
+//
+// Injected as a classic script BEFORE the app's ES module, so the fetch shim is
+// installed before the Svelte app issues its first request. Loaded after
+// wasm_exec.js (which defines the global `Go`).
+(function () {
+  "use strict";
+
+  // Capture the real fetch before we shadow window.fetch below.
+  var realFetch = window.fetch.bind(window);
+
+  // Resolve sibling assets (app.wasm) relative to THIS script's URL so it works
+  // under any base path and from the 404.html SPA fallback at a deep link.
+  var scriptURL = (document.currentScript && document.currentScript.src) || window.location.href;
+
+  // Readiness gate: the Go runtime calls __pactoOnReady() once __pactoServe is
+  // installed. API calls made before then queue on this promise.
+  var resolveReady;
+  window.__pactoReady = new Promise(function (resolve) { resolveReady = resolve; });
+  window.__pactoOnReady = function () { resolveReady(); };
+
+  function instantiate(url, importObject) {
+    if (typeof WebAssembly.instantiateStreaming === "function") {
+      return WebAssembly.instantiateStreaming(realFetch(url), importObject).catch(function () {
+        // Fallback when the host serves app.wasm with the wrong MIME type.
+        return realFetch(url)
+          .then(function (r) { return r.arrayBuffer(); })
+          .then(function (buf) { return WebAssembly.instantiate(buf, importObject); });
+      });
+    }
+    return realFetch(url)
+      .then(function (r) { return r.arrayBuffer(); })
+      .then(function (buf) { return WebAssembly.instantiate(buf, importObject); });
+  }
+
+  var go = new Go();
+  instantiate(new URL("app.wasm", scriptURL), go.importObject)
+    .then(function (result) { go.run(result.instance); })
+    .catch(function (err) { console.error("Pacto engine failed to load:", err); });
+
+  // Only the dashboard's own endpoints are served by wasm; all other requests
+  // (assets, lazy chunks) go to the network as usual.
+  function isApiPath(pathname) {
+    return pathname.indexOf("/api/") === 0 || pathname === "/health" || pathname === "/metrics";
+  }
+
+  window.fetch = function (input, init) {
+    init = init || {};
+    var rawURL = typeof input === "string" ? input : input.url;
+    var u = new URL(rawURL, window.location.href);
+    if (!isApiPath(u.pathname)) {
+      return realFetch(input, init);
+    }
+    var method = (init.method || (typeof input !== "string" && input.method) || "GET").toUpperCase();
+    var body = init.body != null ? String(init.body) : null;
+    return window.__pactoReady.then(function () {
+      var res = window.__pactoServe(method, u.pathname + u.search, body);
+      return new Response(res.body, {
+        status: res.status,
+        headers: { "Content-Type": res.contentType || "application/json" },
+      });
+    });
+  };
+})();

--- a/examples/demo/bundles/api-gateway/v1.0.0/configuration/schema.json
+++ b/examples/demo/bundles/api-gateway/v1.0.0/configuration/schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "API Gateway Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ],
+      "default": "info"
+    },
+    "LOG_FORMAT": {
+      "type": "string",
+      "enum": [
+        "json",
+        "text"
+      ],
+      "default": "json"
+    },
+    "OTEL_EXPORTER_ENDPOINT": {
+      "type": "string",
+      "format": "uri"
+    },
+    "OTEL_SERVICE_NAME": {
+      "type": "string"
+    },
+    "METRICS_PORT": {
+      "type": "integer",
+      "default": 9090
+    },
+    "HEALTH_CHECK_INTERVAL_SECONDS": {
+      "type": "integer",
+      "default": 10
+    },
+    "AUTH_SERVICE_URL": {
+      "type": "string"
+    },
+    "ORDERS_SERVICE_URL": {
+      "type": "string",
+      "format": "uri"
+    },
+    "PAYMENTS_SERVICE_URL": {
+      "type": "string",
+      "format": "uri"
+    },
+    "REQUEST_TIMEOUT_SECONDS": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "AUTH_SERVICE_URL",
+    "ORDERS_SERVICE_URL",
+    "PAYMENTS_SERVICE_URL",
+    "REQUEST_TIMEOUT_SECONDS"
+  ]
+}

--- a/examples/demo/bundles/api-gateway/v1.0.0/docs/overview.md
+++ b/examples/demo/bundles/api-gateway/v1.0.0/docs/overview.md
@@ -1,0 +1,11 @@
+# API Gateway v1.0.0
+
+Central API gateway handling request routing, authentication enforcement, rate limiting, and CORS. Uses a local policy schema (not ref-based) to demonstrate inline policy definition.
+
+## Interfaces
+- **HTTP** on port 8080 (public) - REST API
+
+## Dependencies
+- **auth-service** (required) - Token validation
+- **orders-service** (required) - Order management
+- **payments-service** (required) - Payment processing

--- a/examples/demo/bundles/api-gateway/v1.0.0/interfaces/openapi.json
+++ b/examples/demo/bundles/api-gateway/v1.0.0/interfaces/openapi.json
@@ -1,0 +1,78 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "API Gateway",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/api/v1/auth/login": {
+      "post": {
+        "operationId": "login",
+        "summary": "Authenticate user",
+        "responses": {
+          "200": { "description": "Authentication successful" },
+          "401": { "description": "Invalid credentials" }
+        }
+      }
+    },
+    "/api/v1/auth/refresh": {
+      "post": {
+        "operationId": "refreshToken",
+        "summary": "Refresh access token",
+        "responses": {
+          "200": { "description": "Token refreshed" },
+          "401": { "description": "Invalid refresh token" }
+        }
+      }
+    },
+    "/api/v1/orders": {
+      "get": {
+        "operationId": "listOrders",
+        "summary": "List orders",
+        "responses": {
+          "200": { "description": "List of orders" }
+        }
+      },
+      "post": {
+        "operationId": "createOrder",
+        "summary": "Create a new order",
+        "responses": {
+          "201": { "description": "Order created" },
+          "400": { "description": "Invalid request" }
+        }
+      }
+    },
+    "/api/v1/orders/{id}": {
+      "get": {
+        "operationId": "getOrder",
+        "summary": "Get order details",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Order details" },
+          "404": { "description": "Order not found" }
+        }
+      }
+    },
+    "/api/v1/payments/charges": {
+      "post": {
+        "operationId": "createCharge",
+        "summary": "Create a payment charge",
+        "responses": {
+          "201": { "description": "Charge created" },
+          "402": { "description": "Payment failed" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "healthCheck",
+        "summary": "Gateway health check",
+        "responses": {
+          "200": { "description": "Service healthy" }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/api-gateway/v1.0.0/pacto.yaml
+++ b/examples/demo/bundles/api-gateway/v1.0.0/pacto.yaml
@@ -1,0 +1,75 @@
+pactoVersion: "1.0"
+
+service:
+  name: api-gateway
+  version: 1.0.0
+  owner: team/platform
+  image:
+    ref: ghcr.io/trianalab/pacto-demo/api-gateway
+
+interfaces:
+  - name: http
+    type: http
+    port: 8080
+    visibility: public
+    contract: interfaces/openapi.json
+
+configurations:
+  - name: platform
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-app-config
+  - name: app
+    schema: configuration/schema.json
+    values:
+      OTEL_SERVICE_NAME: api-gateway
+      AUTH_SERVICE_URL: auth-service:50051
+      ORDERS_SERVICE_URL: http://orders-service:8082
+      PAYMENTS_SERVICE_URL: http://payments-service:8083
+      REQUEST_TIMEOUT_SECONDS: 30
+
+policies:
+  - name: gateway-routing
+    schema: policy/schema.json
+
+dependencies:
+  - name: auth-service
+    ref: oci://ghcr.io/trianalab/pacto-demo/auth-service
+    required: true
+    compatibility: "^1.0.0"
+  - name: orders-service
+    ref: oci://ghcr.io/trianalab/pacto-demo/orders-service
+    required: true
+    compatibility: "^1.0.0"
+  - name: payments-service
+    ref: oci://ghcr.io/trianalab/pacto-demo/payments-service
+    required: true
+    compatibility: "^1.0.0"
+
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 30
+
+scaling:
+  min: 2
+  max: 5
+
+metadata:
+  tier: edge
+  category: gateway
+  criticality: high
+  summary: Central API gateway routing requests to domain services with auth enforcement
+  language: go
+  repo: github.com/trianalab/pacto-demo/api-gateway
+  tags:
+    - gateway
+    - routing
+    - authentication
+    - rate-limiting
+    - public

--- a/examples/demo/bundles/api-gateway/v1.0.0/policy/schema.json
+++ b/examples/demo/bundles/api-gateway/v1.0.0/policy/schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "API Gateway Policy",
+  "description": "Enforces gateway-specific standards: public HTTP interface, scaling bounds, and dependency declarations",
+  "type": "object",
+  "properties": {
+    "interfaces": {
+      "type": "array",
+      "minItems": 1,
+      "contains": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "http" },
+          "visibility": { "const": "public" }
+        },
+        "required": ["type", "visibility"]
+      }
+    },
+    "scaling": {
+      "type": "object",
+      "properties": {
+        "min": { "type": "integer", "minimum": 2 }
+      },
+      "required": ["min"]
+    },
+    "dependencies": {
+      "type": "array",
+      "minItems": 1
+    }
+  },
+  "required": ["interfaces", "scaling", "dependencies"]
+}

--- a/examples/demo/bundles/api-gateway/v1.1.0/configuration/schema.json
+++ b/examples/demo/bundles/api-gateway/v1.1.0/configuration/schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "API Gateway Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ],
+      "default": "info"
+    },
+    "LOG_FORMAT": {
+      "type": "string",
+      "enum": [
+        "json",
+        "text"
+      ],
+      "default": "json"
+    },
+    "OTEL_EXPORTER_ENDPOINT": {
+      "type": "string",
+      "format": "uri"
+    },
+    "OTEL_SERVICE_NAME": {
+      "type": "string"
+    },
+    "METRICS_PORT": {
+      "type": "integer",
+      "default": 9090
+    },
+    "HEALTH_CHECK_INTERVAL_SECONDS": {
+      "type": "integer",
+      "default": 10
+    },
+    "AUTH_SERVICE_URL": {
+      "type": "string"
+    },
+    "ORDERS_SERVICE_URL": {
+      "type": "string",
+      "format": "uri"
+    },
+    "PAYMENTS_SERVICE_URL": {
+      "type": "string",
+      "format": "uri"
+    },
+    "REQUEST_TIMEOUT_SECONDS": {
+      "type": "integer"
+    },
+    "ENABLE_WEBSOCKETS": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "AUTH_SERVICE_URL",
+    "ORDERS_SERVICE_URL",
+    "PAYMENTS_SERVICE_URL",
+    "REQUEST_TIMEOUT_SECONDS",
+    "ENABLE_WEBSOCKETS"
+  ]
+}

--- a/examples/demo/bundles/api-gateway/v1.1.0/docs/overview.md
+++ b/examples/demo/bundles/api-gateway/v1.1.0/docs/overview.md
@@ -1,0 +1,8 @@
+# API Gateway v1.1.0
+
+Adds WebSocket support for real-time order tracking updates and order tracking endpoint.
+
+## Changes from v1.0.0
+- Added GET /api/v1/orders/{id}/tracking endpoint
+- Added WebSocket endpoint /ws/orders/{id}/updates
+- Added ENABLE_WEBSOCKETS configuration

--- a/examples/demo/bundles/api-gateway/v1.1.0/interfaces/openapi.json
+++ b/examples/demo/bundles/api-gateway/v1.1.0/interfaces/openapi.json
@@ -1,0 +1,103 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "API Gateway",
+    "version": "1.1.0"
+  },
+  "paths": {
+    "/api/v1/auth/login": {
+      "post": {
+        "operationId": "login",
+        "summary": "Authenticate user",
+        "responses": {
+          "200": { "description": "Authentication successful" },
+          "401": { "description": "Invalid credentials" }
+        }
+      }
+    },
+    "/api/v1/auth/refresh": {
+      "post": {
+        "operationId": "refreshToken",
+        "summary": "Refresh access token",
+        "responses": {
+          "200": { "description": "Token refreshed" },
+          "401": { "description": "Invalid refresh token" }
+        }
+      }
+    },
+    "/api/v1/orders": {
+      "get": {
+        "operationId": "listOrders",
+        "summary": "List orders",
+        "responses": {
+          "200": { "description": "List of orders" }
+        }
+      },
+      "post": {
+        "operationId": "createOrder",
+        "summary": "Create a new order",
+        "responses": {
+          "201": { "description": "Order created" },
+          "400": { "description": "Invalid request" }
+        }
+      }
+    },
+    "/api/v1/orders/{id}": {
+      "get": {
+        "operationId": "getOrder",
+        "summary": "Get order details",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Order details" },
+          "404": { "description": "Order not found" }
+        }
+      }
+    },
+    "/api/v1/orders/{id}/tracking": {
+      "get": {
+        "operationId": "getOrderTracking",
+        "summary": "Get order tracking status",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Tracking information" },
+          "404": { "description": "Order not found" }
+        }
+      }
+    },
+    "/api/v1/payments/charges": {
+      "post": {
+        "operationId": "createCharge",
+        "summary": "Create a payment charge",
+        "responses": {
+          "201": { "description": "Charge created" },
+          "402": { "description": "Payment failed" }
+        }
+      }
+    },
+    "/ws/orders/{id}/updates": {
+      "get": {
+        "operationId": "orderUpdatesWebSocket",
+        "summary": "WebSocket for real-time order updates",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "101": { "description": "WebSocket upgrade" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "healthCheck",
+        "summary": "Gateway health check",
+        "responses": {
+          "200": { "description": "Service healthy" }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/api-gateway/v1.1.0/pacto.yaml
+++ b/examples/demo/bundles/api-gateway/v1.1.0/pacto.yaml
@@ -1,0 +1,76 @@
+pactoVersion: "1.0"
+
+service:
+  name: api-gateway
+  version: 1.1.0
+  owner: team/platform
+  image:
+    ref: ghcr.io/trianalab/pacto-demo/api-gateway
+
+interfaces:
+  - name: http
+    type: http
+    port: 8080
+    visibility: public
+    contract: interfaces/openapi.json
+
+configurations:
+  - name: platform
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-app-config
+  - name: app
+    schema: configuration/schema.json
+    values:
+      OTEL_SERVICE_NAME: api-gateway
+      AUTH_SERVICE_URL: auth-service:50051
+      ORDERS_SERVICE_URL: http://orders-service:8082
+      PAYMENTS_SERVICE_URL: http://payments-service:8083
+      REQUEST_TIMEOUT_SECONDS: 30
+      ENABLE_WEBSOCKETS: true
+
+policies:
+  - name: gateway-routing
+    schema: policy/schema.json
+
+dependencies:
+  - name: auth-service
+    ref: oci://ghcr.io/trianalab/pacto-demo/auth-service
+    required: true
+    compatibility: "^1.0.0"
+  - name: orders-service
+    ref: oci://ghcr.io/trianalab/pacto-demo/orders-service
+    required: true
+    compatibility: "^1.0.0"
+  - name: payments-service
+    ref: oci://ghcr.io/trianalab/pacto-demo/payments-service
+    required: true
+    compatibility: "^1.0.0"
+
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 30
+
+scaling:
+  min: 2
+  max: 5
+
+metadata:
+  tier: edge
+  category: gateway
+  criticality: high
+  summary: API gateway with WebSocket support and order tracking endpoints
+  language: go
+  repo: github.com/trianalab/pacto-demo/api-gateway
+  tags:
+    - gateway
+    - routing
+    - websockets
+    - authentication
+    - public

--- a/examples/demo/bundles/api-gateway/v1.1.0/policy/schema.json
+++ b/examples/demo/bundles/api-gateway/v1.1.0/policy/schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "API Gateway Policy",
+  "description": "Enforces gateway-specific standards: public HTTP interface, scaling bounds, and dependency declarations",
+  "type": "object",
+  "properties": {
+    "interfaces": {
+      "type": "array",
+      "minItems": 1,
+      "contains": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "http" },
+          "visibility": { "const": "public" }
+        },
+        "required": ["type", "visibility"]
+      }
+    },
+    "scaling": {
+      "type": "object",
+      "properties": {
+        "min": { "type": "integer", "minimum": 2 }
+      },
+      "required": ["min"]
+    },
+    "dependencies": {
+      "type": "array",
+      "minItems": 1
+    }
+  },
+  "required": ["interfaces", "scaling", "dependencies"]
+}

--- a/examples/demo/bundles/api-gateway/v1.2.0/configuration/schema.json
+++ b/examples/demo/bundles/api-gateway/v1.2.0/configuration/schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "API Gateway Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ],
+      "default": "info"
+    },
+    "LOG_FORMAT": {
+      "type": "string",
+      "enum": [
+        "json",
+        "text"
+      ],
+      "default": "json"
+    },
+    "OTEL_EXPORTER_ENDPOINT": {
+      "type": "string",
+      "format": "uri"
+    },
+    "OTEL_SERVICE_NAME": {
+      "type": "string"
+    },
+    "METRICS_PORT": {
+      "type": "integer",
+      "default": 9090
+    },
+    "HEALTH_CHECK_INTERVAL_SECONDS": {
+      "type": "integer",
+      "default": 10
+    },
+    "AUTH_SERVICE_URL": {
+      "type": "string"
+    },
+    "ORDERS_SERVICE_URL": {
+      "type": "string",
+      "format": "uri"
+    },
+    "PAYMENTS_SERVICE_URL": {
+      "type": "string",
+      "format": "uri"
+    },
+    "REQUEST_TIMEOUT_SECONDS": {
+      "type": "integer"
+    },
+    "ENABLE_WEBSOCKETS": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "AUTH_SERVICE_URL",
+    "ORDERS_SERVICE_URL",
+    "PAYMENTS_SERVICE_URL",
+    "REQUEST_TIMEOUT_SECONDS",
+    "ENABLE_WEBSOCKETS"
+  ]
+}

--- a/examples/demo/bundles/api-gateway/v1.2.0/docs/overview.md
+++ b/examples/demo/bundles/api-gateway/v1.2.0/docs/overview.md
@@ -1,0 +1,7 @@
+# API Gateway v1.2.0
+
+Introduces structured ownership metadata with team, DRI, and contact information.
+
+## Changes from v1.1.0
+- Migrated `owner` from simple string to structured ownership model
+- Added team, DRI, and contact channels (email, chat, oncall)

--- a/examples/demo/bundles/api-gateway/v1.2.0/interfaces/openapi.json
+++ b/examples/demo/bundles/api-gateway/v1.2.0/interfaces/openapi.json
@@ -1,0 +1,103 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "API Gateway",
+    "version": "1.1.0"
+  },
+  "paths": {
+    "/api/v1/auth/login": {
+      "post": {
+        "operationId": "login",
+        "summary": "Authenticate user",
+        "responses": {
+          "200": { "description": "Authentication successful" },
+          "401": { "description": "Invalid credentials" }
+        }
+      }
+    },
+    "/api/v1/auth/refresh": {
+      "post": {
+        "operationId": "refreshToken",
+        "summary": "Refresh access token",
+        "responses": {
+          "200": { "description": "Token refreshed" },
+          "401": { "description": "Invalid refresh token" }
+        }
+      }
+    },
+    "/api/v1/orders": {
+      "get": {
+        "operationId": "listOrders",
+        "summary": "List orders",
+        "responses": {
+          "200": { "description": "List of orders" }
+        }
+      },
+      "post": {
+        "operationId": "createOrder",
+        "summary": "Create a new order",
+        "responses": {
+          "201": { "description": "Order created" },
+          "400": { "description": "Invalid request" }
+        }
+      }
+    },
+    "/api/v1/orders/{id}": {
+      "get": {
+        "operationId": "getOrder",
+        "summary": "Get order details",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Order details" },
+          "404": { "description": "Order not found" }
+        }
+      }
+    },
+    "/api/v1/orders/{id}/tracking": {
+      "get": {
+        "operationId": "getOrderTracking",
+        "summary": "Get order tracking status",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Tracking information" },
+          "404": { "description": "Order not found" }
+        }
+      }
+    },
+    "/api/v1/payments/charges": {
+      "post": {
+        "operationId": "createCharge",
+        "summary": "Create a payment charge",
+        "responses": {
+          "201": { "description": "Charge created" },
+          "402": { "description": "Payment failed" }
+        }
+      }
+    },
+    "/ws/orders/{id}/updates": {
+      "get": {
+        "operationId": "orderUpdatesWebSocket",
+        "summary": "WebSocket for real-time order updates",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "101": { "description": "WebSocket upgrade" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "healthCheck",
+        "summary": "Gateway health check",
+        "responses": {
+          "200": { "description": "Service healthy" }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/api-gateway/v1.2.0/pacto.yaml
+++ b/examples/demo/bundles/api-gateway/v1.2.0/pacto.yaml
@@ -1,0 +1,88 @@
+pactoVersion: "1.0"
+
+service:
+  name: api-gateway
+  version: 1.2.0
+  owner:
+    team: platform-foundations
+    dri: bob.martinez
+    contacts:
+      - type: email
+        value: platform-foundations@acme.com
+        purpose: escalation
+      - type: chat
+        value: "#platform-foundations"
+        purpose: support
+      - type: oncall
+        value: platform-foundations-oncall
+        purpose: oncall
+  image:
+    ref: ghcr.io/trianalab/pacto-demo/api-gateway
+
+interfaces:
+  - name: http
+    type: http
+    port: 8080
+    visibility: public
+    contract: interfaces/openapi.json
+
+configurations:
+  - name: platform
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-app-config
+  - name: app
+    schema: configuration/schema.json
+    values:
+      OTEL_SERVICE_NAME: api-gateway
+      AUTH_SERVICE_URL: auth-service:50051
+      ORDERS_SERVICE_URL: http://orders-service:8082
+      PAYMENTS_SERVICE_URL: http://payments-service:8083
+      REQUEST_TIMEOUT_SECONDS: 30
+      ENABLE_WEBSOCKETS: true
+
+policies:
+  - name: gateway-routing
+    schema: policy/schema.json
+
+dependencies:
+  - name: auth-service
+    ref: oci://ghcr.io/trianalab/pacto-demo/auth-service
+    required: true
+    compatibility: "^1.0.0"
+  - name: orders-service
+    ref: oci://ghcr.io/trianalab/pacto-demo/orders-service
+    required: true
+    compatibility: "^1.0.0"
+  - name: payments-service
+    ref: oci://ghcr.io/trianalab/pacto-demo/payments-service
+    required: true
+    compatibility: "^1.0.0"
+
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 30
+
+scaling:
+  min: 2
+  max: 5
+
+metadata:
+  tier: edge
+  category: gateway
+  criticality: high
+  summary: API gateway with WebSocket support, order tracking, and structured ownership metadata
+  language: go
+  repo: github.com/trianalab/pacto-demo/api-gateway
+  tags:
+    - gateway
+    - routing
+    - websockets
+    - authentication
+    - public

--- a/examples/demo/bundles/api-gateway/v1.2.0/policy/schema.json
+++ b/examples/demo/bundles/api-gateway/v1.2.0/policy/schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "API Gateway Policy",
+  "description": "Enforces gateway-specific standards: public HTTP interface, scaling bounds, and dependency declarations",
+  "type": "object",
+  "properties": {
+    "interfaces": {
+      "type": "array",
+      "minItems": 1,
+      "contains": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "http" },
+          "visibility": { "const": "public" }
+        },
+        "required": ["type", "visibility"]
+      }
+    },
+    "scaling": {
+      "type": "object",
+      "properties": {
+        "min": { "type": "integer", "minimum": 2 }
+      },
+      "required": ["min"]
+    },
+    "dependencies": {
+      "type": "array",
+      "minItems": 1
+    }
+  },
+  "required": ["interfaces", "scaling", "dependencies"]
+}

--- a/examples/demo/bundles/auth-service/configuration/schema.json
+++ b/examples/demo/bundles/auth-service/configuration/schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Auth Service Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ],
+      "default": "info"
+    },
+    "LOG_FORMAT": {
+      "type": "string",
+      "enum": [
+        "json",
+        "text"
+      ],
+      "default": "json"
+    },
+    "OTEL_EXPORTER_ENDPOINT": {
+      "type": "string",
+      "format": "uri"
+    },
+    "OTEL_SERVICE_NAME": {
+      "type": "string"
+    },
+    "METRICS_PORT": {
+      "type": "integer",
+      "default": 9090
+    },
+    "HEALTH_CHECK_INTERVAL_SECONDS": {
+      "type": "integer",
+      "default": 10
+    },
+    "JWT_ISSUER": {
+      "type": "string",
+      "format": "uri"
+    },
+    "JWT_EXPIRY_SECONDS": {
+      "type": "integer"
+    },
+    "SESSION_STORE": {
+      "type": "string"
+    },
+    "BCRYPT_COST": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "JWT_ISSUER",
+    "JWT_EXPIRY_SECONDS",
+    "SESSION_STORE",
+    "BCRYPT_COST"
+  ]
+}

--- a/examples/demo/bundles/auth-service/docs/overview.md
+++ b/examples/demo/bundles/auth-service/docs/overview.md
@@ -1,0 +1,12 @@
+# Auth Service
+
+gRPC-based authentication and authorization service. Manages JWT token lifecycle, session storage in Redis, and user credential validation.
+
+## Interfaces
+- **gRPC** on port 50051 (internal)
+
+## Dependencies
+- **redis** - Session and token storage
+
+## State
+Hybrid - stateless request handling with semi-persistent session data in Redis.

--- a/examples/demo/bundles/auth-service/interfaces/auth.proto
+++ b/examples/demo/bundles/auth-service/interfaces/auth.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+
+package auth.v1;
+
+option go_package = "github.com/trianalab/pacto-demo/auth-service/gen/auth/v1";
+
+service AuthService {
+  rpc Authenticate(AuthenticateRequest) returns (AuthenticateResponse);
+  rpc ValidateToken(ValidateTokenRequest) returns (ValidateTokenResponse);
+  rpc RefreshToken(RefreshTokenRequest) returns (RefreshTokenResponse);
+  rpc RevokeToken(RevokeTokenRequest) returns (RevokeTokenResponse);
+}
+
+message AuthenticateRequest {
+  string email = 1;
+  string password = 2;
+}
+
+message AuthenticateResponse {
+  string access_token = 1;
+  string refresh_token = 2;
+  int64 expires_at = 3;
+}
+
+message ValidateTokenRequest {
+  string token = 1;
+}
+
+message ValidateTokenResponse {
+  bool valid = 1;
+  string user_id = 2;
+  repeated string roles = 3;
+}
+
+message RefreshTokenRequest {
+  string refresh_token = 1;
+}
+
+message RefreshTokenResponse {
+  string access_token = 1;
+  string refresh_token = 2;
+  int64 expires_at = 3;
+}
+
+message RevokeTokenRequest {
+  string token = 1;
+}
+
+message RevokeTokenResponse {
+  bool revoked = 1;
+}

--- a/examples/demo/bundles/auth-service/pacto.yaml
+++ b/examples/demo/bundles/auth-service/pacto.yaml
@@ -1,0 +1,83 @@
+pactoVersion: "1.0"
+
+service:
+  name: auth-service
+  version: 1.0.0
+  owner:
+    team: identity-team
+    dri: erik.nilsson
+    contacts:
+      - type: email
+        value: identity-team@acme.com
+        purpose: escalation
+      - type: chat
+        value: "#identity-team"
+        purpose: support
+      - type: oncall
+        value: identity-team-oncall
+        purpose: oncall
+  image:
+    ref: ghcr.io/trianalab/pacto-demo/auth-service
+
+interfaces:
+  - name: http
+    type: http
+    port: 8081
+    visibility: internal
+  - name: grpc
+    type: grpc
+    port: 9091
+    visibility: internal
+    contract: interfaces/auth.proto
+
+configurations:
+  - name: platform
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-app-config
+  - name: app
+    schema: configuration/schema.json
+    values:
+      OTEL_SERVICE_NAME: auth-service
+      JWT_ISSUER: https://auth.platform.internal
+      JWT_EXPIRY_SECONDS: 3600
+      SESSION_STORE: redis
+      BCRYPT_COST: 12
+
+policies:
+  - name: http-security
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-http-policy
+
+dependencies:
+  - name: redis
+    ref: oci://ghcr.io/trianalab/pacto-demo/redis
+    required: true
+    compatibility: "^7.0.0"
+
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: high
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 30
+
+scaling:
+  min: 2
+  max: 4
+
+metadata:
+  tier: domain
+  category: identity
+  criticality: high
+  summary: Authentication and authorization service managing JWT tokens and sessions
+  language: go
+  repo: github.com/trianalab/pacto-demo/auth-service
+  tags:
+    - authentication
+    - authorization
+    - jwt
+    - sessions
+    - identity

--- a/examples/demo/bundles/email-provider/docs/overview.md
+++ b/examples/demo/bundles/email-provider/docs/overview.md
@@ -1,0 +1,3 @@
+# Email Provider
+
+External email delivery service (SendGrid) used by notification-worker for transactional emails.

--- a/examples/demo/bundles/email-provider/interfaces/openapi.json
+++ b/examples/demo/bundles/email-provider/interfaces/openapi.json
@@ -1,0 +1,28 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Email Provider API (SendGrid subset)",
+    "version": "1.0.0",
+    "description": "External email delivery API"
+  },
+  "paths": {
+    "/v3/mail/send": {
+      "post": {
+        "operationId": "sendEmail",
+        "summary": "Send a transactional email",
+        "responses": {
+          "202": { "description": "Email accepted for delivery" }
+        }
+      }
+    },
+    "/v3/mail/batch": {
+      "post": {
+        "operationId": "sendBatchEmail",
+        "summary": "Send batch emails",
+        "responses": {
+          "202": { "description": "Batch accepted for delivery" }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/email-provider/pacto.yaml
+++ b/examples/demo/bundles/email-provider/pacto.yaml
@@ -1,0 +1,34 @@
+pactoVersion: "1.0"
+
+service:
+  name: email-provider
+  version: 1.0.0
+  owner:
+    team: external/sendgrid
+    contacts:
+      - type: url
+        value: https://support.sendgrid.com
+        purpose: support
+      - type: url
+        value: https://status.sendgrid.com
+        purpose: oncall
+
+interfaces:
+  - name: http
+    type: http
+    port: 443
+    visibility: public
+    contract: interfaces/openapi.json
+
+metadata:
+  tier: external
+  category: notifications
+  criticality: medium
+  summary: External email delivery provider (SendGrid)
+  serviceType: external
+  protocol: https
+  tags:
+    - email
+    - notifications
+    - external
+    - sendgrid

--- a/examples/demo/bundles/fraud-service/configuration/schema.json
+++ b/examples/demo/bundles/fraud-service/configuration/schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Fraud Service Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": ["debug", "info", "warn", "error"],
+      "default": "info"
+    },
+    "RISK_THRESHOLD": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "default": 0.7,
+      "description": "Transactions scoring above this threshold are flagged as fraudulent"
+    },
+    "MODEL_VERSION": {
+      "type": "string",
+      "description": "Version of the fraud detection ML model"
+    },
+    "REDIS_URL": {
+      "type": "string",
+      "format": "uri",
+      "description": "Redis connection URL for feature caching"
+    }
+  },
+  "required": ["LOG_LEVEL", "RISK_THRESHOLD", "MODEL_VERSION", "REDIS_URL"]
+}

--- a/examples/demo/bundles/fraud-service/docs/overview.md
+++ b/examples/demo/bundles/fraud-service/docs/overview.md
@@ -1,0 +1,9 @@
+# Fraud Service
+
+gRPC-based real-time fraud detection service. Evaluates transactions using ML-based risk scoring and caches feature data in Redis.
+
+## Interfaces
+- **gRPC** on port 50052 (internal)
+
+## Dependencies
+- **redis** - Feature caching for ML model

--- a/examples/demo/bundles/fraud-service/interfaces/fraud.proto
+++ b/examples/demo/bundles/fraud-service/interfaces/fraud.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package fraud.v1;
+
+option go_package = "github.com/trianalab/pacto-demo/fraud-service/gen/fraud/v1";
+
+service FraudService {
+  rpc EvaluateTransaction(EvaluateTransactionRequest) returns (EvaluateTransactionResponse);
+  rpc ReportFraud(ReportFraudRequest) returns (ReportFraudResponse);
+}
+
+message EvaluateTransactionRequest {
+  string transaction_id = 1;
+  double amount = 2;
+  string currency = 3;
+  string customer_id = 4;
+  string payment_method = 5;
+  string ip_address = 6;
+  map<string, string> metadata = 7;
+}
+
+message EvaluateTransactionResponse {
+  string transaction_id = 1;
+  double risk_score = 2;
+  bool flagged = 3;
+  repeated string risk_signals = 4;
+  string recommendation = 5;
+}
+
+message ReportFraudRequest {
+  string transaction_id = 1;
+  string reason = 2;
+}
+
+message ReportFraudResponse {
+  bool acknowledged = 1;
+}

--- a/examples/demo/bundles/fraud-service/pacto.yaml
+++ b/examples/demo/bundles/fraud-service/pacto.yaml
@@ -1,0 +1,76 @@
+pactoVersion: "1.0"
+
+service:
+  name: fraud-service
+  version: 1.0.0
+  owner:
+    team: payments-team
+    dri: priya.sharma
+    contacts:
+      - type: email
+        value: payments-team@acme.com
+        purpose: escalation
+      - type: chat
+        value: "#payments-team"
+        purpose: support
+      - type: oncall
+        value: payments-oncall
+        purpose: oncall
+  image:
+    ref: ghcr.io/trianalab/pacto-demo/fraud-service
+
+interfaces:
+  - name: http
+    type: http
+    port: 8084
+    visibility: internal
+
+configurations:
+  - name: platform
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-app-config
+  - name: app
+    schema: configuration/schema.json
+    values:
+      LOG_LEVEL: info
+      RISK_THRESHOLD: 0.7
+      MODEL_VERSION: v2.3.1
+      REDIS_URL: redis://redis:6379/2
+
+policies:
+  - name: http-security
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-http-policy
+
+dependencies:
+  - name: redis
+    ref: oci://ghcr.io/trianalab/pacto-demo/redis
+    required: true
+    compatibility: "^7.0.0"
+
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 30
+
+scaling:
+  min: 2
+  max: 4
+
+metadata:
+  tier: domain
+  category: payments
+  criticality: high
+  summary: Real-time fraud detection service using ML-based risk scoring
+  language: go
+  repo: github.com/trianalab/pacto-demo/fraud-service
+  tags:
+    - fraud-detection
+    - risk-scoring
+    - ml
+    - payments

--- a/examples/demo/bundles/frontend/configuration/schema.json
+++ b/examples/demo/bundles/frontend/configuration/schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Frontend Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ],
+      "default": "info"
+    },
+    "LOG_FORMAT": {
+      "type": "string",
+      "enum": [
+        "json",
+        "text"
+      ],
+      "default": "json"
+    },
+    "OTEL_EXPORTER_ENDPOINT": {
+      "type": "string",
+      "format": "uri"
+    },
+    "OTEL_SERVICE_NAME": {
+      "type": "string"
+    },
+    "METRICS_PORT": {
+      "type": "integer",
+      "default": 9090
+    },
+    "HEALTH_CHECK_INTERVAL_SECONDS": {
+      "type": "integer",
+      "default": 10
+    },
+    "API_GATEWAY_URL": {
+      "type": "string",
+      "format": "uri"
+    },
+    "NEXT_PUBLIC_APP_NAME": {
+      "type": "string"
+    },
+    "NODE_ENV": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "API_GATEWAY_URL",
+    "NEXT_PUBLIC_APP_NAME",
+    "NODE_ENV"
+  ]
+}

--- a/examples/demo/bundles/frontend/docs/overview.md
+++ b/examples/demo/bundles/frontend/docs/overview.md
@@ -1,0 +1,9 @@
+# Frontend
+
+Customer-facing Next.js web application. Serves the e-commerce storefront including product catalog, shopping cart, checkout, and order history.
+
+## Interfaces
+- **HTTP** on port 3000 (public) - Web application
+
+## Dependencies
+- **api-gateway** (required) - Backend API access

--- a/examples/demo/bundles/frontend/interfaces/openapi.json
+++ b/examples/demo/bundles/frontend/interfaces/openapi.json
@@ -1,0 +1,64 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Frontend",
+    "version": "1.0.0",
+    "description": "Customer-facing web application"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "home",
+        "summary": "Home page",
+        "responses": {
+          "200": { "description": "HTML page" }
+        }
+      }
+    },
+    "/products": {
+      "get": {
+        "operationId": "listProducts",
+        "summary": "Product catalog page",
+        "responses": {
+          "200": { "description": "HTML page" }
+        }
+      }
+    },
+    "/cart": {
+      "get": {
+        "operationId": "viewCart",
+        "summary": "Shopping cart page",
+        "responses": {
+          "200": { "description": "HTML page" }
+        }
+      }
+    },
+    "/checkout": {
+      "get": {
+        "operationId": "checkout",
+        "summary": "Checkout page",
+        "responses": {
+          "200": { "description": "HTML page" }
+        }
+      }
+    },
+    "/orders": {
+      "get": {
+        "operationId": "orderHistory",
+        "summary": "Order history page",
+        "responses": {
+          "200": { "description": "HTML page" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "healthCheck",
+        "summary": "Health check",
+        "responses": {
+          "200": { "description": "Service healthy" }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/frontend/pacto.yaml
+++ b/examples/demo/bundles/frontend/pacto.yaml
@@ -1,0 +1,74 @@
+pactoVersion: "1.0"
+
+service:
+  name: frontend
+  version: 1.0.0
+  owner:
+    team: frontend-team
+    dri: diana.chen
+    contacts:
+      - type: email
+        value: frontend-team@acme.com
+        purpose: escalation
+      - type: chat
+        value: "#frontend-team"
+        purpose: support
+  image:
+    ref: ghcr.io/trianalab/pacto-demo/frontend
+
+interfaces:
+  - name: http
+    type: http
+    port: 3000
+    visibility: public
+    contract: interfaces/openapi.json
+
+configurations:
+  - name: platform
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-app-config
+  - name: app
+    schema: configuration/schema.json
+    values:
+      OTEL_SERVICE_NAME: frontend
+      API_GATEWAY_URL: http://api-gateway:8080
+      NEXT_PUBLIC_APP_NAME: "Commerce Platform"
+      NODE_ENV: production
+
+policies:
+  - name: http-security
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-http-policy
+
+dependencies:
+  - name: api-gateway
+    ref: oci://ghcr.io/trianalab/pacto-demo/api-gateway
+    required: true
+    compatibility: "^1.0.0"
+
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 15
+
+scaling:
+  min: 2
+  max: 6
+
+metadata:
+  tier: edge
+  category: frontend
+  criticality: high
+  summary: Customer-facing web application for the e-commerce platform
+  language: typescript
+  repo: github.com/trianalab/pacto-demo/frontend
+  tags:
+    - frontend
+    - nextjs
+    - web
+    - public

--- a/examples/demo/bundles/notification-worker/configuration/schema.json
+++ b/examples/demo/bundles/notification-worker/configuration/schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Notification Worker Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ],
+      "default": "info"
+    },
+    "LOG_FORMAT": {
+      "type": "string",
+      "enum": [
+        "json",
+        "text"
+      ],
+      "default": "json"
+    },
+    "OTEL_EXPORTER_ENDPOINT": {
+      "type": "string",
+      "format": "uri"
+    },
+    "WORKER_CONCURRENCY": {
+      "type": "integer",
+      "default": 5
+    },
+    "RETRY_MAX_ATTEMPTS": {
+      "type": "integer",
+      "default": 3
+    },
+    "RETRY_BACKOFF_SECONDS": {
+      "type": "integer",
+      "default": 5
+    },
+    "DEAD_LETTER_QUEUE_ENABLED": {
+      "type": "boolean",
+      "default": true
+    },
+    "OTEL_SERVICE_NAME": {
+      "type": "string"
+    },
+    "EMAIL_PROVIDER_URL": {
+      "type": "string",
+      "format": "uri"
+    },
+    "EMAIL_FROM": {
+      "type": "string",
+      "format": "email"
+    },
+    "SENDGRID_API_KEY": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "EMAIL_PROVIDER_URL",
+    "EMAIL_FROM",
+    "SENDGRID_API_KEY"
+  ]
+}

--- a/examples/demo/bundles/notification-worker/docs/overview.md
+++ b/examples/demo/bundles/notification-worker/docs/overview.md
@@ -1,0 +1,12 @@
+# Notification Worker
+
+Background worker that consumes notification events and dispatches emails via the external email provider. Runs as a scheduled workload with configurable concurrency and retry policies.
+
+## Interfaces
+- **Events** (internal) - Consumes notification requests, publishes delivery status
+
+## Dependencies
+- **email-provider** - External email delivery (SendGrid)
+
+## Workload
+Scheduled worker with dead letter queue support.

--- a/examples/demo/bundles/notification-worker/interfaces/events.json
+++ b/examples/demo/bundles/notification-worker/interfaces/events.json
@@ -1,0 +1,64 @@
+{
+  "asyncapi": "2.6.0",
+  "info": {
+    "title": "Notification Worker Events",
+    "version": "1.0.0",
+    "description": "Events consumed and produced by the notification worker"
+  },
+  "channels": {
+    "notification.email.requested": {
+      "subscribe": {
+        "operationId": "onEmailRequested",
+        "summary": "Email notification request received",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "notification_id": { "type": "string" },
+              "to": { "type": "string", "format": "email" },
+              "template": { "type": "string" },
+              "variables": { "type": "object" },
+              "priority": { "type": "string", "enum": ["low", "normal", "high"] }
+            },
+            "required": ["notification_id", "to", "template"]
+          }
+        }
+      }
+    },
+    "notification.sent": {
+      "publish": {
+        "operationId": "notificationSent",
+        "summary": "Notification successfully delivered",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "notification_id": { "type": "string" },
+              "channel": { "type": "string" },
+              "delivered_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["notification_id", "channel", "delivered_at"]
+          }
+        }
+      }
+    },
+    "notification.failed": {
+      "publish": {
+        "operationId": "notificationFailed",
+        "summary": "Notification delivery failed",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "notification_id": { "type": "string" },
+              "error": { "type": "string" },
+              "retry_count": { "type": "integer" },
+              "will_retry": { "type": "boolean" }
+            },
+            "required": ["notification_id", "error"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/notification-worker/pacto.yaml
+++ b/examples/demo/bundles/notification-worker/pacto.yaml
@@ -1,0 +1,74 @@
+pactoVersion: "1.0"
+
+service:
+  name: notification-worker
+  version: 1.0.0
+  owner:
+    team: commerce-team
+    dri: fatima.ahmed
+    contacts:
+      - type: email
+        value: commerce-team@acme.com
+        purpose: escalation
+      - type: chat
+        value: "#commerce-team"
+        purpose: support
+  image:
+    ref: ghcr.io/trianalab/pacto-demo/notification-worker:1.0.0
+
+interfaces:
+  - name: events
+    type: event
+    visibility: internal
+    contract: interfaces/events.json
+
+configurations:
+  - name: platform
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-worker-config
+  - name: app
+    schema: configuration/schema.json
+    values:
+      OTEL_SERVICE_NAME: notification-worker
+      WORKER_CONCURRENCY: 3
+      EMAIL_PROVIDER_URL: https://api.sendgrid.com
+      EMAIL_FROM: noreply@platform.example.com
+      SENDGRID_API_KEY: "${SENDGRID_API_KEY}"
+
+policies:
+  - name: http-security
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-http-policy
+
+dependencies:
+  - name: email-provider
+    ref: oci://ghcr.io/trianalab/pacto-demo/email-provider
+    required: true
+    compatibility: "^1.0.0"
+
+runtime:
+  workload: scheduled
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 30
+
+scaling:
+  replicas: 1
+
+metadata:
+  tier: domain
+  category: notifications
+  criticality: medium
+  summary: Background worker that processes notification events and sends emails
+  language: go
+  repo: github.com/trianalab/pacto-demo/notification-worker
+  tags:
+    - notifications
+    - email
+    - worker
+    - events
+    - scheduled

--- a/examples/demo/bundles/orders-service/v1.0.0/configuration/schema.json
+++ b/examples/demo/bundles/orders-service/v1.0.0/configuration/schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Orders Service Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ],
+      "default": "info"
+    },
+    "LOG_FORMAT": {
+      "type": "string",
+      "enum": [
+        "json",
+        "text"
+      ],
+      "default": "json"
+    },
+    "OTEL_EXPORTER_ENDPOINT": {
+      "type": "string",
+      "format": "uri"
+    },
+    "OTEL_SERVICE_NAME": {
+      "type": "string"
+    },
+    "METRICS_PORT": {
+      "type": "integer",
+      "default": 9090
+    },
+    "HEALTH_CHECK_INTERVAL_SECONDS": {
+      "type": "integer",
+      "default": 10
+    },
+    "DATABASE_URL": {
+      "type": "string",
+      "format": "uri"
+    },
+    "PAYMENTS_SERVICE_URL": {
+      "type": "string",
+      "format": "uri"
+    }
+  },
+  "required": [
+    "DATABASE_URL",
+    "PAYMENTS_SERVICE_URL"
+  ]
+}

--- a/examples/demo/bundles/orders-service/v1.0.0/docs/overview.md
+++ b/examples/demo/bundles/orders-service/v1.0.0/docs/overview.md
@@ -1,0 +1,12 @@
+# Orders Service v1.0.0
+
+Order management service handling the full order lifecycle: creation, fulfillment, and cancellation.
+
+## Interfaces
+- **HTTP** on port 8082 (internal) - REST API for order CRUD
+- **Events** (internal) - Publishes order lifecycle events
+
+## Dependencies
+- **postgresql** (required) - Order persistence
+- **payments-service** (required) - Payment processing
+- **notification-worker** (optional) - Order notification emails

--- a/examples/demo/bundles/orders-service/v1.0.0/interfaces/events.json
+++ b/examples/demo/bundles/orders-service/v1.0.0/interfaces/events.json
@@ -1,0 +1,61 @@
+{
+  "asyncapi": "2.6.0",
+  "info": {
+    "title": "Orders Service Events",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "order.created": {
+      "publish": {
+        "operationId": "orderCreated",
+        "summary": "New order has been created",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "order_id": { "type": "string" },
+              "customer_id": { "type": "string" },
+              "total_amount": { "type": "number" },
+              "currency": { "type": "string" },
+              "created_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["order_id", "customer_id", "total_amount", "currency"]
+          }
+        }
+      }
+    },
+    "order.completed": {
+      "publish": {
+        "operationId": "orderCompleted",
+        "summary": "Order has been fulfilled",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "order_id": { "type": "string" },
+              "completed_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["order_id", "completed_at"]
+          }
+        }
+      }
+    },
+    "order.cancelled": {
+      "publish": {
+        "operationId": "orderCancelled",
+        "summary": "Order has been cancelled",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "order_id": { "type": "string" },
+              "reason": { "type": "string" },
+              "cancelled_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["order_id", "cancelled_at"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/orders-service/v1.0.0/interfaces/openapi.json
+++ b/examples/demo/bundles/orders-service/v1.0.0/interfaces/openapi.json
@@ -1,0 +1,94 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Orders Service API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/orders": {
+      "post": {
+        "operationId": "createOrder",
+        "summary": "Create a new order",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "customer_id": { "type": "string" },
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "product_id": { "type": "string" },
+                        "quantity": { "type": "integer" },
+                        "unit_price": { "type": "number" }
+                      },
+                      "required": ["product_id", "quantity", "unit_price"]
+                    }
+                  },
+                  "currency": { "type": "string" }
+                },
+                "required": ["customer_id", "items", "currency"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Order created" },
+          "400": { "description": "Invalid request" }
+        }
+      },
+      "get": {
+        "operationId": "listOrders",
+        "summary": "List orders with pagination",
+        "parameters": [
+          { "name": "customer_id", "in": "query", "schema": { "type": "string" } },
+          { "name": "status", "in": "query", "schema": { "type": "string" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" } },
+          { "name": "offset", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "List of orders" }
+        }
+      }
+    },
+    "/orders/{id}": {
+      "get": {
+        "operationId": "getOrder",
+        "summary": "Get order by ID",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Order details" },
+          "404": { "description": "Order not found" }
+        }
+      }
+    },
+    "/orders/{id}/cancel": {
+      "post": {
+        "operationId": "cancelOrder",
+        "summary": "Cancel an order",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Order cancelled" },
+          "409": { "description": "Order cannot be cancelled" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "healthCheck",
+        "summary": "Health check endpoint",
+        "responses": {
+          "200": { "description": "Service healthy" }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/orders-service/v1.0.0/pacto.yaml
+++ b/examples/demo/bundles/orders-service/v1.0.0/pacto.yaml
@@ -1,0 +1,76 @@
+pactoVersion: "1.0"
+
+service:
+  name: orders-service
+  version: 1.0.0
+  owner: team/commerce
+  image:
+    ref: ghcr.io/trianalab/pacto-demo/orders-service
+
+interfaces:
+  - name: http
+    type: http
+    port: 8082
+    visibility: internal
+    contract: interfaces/openapi.json
+  - name: events
+    type: event
+    visibility: internal
+    contract: interfaces/events.json
+
+configurations:
+  - name: platform
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-app-config
+  - name: app
+    schema: configuration/schema.json
+    values:
+      OTEL_SERVICE_NAME: orders-service
+      DATABASE_URL: postgresql://postgres:5432/orders
+      PAYMENTS_SERVICE_URL: http://payments-service:8083
+
+policies:
+  - name: http-security
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-http-policy
+
+dependencies:
+  - name: postgresql
+    ref: oci://ghcr.io/trianalab/pacto-demo/postgresql
+    required: true
+    compatibility: "^16.0.0"
+  - name: payments-service
+    ref: oci://ghcr.io/trianalab/pacto-demo/payments-service
+    required: true
+    compatibility: "^1.0.0"
+  - name: notification-worker
+    ref: oci://ghcr.io/trianalab/pacto-demo/notification-worker
+    required: false
+    compatibility: "^1.0.0"
+
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: high
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 30
+
+scaling:
+  min: 2
+  max: 5
+
+metadata:
+  tier: domain
+  category: orders
+  criticality: high
+  summary: Order management service handling order lifecycle and fulfillment
+  language: go
+  repo: github.com/trianalab/pacto-demo/orders-service
+  tags:
+    - orders
+    - commerce
+    - fulfillment
+    - events

--- a/examples/demo/bundles/orders-service/v1.1.0/configuration/schema.json
+++ b/examples/demo/bundles/orders-service/v1.1.0/configuration/schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Orders Service Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ],
+      "default": "info"
+    },
+    "LOG_FORMAT": {
+      "type": "string",
+      "enum": [
+        "json",
+        "text"
+      ],
+      "default": "json"
+    },
+    "OTEL_EXPORTER_ENDPOINT": {
+      "type": "string",
+      "format": "uri"
+    },
+    "OTEL_SERVICE_NAME": {
+      "type": "string"
+    },
+    "METRICS_PORT": {
+      "type": "integer",
+      "default": 9090
+    },
+    "HEALTH_CHECK_INTERVAL_SECONDS": {
+      "type": "integer",
+      "default": 10
+    },
+    "DATABASE_URL": {
+      "type": "string",
+      "format": "uri"
+    },
+    "PAYMENTS_SERVICE_URL": {
+      "type": "string",
+      "format": "uri"
+    },
+    "ENABLE_ORDER_TRACKING": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "DATABASE_URL",
+    "PAYMENTS_SERVICE_URL",
+    "ENABLE_ORDER_TRACKING"
+  ]
+}

--- a/examples/demo/bundles/orders-service/v1.1.0/docs/overview.md
+++ b/examples/demo/bundles/orders-service/v1.1.0/docs/overview.md
@@ -1,0 +1,10 @@
+# Orders Service v1.1.0
+
+Adds order tracking and shipping events. notification-worker dependency becomes required.
+
+## Changes from v1.0.0
+- Added `GET /orders/{id}/tracking` endpoint
+- Added `order.shipped` event
+- Added `shipping_address` field to order creation
+- `notification-worker` dependency is now required
+- Added `ENABLE_ORDER_TRACKING` config

--- a/examples/demo/bundles/orders-service/v1.1.0/interfaces/events.json
+++ b/examples/demo/bundles/orders-service/v1.1.0/interfaces/events.json
@@ -1,0 +1,79 @@
+{
+  "asyncapi": "2.6.0",
+  "info": {
+    "title": "Orders Service Events",
+    "version": "1.1.0"
+  },
+  "channels": {
+    "order.created": {
+      "publish": {
+        "operationId": "orderCreated",
+        "summary": "New order has been created",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "order_id": { "type": "string" },
+              "customer_id": { "type": "string" },
+              "total_amount": { "type": "number" },
+              "currency": { "type": "string" },
+              "created_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["order_id", "customer_id", "total_amount", "currency"]
+          }
+        }
+      }
+    },
+    "order.completed": {
+      "publish": {
+        "operationId": "orderCompleted",
+        "summary": "Order has been fulfilled",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "order_id": { "type": "string" },
+              "completed_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["order_id", "completed_at"]
+          }
+        }
+      }
+    },
+    "order.cancelled": {
+      "publish": {
+        "operationId": "orderCancelled",
+        "summary": "Order has been cancelled",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "order_id": { "type": "string" },
+              "reason": { "type": "string" },
+              "cancelled_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["order_id", "cancelled_at"]
+          }
+        }
+      }
+    },
+    "order.shipped": {
+      "publish": {
+        "operationId": "orderShipped",
+        "summary": "Order has been shipped",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "order_id": { "type": "string" },
+              "tracking_number": { "type": "string" },
+              "carrier": { "type": "string" },
+              "shipped_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["order_id", "tracking_number", "shipped_at"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/orders-service/v1.1.0/interfaces/openapi.json
+++ b/examples/demo/bundles/orders-service/v1.1.0/interfaces/openapi.json
@@ -1,0 +1,116 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Orders Service API",
+    "version": "1.1.0"
+  },
+  "paths": {
+    "/orders": {
+      "post": {
+        "operationId": "createOrder",
+        "summary": "Create a new order",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "customer_id": { "type": "string" },
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "product_id": { "type": "string" },
+                        "quantity": { "type": "integer" },
+                        "unit_price": { "type": "number" }
+                      },
+                      "required": ["product_id", "quantity", "unit_price"]
+                    }
+                  },
+                  "currency": { "type": "string" },
+                  "shipping_address": {
+                    "type": "object",
+                    "properties": {
+                      "line1": { "type": "string" },
+                      "city": { "type": "string" },
+                      "country": { "type": "string" },
+                      "postal_code": { "type": "string" }
+                    }
+                  }
+                },
+                "required": ["customer_id", "items", "currency"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Order created" },
+          "400": { "description": "Invalid request" }
+        }
+      },
+      "get": {
+        "operationId": "listOrders",
+        "summary": "List orders with pagination",
+        "parameters": [
+          { "name": "customer_id", "in": "query", "schema": { "type": "string" } },
+          { "name": "status", "in": "query", "schema": { "type": "string" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" } },
+          { "name": "offset", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "List of orders" }
+        }
+      }
+    },
+    "/orders/{id}": {
+      "get": {
+        "operationId": "getOrder",
+        "summary": "Get order by ID",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Order details" },
+          "404": { "description": "Order not found" }
+        }
+      }
+    },
+    "/orders/{id}/cancel": {
+      "post": {
+        "operationId": "cancelOrder",
+        "summary": "Cancel an order",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Order cancelled" },
+          "409": { "description": "Order cannot be cancelled" }
+        }
+      }
+    },
+    "/orders/{id}/tracking": {
+      "get": {
+        "operationId": "getOrderTracking",
+        "summary": "Get order tracking status",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Tracking information" },
+          "404": { "description": "Order not found" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "healthCheck",
+        "summary": "Health check endpoint",
+        "responses": {
+          "200": { "description": "Service healthy" }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/orders-service/v1.1.0/pacto.yaml
+++ b/examples/demo/bundles/orders-service/v1.1.0/pacto.yaml
@@ -1,0 +1,78 @@
+pactoVersion: "1.0"
+
+service:
+  name: orders-service
+  version: 1.1.0
+  owner: team/commerce
+  image:
+    ref: ghcr.io/trianalab/pacto-demo/orders-service
+
+interfaces:
+  - name: http
+    type: http
+    port: 8082
+    visibility: internal
+    contract: interfaces/openapi.json
+  - name: events
+    type: event
+    visibility: internal
+    contract: interfaces/events.json
+
+configurations:
+  - name: platform
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-app-config
+  - name: app
+    schema: configuration/schema.json
+    values:
+      OTEL_SERVICE_NAME: orders-service
+      DATABASE_URL: postgresql://postgres:5432/orders
+      PAYMENTS_SERVICE_URL: http://payments-service:8083
+      ENABLE_ORDER_TRACKING: true
+
+policies:
+  - name: http-security
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-http-policy
+
+dependencies:
+  - name: postgresql
+    ref: oci://ghcr.io/trianalab/pacto-demo/postgresql
+    required: true
+    compatibility: "^16.0.0"
+  - name: payments-service
+    ref: oci://ghcr.io/trianalab/pacto-demo/payments-service
+    required: true
+    compatibility: "^1.0.0"
+  - name: notification-worker
+    ref: oci://ghcr.io/trianalab/pacto-demo/notification-worker
+    required: true
+    compatibility: "^1.0.0"
+
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: high
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 30
+
+scaling:
+  min: 2
+  max: 5
+
+metadata:
+  tier: domain
+  category: orders
+  criticality: high
+  summary: Order management service with tracking and fulfillment status
+  language: go
+  repo: github.com/trianalab/pacto-demo/orders-service
+  tags:
+    - orders
+    - commerce
+    - fulfillment
+    - tracking
+    - events

--- a/examples/demo/bundles/orders-service/v1.2.0/configuration/schema.json
+++ b/examples/demo/bundles/orders-service/v1.2.0/configuration/schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Orders Service Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ],
+      "default": "info"
+    },
+    "LOG_FORMAT": {
+      "type": "string",
+      "enum": [
+        "json",
+        "text"
+      ],
+      "default": "json"
+    },
+    "OTEL_EXPORTER_ENDPOINT": {
+      "type": "string",
+      "format": "uri"
+    },
+    "OTEL_SERVICE_NAME": {
+      "type": "string"
+    },
+    "METRICS_PORT": {
+      "type": "integer",
+      "default": 9090
+    },
+    "HEALTH_CHECK_INTERVAL_SECONDS": {
+      "type": "integer",
+      "default": 10
+    },
+    "DATABASE_URL": {
+      "type": "string",
+      "format": "uri"
+    },
+    "PAYMENTS_SERVICE_URL": {
+      "type": "string",
+      "format": "uri"
+    },
+    "ENABLE_ORDER_TRACKING": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "DATABASE_URL",
+    "PAYMENTS_SERVICE_URL",
+    "ENABLE_ORDER_TRACKING"
+  ]
+}

--- a/examples/demo/bundles/orders-service/v1.2.0/docs/overview.md
+++ b/examples/demo/bundles/orders-service/v1.2.0/docs/overview.md
@@ -1,0 +1,7 @@
+# Orders Service v1.2.0
+
+Introduces structured ownership metadata with team, DRI, and contact information.
+
+## Changes from v1.1.0
+- Migrated `owner` from simple string to structured ownership model
+- Added team, DRI, and contact channels (email, chat, oncall)

--- a/examples/demo/bundles/orders-service/v1.2.0/docs/runbooks/orders-service.md
+++ b/examples/demo/bundles/orders-service/v1.2.0/docs/runbooks/orders-service.md
@@ -1,0 +1,13 @@
+# Orders Service — On-Call Runbook
+
+## Overview
+The orders-service manages order lifecycle, tracking and fulfillment, calling
+payments-service and emitting order events.
+
+## Common incidents
+- **Payment call failures** — check payments-service health and timeouts.
+- **Event publish lag** — inspect the notification-worker consumer.
+- **Database latency** — review the PostgreSQL `orders` database.
+
+## Escalation
+Page `commerce-oncall`; escalate to the commerce-team DRI.

--- a/examples/demo/bundles/orders-service/v1.2.0/interfaces/events.json
+++ b/examples/demo/bundles/orders-service/v1.2.0/interfaces/events.json
@@ -1,0 +1,79 @@
+{
+  "asyncapi": "2.6.0",
+  "info": {
+    "title": "Orders Service Events",
+    "version": "1.1.0"
+  },
+  "channels": {
+    "order.created": {
+      "publish": {
+        "operationId": "orderCreated",
+        "summary": "New order has been created",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "order_id": { "type": "string" },
+              "customer_id": { "type": "string" },
+              "total_amount": { "type": "number" },
+              "currency": { "type": "string" },
+              "created_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["order_id", "customer_id", "total_amount", "currency"]
+          }
+        }
+      }
+    },
+    "order.completed": {
+      "publish": {
+        "operationId": "orderCompleted",
+        "summary": "Order has been fulfilled",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "order_id": { "type": "string" },
+              "completed_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["order_id", "completed_at"]
+          }
+        }
+      }
+    },
+    "order.cancelled": {
+      "publish": {
+        "operationId": "orderCancelled",
+        "summary": "Order has been cancelled",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "order_id": { "type": "string" },
+              "reason": { "type": "string" },
+              "cancelled_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["order_id", "cancelled_at"]
+          }
+        }
+      }
+    },
+    "order.shipped": {
+      "publish": {
+        "operationId": "orderShipped",
+        "summary": "Order has been shipped",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "order_id": { "type": "string" },
+              "tracking_number": { "type": "string" },
+              "carrier": { "type": "string" },
+              "shipped_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["order_id", "tracking_number", "shipped_at"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/orders-service/v1.2.0/interfaces/openapi.json
+++ b/examples/demo/bundles/orders-service/v1.2.0/interfaces/openapi.json
@@ -1,0 +1,116 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Orders Service API",
+    "version": "1.1.0"
+  },
+  "paths": {
+    "/orders": {
+      "post": {
+        "operationId": "createOrder",
+        "summary": "Create a new order",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "customer_id": { "type": "string" },
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "product_id": { "type": "string" },
+                        "quantity": { "type": "integer" },
+                        "unit_price": { "type": "number" }
+                      },
+                      "required": ["product_id", "quantity", "unit_price"]
+                    }
+                  },
+                  "currency": { "type": "string" },
+                  "shipping_address": {
+                    "type": "object",
+                    "properties": {
+                      "line1": { "type": "string" },
+                      "city": { "type": "string" },
+                      "country": { "type": "string" },
+                      "postal_code": { "type": "string" }
+                    }
+                  }
+                },
+                "required": ["customer_id", "items", "currency"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Order created" },
+          "400": { "description": "Invalid request" }
+        }
+      },
+      "get": {
+        "operationId": "listOrders",
+        "summary": "List orders with pagination",
+        "parameters": [
+          { "name": "customer_id", "in": "query", "schema": { "type": "string" } },
+          { "name": "status", "in": "query", "schema": { "type": "string" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" } },
+          { "name": "offset", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "List of orders" }
+        }
+      }
+    },
+    "/orders/{id}": {
+      "get": {
+        "operationId": "getOrder",
+        "summary": "Get order by ID",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Order details" },
+          "404": { "description": "Order not found" }
+        }
+      }
+    },
+    "/orders/{id}/cancel": {
+      "post": {
+        "operationId": "cancelOrder",
+        "summary": "Cancel an order",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Order cancelled" },
+          "409": { "description": "Order cannot be cancelled" }
+        }
+      }
+    },
+    "/orders/{id}/tracking": {
+      "get": {
+        "operationId": "getOrderTracking",
+        "summary": "Get order tracking status",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Tracking information" },
+          "404": { "description": "Order not found" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "healthCheck",
+        "summary": "Health check endpoint",
+        "responses": {
+          "200": { "description": "Service healthy" }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/orders-service/v1.2.0/pacto.yaml
+++ b/examples/demo/bundles/orders-service/v1.2.0/pacto.yaml
@@ -1,4 +1,4 @@
-pactoVersion: "1.0"
+pactoVersion: "1.1"
 
 service:
   name: orders-service
@@ -88,3 +88,25 @@ metadata:
     - fulfillment
     - tracking
     - events
+
+readiness:
+  minScore: 80
+  checks:
+    - id: dashboard
+      type: url
+      evidence: https://grafana.acme.com/d/orders-service
+      weight: 40
+      expires: "2099-12-31"
+      description: Production Grafana dashboard
+    - id: runbook
+      type: document
+      evidence: docs/runbooks/orders-service.md
+      weight: 30
+      expires: "2099-12-31"
+      description: On-call runbook
+    - id: security-review
+      type: ticket
+      evidence: SEC-2099
+      weight: 30
+      expires: "2099-12-31"
+      description: Annual security review

--- a/examples/demo/bundles/orders-service/v1.2.0/pacto.yaml
+++ b/examples/demo/bundles/orders-service/v1.2.0/pacto.yaml
@@ -1,0 +1,90 @@
+pactoVersion: "1.0"
+
+service:
+  name: orders-service
+  version: 1.2.0
+  owner:
+    team: commerce-team
+    dri: fatima.ahmed
+    contacts:
+      - type: email
+        value: commerce-team@acme.com
+        purpose: escalation
+      - type: chat
+        value: "#commerce-team"
+        purpose: support
+      - type: oncall
+        value: commerce-oncall
+        purpose: oncall
+  image:
+    ref: ghcr.io/trianalab/pacto-demo/orders-service
+
+interfaces:
+  - name: http
+    type: http
+    port: 8082
+    visibility: internal
+    contract: interfaces/openapi.json
+  - name: events
+    type: event
+    visibility: internal
+    contract: interfaces/events.json
+
+configurations:
+  - name: platform
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-app-config
+  - name: app
+    schema: configuration/schema.json
+    values:
+      OTEL_SERVICE_NAME: orders-service
+      DATABASE_URL: postgresql://postgres:5432/orders
+      PAYMENTS_SERVICE_URL: http://payments-service:8083
+      ENABLE_ORDER_TRACKING: true
+
+policies:
+  - name: http-security
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-http-policy
+
+dependencies:
+  - name: postgresql
+    ref: oci://ghcr.io/trianalab/pacto-demo/postgresql
+    required: true
+    compatibility: "^16.0.0"
+  - name: payments-service
+    ref: oci://ghcr.io/trianalab/pacto-demo/payments-service
+    required: true
+    compatibility: "^1.0.0"
+  - name: notification-worker
+    ref: oci://ghcr.io/trianalab/pacto-demo/notification-worker
+    required: true
+    compatibility: "^1.0.0"
+
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: high
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 30
+
+scaling:
+  min: 2
+  max: 5
+
+metadata:
+  tier: domain
+  category: orders
+  criticality: high
+  summary: Order management service with tracking, fulfillment, and structured ownership metadata
+  language: go
+  repo: github.com/trianalab/pacto-demo/orders-service
+  tags:
+    - orders
+    - commerce
+    - fulfillment
+    - tracking
+    - events

--- a/examples/demo/bundles/pacto-demo/docs/overview.md
+++ b/examples/demo/bundles/pacto-demo/docs/overview.md
@@ -1,0 +1,11 @@
+# Pacto Demo
+
+Single entry point for the entire e-commerce platform graph. Depends only on `frontend` - all other services are discovered recursively through the dependency chain.
+
+## Usage
+
+```
+pacto dashboard oci://ghcr.io/trianalab/pacto-demo/pacto-demo
+```
+
+This reveals the full platform: frontend -> api-gateway -> [auth, orders, payments] -> [postgresql, redis, stripe, fraud, notifications] -> [email-provider].

--- a/examples/demo/bundles/pacto-demo/pacto.yaml
+++ b/examples/demo/bundles/pacto-demo/pacto.yaml
@@ -1,0 +1,44 @@
+pactoVersion: "1.0"
+
+service:
+  name: pacto-demo
+  version: 1.0.0
+  owner:
+    team: platform-foundations
+    dri: alice.johnson
+    contacts:
+      - type: email
+        value: platform-foundations@acme.com
+        purpose: escalation
+      - type: chat
+        value: "#platform-foundations"
+        purpose: support
+
+dependencies:
+  - name: frontend
+    ref: oci://ghcr.io/trianalab/pacto-demo/frontend
+    required: true
+    compatibility: "^1.0.0"
+
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 5
+
+metadata:
+  tier: demo-root
+  category: platform
+  criticality: low
+  summary: Entry point for full platform graph - discovers all services recursively via frontend
+  tags:
+    - demo
+    - root
+    - entry-point
+    - platform

--- a/examples/demo/bundles/payments-service/v1.0.0/configuration/schema.json
+++ b/examples/demo/bundles/payments-service/v1.0.0/configuration/schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Payments Service Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": ["debug", "info", "warn", "error"],
+      "default": "info"
+    },
+    "STRIPE_API_KEY": {
+      "type": "string",
+      "description": "Stripe API secret key for payment processing"
+    },
+    "PAYMENTS_DB_URL": {
+      "type": "string",
+      "format": "uri",
+      "description": "PostgreSQL connection string for payments database"
+    },
+    "ENABLE_REFUNDS": {
+      "type": "boolean",
+      "default": true,
+      "description": "Feature flag to enable/disable refund processing"
+    }
+  },
+  "required": ["STRIPE_API_KEY", "PAYMENTS_DB_URL"]
+}

--- a/examples/demo/bundles/payments-service/v1.0.0/docs/overview.md
+++ b/examples/demo/bundles/payments-service/v1.0.0/docs/overview.md
@@ -1,0 +1,16 @@
+# Payments Service v1.0.0
+
+Core payment processing service. Handles charge creation, retrieval, and refunds via Stripe.
+
+## Interfaces
+- **HTTP** on port 8083 (internal) - REST API for charges and refunds
+- **Events** (internal) - Publishes payment lifecycle events
+
+## Dependencies
+- **postgresql** (required) - Payment transaction persistence
+- **stripe-api** (required) - External payment processing
+
+## Endpoints
+- POST /charges - Create a charge
+- GET /charges/{id} - Get charge details
+- POST /refunds - Create a refund

--- a/examples/demo/bundles/payments-service/v1.0.0/interfaces/events.json
+++ b/examples/demo/bundles/payments-service/v1.0.0/interfaces/events.json
@@ -1,0 +1,47 @@
+{
+  "asyncapi": "2.6.0",
+  "info": {
+    "title": "Payments Service Events",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "payment.completed": {
+      "publish": {
+        "operationId": "paymentCompleted",
+        "summary": "Payment has been successfully processed",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "charge_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "currency": { "type": "string" },
+              "customer_id": { "type": "string" },
+              "completed_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["charge_id", "amount", "currency", "customer_id"]
+          }
+        }
+      }
+    },
+    "payment.refunded": {
+      "publish": {
+        "operationId": "paymentRefunded",
+        "summary": "Payment has been refunded",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "charge_id": { "type": "string" },
+              "refund_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "reason": { "type": "string" },
+              "refunded_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["charge_id", "refund_id", "amount"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/payments-service/v1.0.0/interfaces/openapi.json
+++ b/examples/demo/bundles/payments-service/v1.0.0/interfaces/openapi.json
@@ -1,0 +1,87 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Payments Service API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/charges": {
+      "post": {
+        "operationId": "createCharge",
+        "summary": "Create a new charge",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "amount": { "type": "integer", "description": "Amount in cents" },
+                  "currency": { "type": "string" },
+                  "customer_id": { "type": "string" },
+                  "payment_method": { "type": "string" },
+                  "description": { "type": "string" }
+                },
+                "required": ["amount", "currency", "customer_id", "payment_method"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Charge created successfully" },
+          "400": { "description": "Invalid request" },
+          "402": { "description": "Payment failed" }
+        }
+      }
+    },
+    "/charges/{id}": {
+      "get": {
+        "operationId": "getCharge",
+        "summary": "Retrieve a charge by ID",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Charge details" },
+          "404": { "description": "Charge not found" }
+        }
+      }
+    },
+    "/refunds": {
+      "post": {
+        "operationId": "createRefund",
+        "summary": "Create a refund for a charge",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "charge_id": { "type": "string" },
+                  "amount": { "type": "integer", "description": "Refund amount in cents (partial refund if less than charge)" },
+                  "reason": { "type": "string", "enum": ["duplicate", "fraudulent", "requested_by_customer"] }
+                },
+                "required": ["charge_id"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Refund created" },
+          "400": { "description": "Invalid request" },
+          "404": { "description": "Charge not found" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "healthCheck",
+        "summary": "Health check",
+        "responses": {
+          "200": { "description": "Service healthy" }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/payments-service/v1.0.0/pacto.yaml
+++ b/examples/demo/bundles/payments-service/v1.0.0/pacto.yaml
@@ -1,0 +1,74 @@
+pactoVersion: "1.0"
+
+service:
+  name: payments-service
+  version: 1.0.0
+  owner: team/payments
+  image:
+    ref: ghcr.io/trianalab/pacto-demo/payments-service:1.0.0
+
+interfaces:
+  - name: http
+    type: http
+    port: 8083
+    visibility: internal
+    contract: interfaces/openapi.json
+  - name: events
+    type: event
+    visibility: internal
+    contract: interfaces/events.json
+
+configurations:
+  - name: platform
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-app-config
+  - name: app
+    schema: configuration/schema.json
+    values:
+      LOG_LEVEL: info
+      STRIPE_API_KEY: "${STRIPE_API_KEY}"
+      PAYMENTS_DB_URL: postgresql://postgres:5432/payments
+      ENABLE_REFUNDS: true
+
+policies:
+  - name: http-security
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-http-policy
+
+dependencies:
+  - name: postgresql
+    ref: oci://ghcr.io/trianalab/pacto-demo/postgresql
+    required: true
+    compatibility: "^16.0.0"
+  - name: stripe-api
+    ref: oci://ghcr.io/trianalab/pacto-demo/stripe-api
+    required: true
+    compatibility: "^2024.01.01"
+
+runtime:
+  workload: service
+  state:
+    type: stateful
+    persistence:
+      scope: shared
+      durability: persistent
+    dataCriticality: high
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 30
+
+scaling:
+  min: 2
+  max: 4
+
+metadata:
+  tier: domain
+  category: payments
+  criticality: high
+  summary: Core payment processing service handling charges and refunds via Stripe
+  language: go
+  repo: github.com/trianalab/pacto-demo/payments-service
+  tags:
+    - payments
+    - stripe
+    - charges
+    - refunds
+    - pci

--- a/examples/demo/bundles/payments-service/v1.1.0/configuration/schema.json
+++ b/examples/demo/bundles/payments-service/v1.1.0/configuration/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Payments Service Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": ["debug", "info", "warn", "error"],
+      "default": "info"
+    },
+    "STRIPE_API_KEY": {
+      "type": "string",
+      "description": "Stripe API secret key for payment processing"
+    },
+    "PAYMENTS_DB_URL": {
+      "type": "string",
+      "format": "uri",
+      "description": "PostgreSQL connection string for payments database"
+    },
+    "ENABLE_REFUNDS": {
+      "type": "boolean",
+      "default": true,
+      "description": "Feature flag to enable/disable refund processing"
+    },
+    "WEBHOOK_SECRET": {
+      "type": "string",
+      "description": "Stripe webhook signing secret for signature verification"
+    }
+  },
+  "required": ["STRIPE_API_KEY", "PAYMENTS_DB_URL"]
+}

--- a/examples/demo/bundles/payments-service/v1.1.0/docs/overview.md
+++ b/examples/demo/bundles/payments-service/v1.1.0/docs/overview.md
@@ -1,0 +1,8 @@
+# Payments Service v1.1.0
+
+Adds Stripe webhook handling and payment failure tracking.
+
+## Changes from v1.0.0
+- Added POST /webhooks/stripe endpoint
+- Added payment.failed event
+- Added WEBHOOK_SECRET config (optional)

--- a/examples/demo/bundles/payments-service/v1.1.0/interfaces/events.json
+++ b/examples/demo/bundles/payments-service/v1.1.0/interfaces/events.json
@@ -1,0 +1,68 @@
+{
+  "asyncapi": "2.6.0",
+  "info": {
+    "title": "Payments Service Events",
+    "version": "1.1.0"
+  },
+  "channels": {
+    "payment.completed": {
+      "publish": {
+        "operationId": "paymentCompleted",
+        "summary": "Payment has been successfully processed",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "charge_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "currency": { "type": "string" },
+              "customer_id": { "type": "string" },
+              "completed_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["charge_id", "amount", "currency", "customer_id"]
+          }
+        }
+      }
+    },
+    "payment.refunded": {
+      "publish": {
+        "operationId": "paymentRefunded",
+        "summary": "Payment has been refunded",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "charge_id": { "type": "string" },
+              "refund_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "reason": { "type": "string" },
+              "refunded_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["charge_id", "refund_id", "amount"]
+          }
+        }
+      }
+    },
+    "payment.failed": {
+      "publish": {
+        "operationId": "paymentFailed",
+        "summary": "Payment processing has failed",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "charge_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "currency": { "type": "string" },
+              "customer_id": { "type": "string" },
+              "error_code": { "type": "string" },
+              "error_message": { "type": "string" },
+              "failed_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["charge_id", "amount", "currency", "error_code"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/payments-service/v1.1.0/interfaces/openapi.json
+++ b/examples/demo/bundles/payments-service/v1.1.0/interfaces/openapi.json
@@ -1,0 +1,113 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Payments Service API",
+    "version": "1.1.0"
+  },
+  "paths": {
+    "/charges": {
+      "post": {
+        "operationId": "createCharge",
+        "summary": "Create a new charge",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "amount": { "type": "integer", "description": "Amount in cents" },
+                  "currency": { "type": "string" },
+                  "customer_id": { "type": "string" },
+                  "payment_method": { "type": "string" },
+                  "description": { "type": "string" }
+                },
+                "required": ["amount", "currency", "customer_id", "payment_method"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Charge created successfully" },
+          "400": { "description": "Invalid request" },
+          "402": { "description": "Payment failed" }
+        }
+      }
+    },
+    "/charges/{id}": {
+      "get": {
+        "operationId": "getCharge",
+        "summary": "Retrieve a charge by ID",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Charge details" },
+          "404": { "description": "Charge not found" }
+        }
+      }
+    },
+    "/refunds": {
+      "post": {
+        "operationId": "createRefund",
+        "summary": "Create a refund for a charge",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "charge_id": { "type": "string" },
+                  "amount": { "type": "integer", "description": "Refund amount in cents" },
+                  "reason": { "type": "string", "enum": ["duplicate", "fraudulent", "requested_by_customer"] }
+                },
+                "required": ["charge_id"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Refund created" },
+          "400": { "description": "Invalid request" },
+          "404": { "description": "Charge not found" }
+        }
+      }
+    },
+    "/webhooks/stripe": {
+      "post": {
+        "operationId": "handleStripeWebhook",
+        "summary": "Handle incoming Stripe webhook events",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": { "type": "string" },
+                  "type": { "type": "string" },
+                  "data": { "type": "object" }
+                },
+                "required": ["id", "type", "data"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Webhook processed" },
+          "400": { "description": "Invalid webhook signature" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "healthCheck",
+        "summary": "Health check",
+        "responses": {
+          "200": { "description": "Service healthy" }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/payments-service/v1.1.0/pacto.yaml
+++ b/examples/demo/bundles/payments-service/v1.1.0/pacto.yaml
@@ -1,0 +1,75 @@
+pactoVersion: "1.0"
+
+service:
+  name: payments-service
+  version: 1.1.0
+  owner: team/payments
+  image:
+    ref: ghcr.io/trianalab/pacto-demo/payments-service:1.1.0
+
+interfaces:
+  - name: http
+    type: http
+    port: 8083
+    visibility: internal
+    contract: interfaces/openapi.json
+  - name: events
+    type: event
+    visibility: internal
+    contract: interfaces/events.json
+
+configurations:
+  - name: platform
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-app-config
+  - name: app
+    schema: configuration/schema.json
+    values:
+      LOG_LEVEL: info
+      STRIPE_API_KEY: "${STRIPE_API_KEY}"
+      PAYMENTS_DB_URL: postgresql://postgres:5432/payments
+      ENABLE_REFUNDS: true
+      WEBHOOK_SECRET: "${STRIPE_WEBHOOK_SECRET}"
+
+policies:
+  - name: http-security
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-http-policy
+
+dependencies:
+  - name: postgresql
+    ref: oci://ghcr.io/trianalab/pacto-demo/postgresql
+    required: true
+    compatibility: "^16.0.0"
+  - name: stripe-api
+    ref: oci://ghcr.io/trianalab/pacto-demo/stripe-api
+    required: true
+    compatibility: "^2024.01.01"
+
+runtime:
+  workload: service
+  state:
+    type: stateful
+    persistence:
+      scope: shared
+      durability: persistent
+    dataCriticality: high
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 30
+
+scaling:
+  min: 2
+  max: 4
+
+metadata:
+  tier: domain
+  category: payments
+  criticality: high
+  summary: Payment processing with Stripe webhook support and failure tracking
+  language: go
+  repo: github.com/trianalab/pacto-demo/payments-service
+  tags:
+    - payments
+    - stripe
+    - webhooks
+    - charges
+    - refunds

--- a/examples/demo/bundles/payments-service/v1.2.0/configuration/schema.json
+++ b/examples/demo/bundles/payments-service/v1.2.0/configuration/schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Payments Service Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": ["debug", "info", "warn", "error"],
+      "default": "info"
+    },
+    "STRIPE_API_KEY": {
+      "type": "string",
+      "description": "Stripe API secret key for payment processing"
+    },
+    "PAYMENTS_DB_URL": {
+      "type": "string",
+      "format": "uri",
+      "description": "PostgreSQL connection string for payments database"
+    },
+    "ENABLE_REFUNDS": {
+      "type": "boolean",
+      "default": true,
+      "description": "Feature flag to enable/disable refund processing"
+    },
+    "WEBHOOK_SECRET": {
+      "type": "string",
+      "description": "Stripe webhook signing secret for signature verification"
+    },
+    "FRAUD_CHECK_ENABLED": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable fraud detection checks before processing payments"
+    }
+  },
+  "required": ["STRIPE_API_KEY", "PAYMENTS_DB_URL"]
+}

--- a/examples/demo/bundles/payments-service/v1.2.0/docs/overview.md
+++ b/examples/demo/bundles/payments-service/v1.2.0/docs/overview.md
@@ -1,0 +1,8 @@
+# Payments Service v1.2.0
+
+Adds optional fraud detection integration. When FRAUD_CHECK_ENABLED is true, charges are evaluated by fraud-service before processing.
+
+## Changes from v1.1.0
+- Added optional fraud-service dependency
+- Added optional risk_score field in charge response and payment.completed event
+- Added FRAUD_CHECK_ENABLED configuration

--- a/examples/demo/bundles/payments-service/v1.2.0/interfaces/events.json
+++ b/examples/demo/bundles/payments-service/v1.2.0/interfaces/events.json
@@ -1,0 +1,69 @@
+{
+  "asyncapi": "2.6.0",
+  "info": {
+    "title": "Payments Service Events",
+    "version": "1.2.0"
+  },
+  "channels": {
+    "payment.completed": {
+      "publish": {
+        "operationId": "paymentCompleted",
+        "summary": "Payment has been successfully processed",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "charge_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "currency": { "type": "string" },
+              "customer_id": { "type": "string" },
+              "risk_score": { "type": "number", "description": "Fraud risk score if fraud check was enabled" },
+              "completed_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["charge_id", "amount", "currency", "customer_id"]
+          }
+        }
+      }
+    },
+    "payment.refunded": {
+      "publish": {
+        "operationId": "paymentRefunded",
+        "summary": "Payment has been refunded",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "charge_id": { "type": "string" },
+              "refund_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "reason": { "type": "string" },
+              "refunded_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["charge_id", "refund_id", "amount"]
+          }
+        }
+      }
+    },
+    "payment.failed": {
+      "publish": {
+        "operationId": "paymentFailed",
+        "summary": "Payment processing has failed",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "charge_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "currency": { "type": "string" },
+              "customer_id": { "type": "string" },
+              "error_code": { "type": "string" },
+              "error_message": { "type": "string" },
+              "failed_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["charge_id", "amount", "currency", "error_code"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/payments-service/v1.2.0/interfaces/openapi.json
+++ b/examples/demo/bundles/payments-service/v1.2.0/interfaces/openapi.json
@@ -1,0 +1,129 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Payments Service API",
+    "version": "1.2.0"
+  },
+  "paths": {
+    "/charges": {
+      "post": {
+        "operationId": "createCharge",
+        "summary": "Create a new charge (with optional fraud check)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "amount": { "type": "integer", "description": "Amount in cents" },
+                  "currency": { "type": "string" },
+                  "customer_id": { "type": "string" },
+                  "payment_method": { "type": "string" },
+                  "description": { "type": "string" }
+                },
+                "required": ["amount", "currency", "customer_id", "payment_method"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Charge created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "charge_id": { "type": "string" },
+                    "amount": { "type": "integer" },
+                    "currency": { "type": "string" },
+                    "status": { "type": "string" },
+                    "risk_score": { "type": "number", "description": "Fraud risk score (0-1), present when fraud check is enabled" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid request" },
+          "402": { "description": "Payment failed" }
+        }
+      }
+    },
+    "/charges/{id}": {
+      "get": {
+        "operationId": "getCharge",
+        "summary": "Retrieve a charge by ID",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Charge details" },
+          "404": { "description": "Charge not found" }
+        }
+      }
+    },
+    "/refunds": {
+      "post": {
+        "operationId": "createRefund",
+        "summary": "Create a refund for a charge",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "charge_id": { "type": "string" },
+                  "amount": { "type": "integer" },
+                  "reason": { "type": "string", "enum": ["duplicate", "fraudulent", "requested_by_customer"] }
+                },
+                "required": ["charge_id"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Refund created" },
+          "400": { "description": "Invalid request" },
+          "404": { "description": "Charge not found" }
+        }
+      }
+    },
+    "/webhooks/stripe": {
+      "post": {
+        "operationId": "handleStripeWebhook",
+        "summary": "Handle incoming Stripe webhook events",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": { "type": "string" },
+                  "type": { "type": "string" },
+                  "data": { "type": "object" }
+                },
+                "required": ["id", "type", "data"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Webhook processed" },
+          "400": { "description": "Invalid webhook signature" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "healthCheck",
+        "summary": "Health check",
+        "responses": {
+          "200": { "description": "Service healthy" }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/payments-service/v1.2.0/pacto.yaml
+++ b/examples/demo/bundles/payments-service/v1.2.0/pacto.yaml
@@ -1,0 +1,81 @@
+pactoVersion: "1.0"
+
+service:
+  name: payments-service
+  version: 1.2.0
+  owner: team/payments
+  image:
+    ref: ghcr.io/trianalab/pacto-demo/payments-service:1.2.0
+
+interfaces:
+  - name: http
+    type: http
+    port: 8083
+    visibility: internal
+    contract: interfaces/openapi.json
+  - name: events
+    type: event
+    visibility: internal
+    contract: interfaces/events.json
+
+configurations:
+  - name: platform
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-app-config
+  - name: app
+    schema: configuration/schema.json
+    values:
+      LOG_LEVEL: info
+      STRIPE_API_KEY: "${STRIPE_API_KEY}"
+      PAYMENTS_DB_URL: postgresql://postgres:5432/payments
+      ENABLE_REFUNDS: true
+      WEBHOOK_SECRET: "${STRIPE_WEBHOOK_SECRET}"
+      FRAUD_CHECK_ENABLED: false
+
+policies:
+  - name: http-security
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-http-policy
+
+dependencies:
+  - name: postgresql
+    ref: oci://ghcr.io/trianalab/pacto-demo/postgresql
+    required: true
+    compatibility: "^16.0.0"
+  - name: stripe-api
+    ref: oci://ghcr.io/trianalab/pacto-demo/stripe-api
+    required: true
+    compatibility: "^2024.01.01"
+  - name: fraud-service
+    ref: oci://ghcr.io/trianalab/pacto-demo/fraud-service
+    required: false
+    compatibility: "^1.0.0"
+
+runtime:
+  workload: service
+  state:
+    type: stateful
+    persistence:
+      scope: shared
+      durability: persistent
+    dataCriticality: high
+  lifecycle:
+    upgradeStrategy: rolling
+    gracefulShutdownSeconds: 30
+
+scaling:
+  min: 2
+  max: 4
+
+metadata:
+  tier: domain
+  category: payments
+  criticality: high
+  summary: Payment processing with optional fraud detection integration
+  language: go
+  repo: github.com/trianalab/pacto-demo/payments-service
+  tags:
+    - payments
+    - stripe
+    - webhooks
+    - fraud-detection
+    - charges
+    - refunds

--- a/examples/demo/bundles/payments-service/v2.0.0/configuration/schema.json
+++ b/examples/demo/bundles/payments-service/v2.0.0/configuration/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Payments Service Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": ["debug", "info", "warn", "error"],
+      "default": "info"
+    },
+    "STRIPE_SECRET_KEY": {
+      "type": "string",
+      "description": "Stripe secret key (renamed from STRIPE_API_KEY)"
+    },
+    "PAYMENTS_DB_URL": {
+      "type": "string",
+      "format": "uri",
+      "description": "PostgreSQL connection string for payments database"
+    },
+    "WEBHOOK_SECRET": {
+      "type": "string",
+      "description": "Stripe webhook signing secret (now required)"
+    },
+    "FRAUD_CHECK_ENABLED": {
+      "type": "boolean",
+      "default": true,
+      "description": "Fraud detection is now enabled by default and required"
+    }
+  },
+  "required": ["STRIPE_SECRET_KEY", "PAYMENTS_DB_URL", "WEBHOOK_SECRET"]
+}

--- a/examples/demo/bundles/payments-service/v2.0.0/docs/overview.md
+++ b/examples/demo/bundles/payments-service/v2.0.0/docs/overview.md
@@ -1,0 +1,18 @@
+# Payments Service v2.0.0 (BREAKING)
+
+Major version upgrade replacing the charges API with Payment Intents. Fraud detection is now mandatory.
+
+## BREAKING CHANGES from v1.x
+- **Removed** `/charges` endpoint -> replaced by `/payment-intents`
+- **Renamed** `STRIPE_API_KEY` -> `STRIPE_SECRET_KEY`
+- **Required** `WEBHOOK_SECRET` (was optional)
+- **Required** `fraud-service` dependency (was optional)
+- **Removed** `ENABLE_REFUNDS` config (refunds always enabled)
+- **Changed** upgrade strategy from rolling to blue-green
+- **Changed** events from payment.completed/failed to payment.intent.created/succeeded/failed
+
+## New Features
+- Payment Intents with confirm/cancel lifecycle
+- Cursor-based pagination for listing intents
+- Mandatory fraud scoring on all payment creation
+- Risk signals array in responses

--- a/examples/demo/bundles/payments-service/v2.0.0/interfaces/events.json
+++ b/examples/demo/bundles/payments-service/v2.0.0/interfaces/events.json
@@ -1,0 +1,87 @@
+{
+  "asyncapi": "2.6.0",
+  "info": {
+    "title": "Payments Service Events",
+    "version": "2.0.0"
+  },
+  "channels": {
+    "payment.intent.created": {
+      "publish": {
+        "operationId": "paymentIntentCreated",
+        "summary": "Payment intent has been created",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "payment_intent_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "currency": { "type": "string" },
+              "customer_id": { "type": "string" },
+              "risk_score": { "type": "number" },
+              "created_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["payment_intent_id", "amount", "currency", "customer_id"]
+          }
+        }
+      }
+    },
+    "payment.intent.succeeded": {
+      "publish": {
+        "operationId": "paymentIntentSucceeded",
+        "summary": "Payment intent has been confirmed and succeeded",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "payment_intent_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "currency": { "type": "string" },
+              "customer_id": { "type": "string" },
+              "succeeded_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["payment_intent_id", "amount", "currency", "customer_id"]
+          }
+        }
+      }
+    },
+    "payment.intent.failed": {
+      "publish": {
+        "operationId": "paymentIntentFailed",
+        "summary": "Payment intent has failed",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "payment_intent_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "currency": { "type": "string" },
+              "error_code": { "type": "string" },
+              "error_message": { "type": "string" },
+              "failed_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["payment_intent_id", "amount", "currency", "error_code"]
+          }
+        }
+      }
+    },
+    "payment.refunded": {
+      "publish": {
+        "operationId": "paymentRefunded",
+        "summary": "Payment has been refunded",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "payment_intent_id": { "type": "string" },
+              "refund_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "reason": { "type": "string" },
+              "refunded_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["payment_intent_id", "refund_id", "amount"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/payments-service/v2.0.0/interfaces/openapi.json
+++ b/examples/demo/bundles/payments-service/v2.0.0/interfaces/openapi.json
@@ -1,0 +1,157 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Payments Service API",
+    "version": "2.0.0"
+  },
+  "paths": {
+    "/payment-intents": {
+      "post": {
+        "operationId": "createPaymentIntent",
+        "summary": "Create a new payment intent",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "amount": { "type": "integer", "description": "Amount in cents" },
+                  "currency": { "type": "string" },
+                  "customer_id": { "type": "string" },
+                  "payment_method": { "type": "string" },
+                  "description": { "type": "string" },
+                  "metadata": { "type": "object", "additionalProperties": { "type": "string" } }
+                },
+                "required": ["amount", "currency", "customer_id", "payment_method"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Payment intent created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "payment_intent_id": { "type": "string" },
+                    "amount": { "type": "integer" },
+                    "currency": { "type": "string" },
+                    "status": { "type": "string", "enum": ["requires_confirmation", "processing", "succeeded", "failed"] },
+                    "risk_score": { "type": "number" },
+                    "risk_signals": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid request" },
+          "402": { "description": "Payment failed" },
+          "422": { "description": "Fraud check rejected" }
+        }
+      },
+      "get": {
+        "operationId": "listPaymentIntents",
+        "summary": "List payment intents",
+        "parameters": [
+          { "name": "customer_id", "in": "query", "schema": { "type": "string" } },
+          { "name": "status", "in": "query", "schema": { "type": "string" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" } },
+          { "name": "cursor", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "List of payment intents" }
+        }
+      }
+    },
+    "/payment-intents/{id}": {
+      "get": {
+        "operationId": "getPaymentIntent",
+        "summary": "Get payment intent by ID",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Payment intent details" },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/payment-intents/{id}/confirm": {
+      "post": {
+        "operationId": "confirmPaymentIntent",
+        "summary": "Confirm a payment intent",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Payment intent confirmed" },
+          "400": { "description": "Cannot confirm" },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/payment-intents/{id}/cancel": {
+      "post": {
+        "operationId": "cancelPaymentIntent",
+        "summary": "Cancel a payment intent",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Payment intent cancelled" },
+          "400": { "description": "Cannot cancel" },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/refunds": {
+      "post": {
+        "operationId": "createRefund",
+        "summary": "Create a refund for a payment intent",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "payment_intent_id": { "type": "string" },
+                  "amount": { "type": "integer" },
+                  "reason": { "type": "string", "enum": ["duplicate", "fraudulent", "requested_by_customer"] }
+                },
+                "required": ["payment_intent_id"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Refund created" },
+          "400": { "description": "Invalid request" },
+          "404": { "description": "Payment intent not found" }
+        }
+      }
+    },
+    "/webhooks/stripe": {
+      "post": {
+        "operationId": "handleStripeWebhook",
+        "summary": "Handle Stripe webhook events",
+        "responses": {
+          "200": { "description": "Webhook processed" },
+          "400": { "description": "Invalid signature" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "healthCheck",
+        "summary": "Health check",
+        "responses": {
+          "200": { "description": "Service healthy" }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/payments-service/v2.0.0/pacto.yaml
+++ b/examples/demo/bundles/payments-service/v2.0.0/pacto.yaml
@@ -1,0 +1,80 @@
+pactoVersion: "1.0"
+
+service:
+  name: payments-service
+  version: 2.0.0
+  owner: team/payments
+  image:
+    ref: ghcr.io/trianalab/pacto-demo/payments-service:2.0.0
+
+interfaces:
+  - name: http
+    type: http
+    port: 8083
+    visibility: internal
+    contract: interfaces/openapi.json
+  - name: events
+    type: event
+    visibility: internal
+    contract: interfaces/events.json
+
+configurations:
+  - name: platform
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-app-config
+  - name: app
+    schema: configuration/schema.json
+    values:
+      LOG_LEVEL: info
+      STRIPE_SECRET_KEY: "${STRIPE_SECRET_KEY}"
+      PAYMENTS_DB_URL: postgresql://postgres:5432/payments
+      WEBHOOK_SECRET: "${STRIPE_WEBHOOK_SECRET}"
+      FRAUD_CHECK_ENABLED: true
+
+policies:
+  - name: http-security
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-http-policy
+
+dependencies:
+  - name: postgresql
+    ref: oci://ghcr.io/trianalab/pacto-demo/postgresql
+    required: true
+    compatibility: "^16.0.0"
+  - name: stripe-api
+    ref: oci://ghcr.io/trianalab/pacto-demo/stripe-api
+    required: true
+    compatibility: "^2024.01.01"
+  - name: fraud-service
+    ref: oci://ghcr.io/trianalab/pacto-demo/fraud-service
+    required: true
+    compatibility: "^1.0.0"
+
+runtime:
+  workload: service
+  state:
+    type: stateful
+    persistence:
+      scope: shared
+      durability: persistent
+    dataCriticality: high
+  lifecycle:
+    upgradeStrategy: recreate
+    gracefulShutdownSeconds: 60
+
+scaling:
+  min: 2
+  max: 4
+
+metadata:
+  tier: domain
+  category: payments
+  criticality: high
+  summary: Payment Intents API with mandatory fraud detection - BREAKING from v1.x charges API
+  language: go
+  repo: github.com/trianalab/pacto-demo/payments-service
+  tags:
+    - payments
+    - stripe
+    - payment-intents
+    - fraud-detection
+    - webhooks
+    - breaking-change

--- a/examples/demo/bundles/payments-service/v2.1.0/configuration/schema.json
+++ b/examples/demo/bundles/payments-service/v2.1.0/configuration/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Payments Service Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": ["debug", "info", "warn", "error"],
+      "default": "info"
+    },
+    "STRIPE_SECRET_KEY": {
+      "type": "string",
+      "description": "Stripe secret key (renamed from STRIPE_API_KEY)"
+    },
+    "PAYMENTS_DB_URL": {
+      "type": "string",
+      "format": "uri",
+      "description": "PostgreSQL connection string for payments database"
+    },
+    "WEBHOOK_SECRET": {
+      "type": "string",
+      "description": "Stripe webhook signing secret (now required)"
+    },
+    "FRAUD_CHECK_ENABLED": {
+      "type": "boolean",
+      "default": true,
+      "description": "Fraud detection is now enabled by default and required"
+    }
+  },
+  "required": ["STRIPE_SECRET_KEY", "PAYMENTS_DB_URL", "WEBHOOK_SECRET"]
+}

--- a/examples/demo/bundles/payments-service/v2.1.0/docs/overview.md
+++ b/examples/demo/bundles/payments-service/v2.1.0/docs/overview.md
@@ -1,0 +1,7 @@
+# Payments Service v2.1.0
+
+Introduces structured ownership metadata with team, DRI, and contact information.
+
+## Changes from v2.0.0
+- Migrated `owner` from simple string to structured ownership model
+- Added team, DRI, and contact channels (email, chat, oncall)

--- a/examples/demo/bundles/payments-service/v2.1.0/docs/runbooks/payments-service.md
+++ b/examples/demo/bundles/payments-service/v2.1.0/docs/runbooks/payments-service.md
@@ -1,0 +1,15 @@
+# Payments Service — On-Call Runbook
+
+## Overview
+The payments-service exposes the Payment Intents API and processes charges via
+Stripe with mandatory fraud detection.
+
+## Common incidents
+- **Stripe webhook backlog** — check the webhook consumer lag and the
+  `WEBHOOK_SECRET` rotation status.
+- **Fraud-service unavailable** — payments fail closed; verify fraud-service
+  health and Redis connectivity.
+- **Database connection saturation** — inspect the PostgreSQL connection pool.
+
+## Escalation
+Page `payments-oncall`; escalate to the payments-team DRI for sustained outages.

--- a/examples/demo/bundles/payments-service/v2.1.0/interfaces/events.json
+++ b/examples/demo/bundles/payments-service/v2.1.0/interfaces/events.json
@@ -1,0 +1,87 @@
+{
+  "asyncapi": "2.6.0",
+  "info": {
+    "title": "Payments Service Events",
+    "version": "2.0.0"
+  },
+  "channels": {
+    "payment.intent.created": {
+      "publish": {
+        "operationId": "paymentIntentCreated",
+        "summary": "Payment intent has been created",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "payment_intent_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "currency": { "type": "string" },
+              "customer_id": { "type": "string" },
+              "risk_score": { "type": "number" },
+              "created_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["payment_intent_id", "amount", "currency", "customer_id"]
+          }
+        }
+      }
+    },
+    "payment.intent.succeeded": {
+      "publish": {
+        "operationId": "paymentIntentSucceeded",
+        "summary": "Payment intent has been confirmed and succeeded",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "payment_intent_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "currency": { "type": "string" },
+              "customer_id": { "type": "string" },
+              "succeeded_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["payment_intent_id", "amount", "currency", "customer_id"]
+          }
+        }
+      }
+    },
+    "payment.intent.failed": {
+      "publish": {
+        "operationId": "paymentIntentFailed",
+        "summary": "Payment intent has failed",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "payment_intent_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "currency": { "type": "string" },
+              "error_code": { "type": "string" },
+              "error_message": { "type": "string" },
+              "failed_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["payment_intent_id", "amount", "currency", "error_code"]
+          }
+        }
+      }
+    },
+    "payment.refunded": {
+      "publish": {
+        "operationId": "paymentRefunded",
+        "summary": "Payment has been refunded",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "payment_intent_id": { "type": "string" },
+              "refund_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "reason": { "type": "string" },
+              "refunded_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["payment_intent_id", "refund_id", "amount"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/payments-service/v2.1.0/interfaces/openapi.json
+++ b/examples/demo/bundles/payments-service/v2.1.0/interfaces/openapi.json
@@ -1,0 +1,157 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Payments Service API",
+    "version": "2.0.0"
+  },
+  "paths": {
+    "/payment-intents": {
+      "post": {
+        "operationId": "createPaymentIntent",
+        "summary": "Create a new payment intent",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "amount": { "type": "integer", "description": "Amount in cents" },
+                  "currency": { "type": "string" },
+                  "customer_id": { "type": "string" },
+                  "payment_method": { "type": "string" },
+                  "description": { "type": "string" },
+                  "metadata": { "type": "object", "additionalProperties": { "type": "string" } }
+                },
+                "required": ["amount", "currency", "customer_id", "payment_method"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Payment intent created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "payment_intent_id": { "type": "string" },
+                    "amount": { "type": "integer" },
+                    "currency": { "type": "string" },
+                    "status": { "type": "string", "enum": ["requires_confirmation", "processing", "succeeded", "failed"] },
+                    "risk_score": { "type": "number" },
+                    "risk_signals": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid request" },
+          "402": { "description": "Payment failed" },
+          "422": { "description": "Fraud check rejected" }
+        }
+      },
+      "get": {
+        "operationId": "listPaymentIntents",
+        "summary": "List payment intents",
+        "parameters": [
+          { "name": "customer_id", "in": "query", "schema": { "type": "string" } },
+          { "name": "status", "in": "query", "schema": { "type": "string" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" } },
+          { "name": "cursor", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "List of payment intents" }
+        }
+      }
+    },
+    "/payment-intents/{id}": {
+      "get": {
+        "operationId": "getPaymentIntent",
+        "summary": "Get payment intent by ID",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Payment intent details" },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/payment-intents/{id}/confirm": {
+      "post": {
+        "operationId": "confirmPaymentIntent",
+        "summary": "Confirm a payment intent",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Payment intent confirmed" },
+          "400": { "description": "Cannot confirm" },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/payment-intents/{id}/cancel": {
+      "post": {
+        "operationId": "cancelPaymentIntent",
+        "summary": "Cancel a payment intent",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Payment intent cancelled" },
+          "400": { "description": "Cannot cancel" },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/refunds": {
+      "post": {
+        "operationId": "createRefund",
+        "summary": "Create a refund for a payment intent",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "payment_intent_id": { "type": "string" },
+                  "amount": { "type": "integer" },
+                  "reason": { "type": "string", "enum": ["duplicate", "fraudulent", "requested_by_customer"] }
+                },
+                "required": ["payment_intent_id"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Refund created" },
+          "400": { "description": "Invalid request" },
+          "404": { "description": "Payment intent not found" }
+        }
+      }
+    },
+    "/webhooks/stripe": {
+      "post": {
+        "operationId": "handleStripeWebhook",
+        "summary": "Handle Stripe webhook events",
+        "responses": {
+          "200": { "description": "Webhook processed" },
+          "400": { "description": "Invalid signature" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "healthCheck",
+        "summary": "Health check",
+        "responses": {
+          "200": { "description": "Service healthy" }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/payments-service/v2.1.0/pacto.yaml
+++ b/examples/demo/bundles/payments-service/v2.1.0/pacto.yaml
@@ -1,4 +1,4 @@
-pactoVersion: "1.0"
+pactoVersion: "1.1"
 
 service:
   name: payments-service
@@ -90,3 +90,31 @@ metadata:
     - fraud-detection
     - webhooks
     - ownership
+
+readiness:
+  minScore: 80
+  checks:
+    - id: dashboard
+      type: url
+      evidence: https://grafana.acme.com/d/payments-service
+      weight: 25
+      expires: "2099-12-31"
+      description: Production Grafana dashboard
+    - id: runbook
+      type: document
+      evidence: docs/runbooks/payments-service.md
+      weight: 20
+      expires: "2099-12-31"
+      description: On-call runbook for payment incidents
+    - id: security-review
+      type: ticket
+      evidence: SEC-2087
+      weight: 25
+      expires: "2099-12-31"
+      description: Annual security review
+    - id: ai-evals
+      type: report
+      evidence: https://evals.acme.com/payments-service
+      weight: 30
+      expires: "2025-06-30"
+      description: LLM safety evaluation suite (stale — needs refresh)

--- a/examples/demo/bundles/payments-service/v2.1.0/pacto.yaml
+++ b/examples/demo/bundles/payments-service/v2.1.0/pacto.yaml
@@ -1,0 +1,92 @@
+pactoVersion: "1.0"
+
+service:
+  name: payments-service
+  version: 2.1.0
+  owner:
+    team: payments-team
+    dri: james.wilson
+    contacts:
+      - type: email
+        value: payments-team@acme.com
+        purpose: escalation
+      - type: chat
+        value: "#payments-team"
+        purpose: support
+      - type: oncall
+        value: payments-oncall
+        purpose: oncall
+  image:
+    ref: ghcr.io/trianalab/pacto-demo/payments-service:2.1.0
+
+interfaces:
+  - name: http
+    type: http
+    port: 8083
+    visibility: internal
+    contract: interfaces/openapi.json
+  - name: events
+    type: event
+    visibility: internal
+    contract: interfaces/events.json
+
+configurations:
+  - name: platform
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-app-config
+  - name: app
+    schema: configuration/schema.json
+    values:
+      LOG_LEVEL: info
+      STRIPE_SECRET_KEY: "${STRIPE_SECRET_KEY}"
+      PAYMENTS_DB_URL: postgresql://postgres:5432/payments
+      WEBHOOK_SECRET: "${STRIPE_WEBHOOK_SECRET}"
+      FRAUD_CHECK_ENABLED: true
+
+policies:
+  - name: http-security
+    ref: oci://ghcr.io/trianalab/pacto-demo/platform-http-policy
+
+dependencies:
+  - name: postgresql
+    ref: oci://ghcr.io/trianalab/pacto-demo/postgresql
+    required: true
+    compatibility: "^16.0.0"
+  - name: stripe-api
+    ref: oci://ghcr.io/trianalab/pacto-demo/stripe-api
+    required: true
+    compatibility: "^2024.01.01"
+  - name: fraud-service
+    ref: oci://ghcr.io/trianalab/pacto-demo/fraud-service
+    required: true
+    compatibility: "^1.0.0"
+
+runtime:
+  workload: service
+  state:
+    type: stateful
+    persistence:
+      scope: shared
+      durability: persistent
+    dataCriticality: high
+  lifecycle:
+    upgradeStrategy: recreate
+    gracefulShutdownSeconds: 60
+
+scaling:
+  min: 2
+  max: 4
+
+metadata:
+  tier: domain
+  category: payments
+  criticality: high
+  summary: Payment Intents API with structured ownership metadata and mandatory fraud detection
+  language: go
+  repo: github.com/trianalab/pacto-demo/payments-service
+  tags:
+    - payments
+    - stripe
+    - payment-intents
+    - fraud-detection
+    - webhooks
+    - ownership

--- a/examples/demo/bundles/platform-app-config/configuration/schema.json
+++ b/examples/demo/bundles/platform-app-config/configuration/schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Platform App Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ],
+      "default": "info"
+    },
+    "LOG_FORMAT": {
+      "type": "string",
+      "enum": [
+        "json",
+        "text"
+      ],
+      "default": "json"
+    },
+    "OTEL_EXPORTER_ENDPOINT": {
+      "type": "string",
+      "format": "uri"
+    },
+    "OTEL_SERVICE_NAME": {
+      "type": "string"
+    },
+    "METRICS_PORT": {
+      "type": "integer",
+      "default": 9090
+    },
+    "HEALTH_CHECK_INTERVAL_SECONDS": {
+      "type": "integer",
+      "default": 10
+    }
+  },
+  "required": []
+}

--- a/examples/demo/bundles/platform-app-config/docs/overview.md
+++ b/examples/demo/bundles/platform-app-config/docs/overview.md
@@ -1,0 +1,3 @@
+# Platform App Config
+
+Shared application configuration for standard platform services. Includes logging, observability, and health check settings.

--- a/examples/demo/bundles/platform-app-config/pacto.yaml
+++ b/examples/demo/bundles/platform-app-config/pacto.yaml
@@ -1,0 +1,33 @@
+pactoVersion: "1.0"
+
+service:
+  name: platform-app-config
+  version: 1.0.0
+  owner:
+    team: platform-foundations
+    dri: alice.johnson
+    contacts:
+      - type: email
+        value: platform-foundations@acme.com
+        purpose: escalation
+      - type: chat
+        value: "#platform-foundations"
+        purpose: support
+      - type: oncall
+        value: platform-foundations-oncall
+        purpose: oncall
+
+configurations:
+  - name: default
+    schema: configuration/schema.json
+
+metadata:
+  tier: platform
+  category: configuration
+  criticality: medium
+  summary: Shared application configuration schema for standard platform services
+  repo: github.com/trianalab/pacto-demo/platform-app-config
+  tags:
+    - configuration
+    - shared
+    - observability

--- a/examples/demo/bundles/platform-http-policy/docs/overview.md
+++ b/examples/demo/bundles/platform-http-policy/docs/overview.md
@@ -1,0 +1,9 @@
+# Platform HTTP Policy
+
+Shared HTTP security and rate-limiting policy applied to all platform services.
+
+## Features
+- Rate limiting with configurable RPS and burst
+- CORS policy management
+- Authentication enforcement (JWT, API key, OAuth2)
+- TLS version enforcement

--- a/examples/demo/bundles/platform-http-policy/pacto.yaml
+++ b/examples/demo/bundles/platform-http-policy/pacto.yaml
@@ -1,0 +1,30 @@
+pactoVersion: "1.0"
+
+service:
+  name: platform-http-policy
+  version: 1.0.0
+  owner:
+    team: platform-foundations
+    dri: alice.johnson
+    contacts:
+      - type: email
+        value: platform-foundations@acme.com
+        purpose: escalation
+      - type: chat
+        value: "#platform-foundations"
+        purpose: support
+      - type: oncall
+        value: platform-foundations-oncall
+        purpose: oncall
+
+metadata:
+  tier: platform
+  category: policy
+  criticality: high
+  summary: Shared HTTP security and rate-limiting policy for all platform services
+  repo: github.com/trianalab/pacto-demo/platform-http-policy
+  tags:
+    - policy
+    - security
+    - rate-limiting
+    - shared

--- a/examples/demo/bundles/platform-http-policy/policy/schema.json
+++ b/examples/demo/bundles/platform-http-policy/policy/schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Platform HTTP Policy",
+  "description": "Enforces platform standards: structured ownership, metadata classification, and runtime declaration",
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            {
+              "type": "object",
+              "properties": {
+                "team": { "type": "string", "minLength": 1 }
+              },
+              "required": ["team"]
+            }
+          ]
+        }
+      },
+      "required": ["owner"]
+    },
+    "metadata": {
+      "type": "object",
+      "required": ["tier", "criticality"]
+    },
+    "runtime": {
+      "type": "object"
+    }
+  },
+  "required": ["service", "metadata", "runtime"]
+}

--- a/examples/demo/bundles/platform-worker-config/configuration/schema.json
+++ b/examples/demo/bundles/platform-worker-config/configuration/schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Platform Worker Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ],
+      "default": "info"
+    },
+    "LOG_FORMAT": {
+      "type": "string",
+      "enum": [
+        "json",
+        "text"
+      ],
+      "default": "json"
+    },
+    "OTEL_EXPORTER_ENDPOINT": {
+      "type": "string",
+      "format": "uri"
+    },
+    "WORKER_CONCURRENCY": {
+      "type": "integer",
+      "default": 5
+    },
+    "RETRY_MAX_ATTEMPTS": {
+      "type": "integer",
+      "default": 3
+    },
+    "RETRY_BACKOFF_SECONDS": {
+      "type": "integer",
+      "default": 5
+    },
+    "DEAD_LETTER_QUEUE_ENABLED": {
+      "type": "boolean",
+      "default": true
+    }
+  },
+  "required": []
+}

--- a/examples/demo/bundles/platform-worker-config/docs/overview.md
+++ b/examples/demo/bundles/platform-worker-config/docs/overview.md
@@ -1,0 +1,3 @@
+# Platform Worker Config
+
+Shared configuration for background workers and scheduled jobs. Includes concurrency, retry, and dead letter queue settings.

--- a/examples/demo/bundles/platform-worker-config/pacto.yaml
+++ b/examples/demo/bundles/platform-worker-config/pacto.yaml
@@ -1,0 +1,34 @@
+pactoVersion: "1.0"
+
+service:
+  name: platform-worker-config
+  version: 1.0.0
+  owner:
+    team: platform-foundations
+    dri: alice.johnson
+    contacts:
+      - type: email
+        value: platform-foundations@acme.com
+        purpose: escalation
+      - type: chat
+        value: "#platform-foundations"
+        purpose: support
+      - type: oncall
+        value: platform-foundations-oncall
+        purpose: oncall
+
+configurations:
+  - name: default
+    schema: configuration/schema.json
+
+metadata:
+  tier: platform
+  category: configuration
+  criticality: medium
+  summary: Shared configuration schema for background workers and scheduled jobs
+  repo: github.com/trianalab/pacto-demo/platform-worker-config
+  tags:
+    - configuration
+    - shared
+    - workers
+    - scheduled

--- a/examples/demo/bundles/postgresql/docs/overview.md
+++ b/examples/demo/bundles/postgresql/docs/overview.md
@@ -1,0 +1,9 @@
+# PostgreSQL
+
+Primary relational database providing transactional storage for orders, payments, and other domain services.
+
+## Configuration
+Managed via standard PostgreSQL environment variables and mounted configuration files.
+
+## Persistence
+Data is stored on persistent volumes with automated backups.

--- a/examples/demo/bundles/postgresql/pacto.yaml
+++ b/examples/demo/bundles/postgresql/pacto.yaml
@@ -1,0 +1,49 @@
+pactoVersion: "1.0"
+
+service:
+  name: postgresql
+  version: 16.0.0
+  owner:
+    team: infra-data
+    dri: carlos.silva
+    contacts:
+      - type: email
+        value: infra-data@acme.com
+        purpose: escalation
+      - type: chat
+        value: "#infra-data"
+        purpose: support
+      - type: oncall
+        value: infra-data-oncall
+        purpose: oncall
+  image:
+    ref: docker.io/library/postgres:16
+
+runtime:
+  workload: service
+  state:
+    type: stateful
+    persistence:
+      scope: shared
+      durability: persistent
+    dataCriticality: high
+  lifecycle:
+    upgradeStrategy: ordered
+    gracefulShutdownSeconds: 120
+
+scaling:
+  replicas: 1
+
+metadata:
+  tier: infra
+  category: storage
+  criticality: high
+  summary: Primary relational database for transactional data
+  serviceType: infrastructure
+  protocol: postgresql
+  repo: github.com/trianalab/pacto-demo/postgresql
+  tags:
+    - database
+    - relational
+    - persistence
+    - infrastructure

--- a/examples/demo/bundles/redis/docs/overview.md
+++ b/examples/demo/bundles/redis/docs/overview.md
@@ -1,0 +1,3 @@
+# Redis
+
+In-memory data store used for caching, session management, and rate limiting across the platform.

--- a/examples/demo/bundles/redis/pacto.yaml
+++ b/examples/demo/bundles/redis/pacto.yaml
@@ -1,0 +1,49 @@
+pactoVersion: "1.0"
+
+service:
+  name: redis
+  version: 7.2.0
+  owner:
+    team: infra-data
+    dri: carlos.silva
+    contacts:
+      - type: email
+        value: infra-data@acme.com
+        purpose: escalation
+      - type: chat
+        value: "#infra-data"
+        purpose: support
+      - type: oncall
+        value: infra-data-oncall
+        purpose: oncall
+  image:
+    ref: docker.io/library/redis:7
+
+runtime:
+  workload: service
+  state:
+    type: stateful
+    persistence:
+      scope: shared
+      durability: persistent
+    dataCriticality: medium
+  lifecycle:
+    upgradeStrategy: ordered
+    gracefulShutdownSeconds: 60
+
+scaling:
+  replicas: 1
+
+metadata:
+  tier: infra
+  category: storage
+  criticality: high
+  summary: In-memory data store for caching, sessions, and rate limiting
+  serviceType: infrastructure
+  protocol: redis
+  repo: github.com/trianalab/pacto-demo/redis
+  tags:
+    - cache
+    - sessions
+    - rate-limiting
+    - infrastructure

--- a/examples/demo/bundles/stripe-api/docs/overview.md
+++ b/examples/demo/bundles/stripe-api/docs/overview.md
@@ -1,0 +1,3 @@
+# Stripe API
+
+External payment processing provider. Used by payments-service for charge creation, refunds, and webhook handling.

--- a/examples/demo/bundles/stripe-api/interfaces/openapi.json
+++ b/examples/demo/bundles/stripe-api/interfaces/openapi.json
@@ -1,0 +1,49 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Stripe API (subset)",
+    "version": "2024.01.01",
+    "description": "External Stripe payment processing API"
+  },
+  "paths": {
+    "/v1/payment_intents": {
+      "post": {
+        "operationId": "createPaymentIntent",
+        "summary": "Create a payment intent",
+        "responses": {
+          "200": { "description": "Payment intent created" }
+        }
+      }
+    },
+    "/v1/payment_intents/{id}": {
+      "get": {
+        "operationId": "getPaymentIntent",
+        "summary": "Retrieve a payment intent",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Payment intent details" }
+        }
+      }
+    },
+    "/v1/refunds": {
+      "post": {
+        "operationId": "createRefund",
+        "summary": "Create a refund",
+        "responses": {
+          "200": { "description": "Refund created" }
+        }
+      }
+    },
+    "/v1/webhooks": {
+      "post": {
+        "operationId": "receiveWebhook",
+        "summary": "Receive webhook events from Stripe",
+        "responses": {
+          "200": { "description": "Webhook received" }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/stripe-api/pacto.yaml
+++ b/examples/demo/bundles/stripe-api/pacto.yaml
@@ -1,0 +1,35 @@
+pactoVersion: "1.0"
+
+service:
+  name: stripe-api
+  version: 2024.01.01
+  owner:
+    team: external/stripe
+    contacts:
+      - type: url
+        value: https://support.stripe.com
+        purpose: support
+      - type: url
+        value: https://status.stripe.com
+        purpose: oncall
+
+interfaces:
+  - name: http
+    type: http
+    port: 443
+    visibility: public
+    contract: interfaces/openapi.json
+
+metadata:
+  tier: external
+  category: payments
+  criticality: high
+  summary: Stripe payment processing API (external dependency)
+  serviceType: external
+  protocol: https
+  repo: https://stripe.com/docs/api
+  tags:
+    - payments
+    - external
+    - stripe
+    - pci

--- a/examples/demo/main_host.go
+++ b/examples/demo/main_host.go
@@ -1,0 +1,12 @@
+//go:build !(js && wasm)
+
+package main
+
+import "fmt"
+
+// This binary is meant to be built for the browser (GOOS=js GOARCH=wasm). The
+// host build exists only so `go build ./...` and `go test ./...` work during
+// development and CI; running it does nothing useful.
+func main() {
+	fmt.Println("pacto dashboard demo: build with GOOS=js GOARCH=wasm (see Makefile)")
+}

--- a/examples/demo/main_wasm.go
+++ b/examples/demo/main_wasm.go
@@ -1,0 +1,79 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"embed"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"syscall/js"
+
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
+	"github.com/trianalab/pacto/pkg/dashboard"
+)
+
+// embeddedBundles holds the demo contracts baked into the wasm binary at build
+// time. They live in ./bundles, embedded directly (no copy step).
+//
+//go:embed bundles
+var embeddedBundles embed.FS
+
+// handler is the in-memory dashboard router (the same Huma operations the real
+// `pacto dashboard` server serves), driven per request from JavaScript.
+var handler http.Handler
+
+func main() {
+	root, err := fs.Sub(embeddedBundles, "bundles")
+	if err != nil {
+		panic(err)
+	}
+	src, err := NewEmbedSource(root)
+	if err != nil {
+		panic(err)
+	}
+
+	// nil UI fs and nil resolver: the static host serves the UI, and the graph
+	// resolves from the embedded contracts' declared dependencies — no OCI.
+	srv := dashboard.NewServer(src, nil)
+	mux := http.NewServeMux()
+	api := humago.New(mux, dashboard.APIConfig())
+	srv.RegisterOperations(api)
+	handler = mux
+
+	js.Global().Set("__pactoServe", js.FuncOf(serve))
+	if cb := js.Global().Get("__pactoOnReady"); cb.Type() == js.TypeFunction {
+		cb.Invoke()
+	}
+
+	select {} // keep the Go runtime alive so __pactoServe stays callable
+}
+
+// serve answers a single API request in memory. JS calls it as
+// __pactoServe(method, path, body?) and receives { status, body, contentType }.
+func serve(_ js.Value, args []js.Value) any {
+	method := args[0].String()
+	path := args[1].String()
+
+	var body io.Reader
+	if len(args) > 2 && args[2].Type() == js.TypeString {
+		body = strings.NewReader(args[2].String())
+	}
+
+	req := httptest.NewRequest(method, path, body)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	res := rec.Result()
+	out, _ := io.ReadAll(res.Body)
+	return map[string]any{
+		"status":      res.StatusCode,
+		"body":        string(out),
+		"contentType": res.Header.Get("Content-Type"),
+	}
+}

--- a/examples/demo/smoke.mjs
+++ b/examples/demo/smoke.mjs
@@ -1,0 +1,73 @@
+// Smoke test: load the built app.wasm in Node and exercise the in-wasm API the
+// same way boot.js does in the browser. Verifies the engine end-to-end without
+// a browser. Run after `make build` (or via `make smoke`).
+import { readFile } from "node:fs/promises";
+
+// Node provides globalThis.crypto (used by the Go runtime) already.
+const wasmExec = await readFile("dist/wasm_exec.js", "utf8");
+new Function(wasmExec)(); // defines globalThis.Go
+
+const go = new globalThis.Go();
+const { instance } = await WebAssembly.instantiate(await readFile("dist/app.wasm"), go.importObject);
+
+let ready;
+const readyP = new Promise((r) => (ready = r));
+globalThis.__pactoOnReady = () => ready();
+go.run(instance); // parks on select{}; do not await
+await readyP;
+
+const call = (method, path, body = null) => globalThis.__pactoServe(method, path, body);
+const json = (res) => JSON.parse(res.body);
+
+let failures = 0;
+const check = (name, cond, detail) => {
+  console.log(`${cond ? "PASS" : "FAIL"}  ${name}${detail ? "  — " + detail : ""}`);
+  if (!cond) failures++;
+};
+
+check("GET /health 200", call("GET", "/health").status === 200);
+
+const services = json(call("GET", "/api/services"));
+check("GET /api/services returns fleet", Array.isArray(services) && services.length >= 10, `${services.length} services`);
+check("fleet includes payments-service@2.1.0",
+  services.some((s) => s.name === "payments-service" && s.version === "2.1.0"));
+
+const graphRes = call("GET", "/api/graph");
+check("GET /api/graph 200 with content", graphRes.status === 200 && graphRes.body.length > 100, `${graphRes.body.length} bytes`);
+
+const versions = json(call("GET", "/api/services/payments-service/versions"));
+check("payments-service has 5 versions", Array.isArray(versions) && versions.length === 5, `${versions.length}`);
+const v200 = versions.find((v) => v.version === "2.0.0");
+check("2.0.0 classified BREAKING", v200 && v200.classification === "BREAKING", v200 && v200.classification);
+
+const diff = json(call("GET", "/api/diff?from_name=payments-service&from_version=1.2.0&to_name=payments-service&to_version=2.0.0"));
+check("diff 1.2.0->2.0.0 BREAKING", diff.classification === "BREAKING", `${diff.changes && diff.changes.length} changes`);
+check("diff includes /charges removal", (diff.changes || []).some((c) => c.path === "openapi.paths[/charges]"));
+
+// Every other GET endpoint the UI's api.ts calls must answer (no 500s), so no
+// dashboard view errors out in the browser.
+const n = encodeURIComponent("payments-service");
+for (const [name, path] of [
+  ["sources", "/api/sources"],
+  ["service sources", `/api/services/${n}/sources`],
+  ["dependents", `/api/services/${n}/dependents`],
+  ["cross-refs", `/api/services/${n}/refs`],
+  ["service graph", `/api/services/${n}/graph`],
+]) {
+  const res = call("GET", path);
+  check(`GET ${path} ok`, res.status === 200, `${name} status ${res.status}`);
+}
+
+// Readiness showcase: payments-service 2.1.0 declares a readiness block that
+// fails its gate (an expired ai-evals check drops the score to 70 < 80);
+// orders-service 1.2.0 declares an all-current block that passes.
+const pay = json(call("GET", "/api/services/payments-service"));
+check("payments 2.1.0 exposes readiness", pay.readiness != null);
+check("payments readiness Score 70", pay.readiness && pay.readiness.score === 70, pay.readiness && `score ${pay.readiness.score}`);
+check("payments readiness gate FAIL", pay.readiness && pay.readiness.passing === false);
+
+const ord = json(call("GET", "/api/services/orders-service"));
+check("orders 1.2.0 readiness passes", ord.readiness && ord.readiness.passing === true, ord.readiness && `score ${ord.readiness.score}`);
+
+console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+process.exit(failures === 0 ? 0 : 1);

--- a/examples/demo/source_embed.go
+++ b/examples/demo/source_embed.go
@@ -1,0 +1,232 @@
+// Package main provides a browser/WASM build of the Pacto dashboard backed by
+// contracts embedded at compile time, so the whole demo runs client-side with
+// no server and no live OCI access.
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+
+	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/pkg/dashboard"
+	"github.com/trianalab/pacto/pkg/semver"
+	"github.com/trianalab/pacto/pkg/validation"
+)
+
+const contractFile = "pacto.yaml"
+
+// embedSourceName is the source label reported to the dashboard. "local" is one
+// of the source types the UI already understands; the data is local to the wasm
+// binary, so the label is accurate.
+const embedSourceName = "local"
+
+// versionEntry is one parsed contract version held in memory.
+type versionEntry struct {
+	bundle *contract.Bundle
+	hash   string // sha256 of the raw YAML, used as the version's contract hash
+}
+
+// EmbedSource implements dashboard.DataSource over an embedded filesystem of
+// bundles. Unlike dashboard.LocalSource (which only knows the single version on
+// disk), it indexes every versioned directory it finds, so version history and
+// cross-version diffs work fully offline. The graph, dependents and cross-ref
+// views need no OCI resolver: they are derived from each contract's declared
+// dependencies, and every referenced bundle is embedded.
+type EmbedSource struct {
+	byName map[string]map[string]*versionEntry // service name -> version -> entry
+	names  []string                            // sorted service names
+}
+
+// NewEmbedSource walks fsys for pacto.yaml files and indexes them by service
+// name and version. Both layouts are supported: flat (bundles/<svc>/pacto.yaml)
+// and versioned (bundles/<svc>/vX.Y.Z/pacto.yaml). Unparseable files are skipped
+// so one bad bundle never breaks the whole demo.
+func NewEmbedSource(fsys fs.FS) (*EmbedSource, error) {
+	s := &EmbedSource{byName: make(map[string]map[string]*versionEntry)}
+
+	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Name() != contractFile {
+			return nil
+		}
+		raw, err := fs.ReadFile(fsys, p)
+		if err != nil {
+			return nil // skip unreadable
+		}
+		c, err := contract.Parse(bytes.NewReader(raw))
+		if err != nil {
+			return nil // skip invalid
+		}
+		// Root the bundle FS at the contract's directory so validation can
+		// resolve sibling files (referenced schemas, policies, docs).
+		sub, err := fs.Sub(fsys, path.Dir(p))
+		if err != nil {
+			return nil
+		}
+		h := sha256.Sum256(raw)
+		name, ver := c.Service.Name, c.Service.Version
+		if s.byName[name] == nil {
+			s.byName[name] = make(map[string]*versionEntry)
+		}
+		s.byName[name][ver] = &versionEntry{
+			bundle: &contract.Bundle{Contract: c, RawYAML: raw, FS: sub},
+			hash:   hex.EncodeToString(h[:]),
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("indexing embedded bundles: %w", err)
+	}
+
+	for name := range s.byName {
+		s.names = append(s.names, name)
+	}
+	sort.Strings(s.names)
+	return s, nil
+}
+
+// versionsDesc returns a service's versions sorted latest-first.
+func (s *EmbedSource) versionsDesc(name string) []string {
+	m := s.byName[name]
+	all := make([]string, 0, len(m))
+	for v := range m {
+		all = append(all, v)
+	}
+	return semver.Filter(all) // valid semver, descending
+}
+
+// latestEntry returns the highest-semver version entry for a service.
+func (s *EmbedSource) latestEntry(name string) (*versionEntry, string, error) {
+	m := s.byName[name]
+	if len(m) == 0 {
+		return nil, "", fmt.Errorf("service %q not found", name)
+	}
+	all := make([]string, 0, len(m))
+	for v := range m {
+		all = append(all, v)
+	}
+	latest := semver.Latest(all)
+	if latest == "" {
+		// No valid semver tags; fall back to any deterministic choice.
+		sort.Strings(all)
+		latest = all[len(all)-1]
+	}
+	return m[latest], latest, nil
+}
+
+// ListServices returns one entry per service (its latest version), matching the
+// "current fleet" view. ContractStatus is computed the same way the dashboard's
+// own LocalSource does (validate the bundle), via the exported validator.
+func (s *EmbedSource) ListServices(_ context.Context) ([]dashboard.Service, error) {
+	services := make([]dashboard.Service, 0, len(s.names))
+	for _, name := range s.names {
+		entry, _, err := s.latestEntry(name)
+		if err != nil {
+			continue
+		}
+		svc := dashboard.ServiceFromContract(entry.bundle.Contract, embedSourceName)
+		svc.ContractStatus = contractStatus(entry.bundle)
+		services = append(services, svc)
+	}
+	return services, nil
+}
+
+// GetService returns full details for a service's latest version.
+func (s *EmbedSource) GetService(_ context.Context, name string) (*dashboard.ServiceDetails, error) {
+	entry, _, err := s.latestEntry(name)
+	if err != nil {
+		return nil, err
+	}
+	return dashboard.ServiceDetailsFromBundle(entry.bundle, embedSourceName), nil
+}
+
+// GetVersions returns every indexed version for a service, latest first, each
+// annotated with its contract hash and the diff classification against the
+// immediately preceding version (BREAKING / POTENTIAL_BREAKING / NON_BREAKING).
+// The server marks the current version separately via GetService.
+func (s *EmbedSource) GetVersions(_ context.Context, name string) ([]dashboard.Version, error) {
+	desc := s.versionsDesc(name)
+	if len(desc) == 0 {
+		return nil, fmt.Errorf("service %q not found", name)
+	}
+	out := make([]dashboard.Version, 0, len(desc))
+	for i, v := range desc {
+		entry := s.byName[name][v]
+		ver := dashboard.Version{
+			Version:      v,
+			ContractHash: entry.hash,
+			Source:       embedSourceName,
+		}
+		// Classify against the previous (older) version, which sits at i+1 in a
+		// descending list. The oldest version has no predecessor.
+		if i+1 < len(desc) {
+			prev := desc[i+1]
+			prevEntry := s.byName[name][prev]
+			d := dashboard.ComputeDiff(
+				dashboard.Ref{Name: name, Version: prev},
+				dashboard.Ref{Name: name, Version: v},
+				prevEntry.bundle, entry.bundle,
+			)
+			if d != nil {
+				ver.Classification = d.Classification
+			}
+		}
+		out = append(out, ver)
+	}
+	return out, nil
+}
+
+// GetDiff compares two specific service versions. An empty Ref.Version means the
+// service's latest version.
+func (s *EmbedSource) GetDiff(_ context.Context, a, b dashboard.Ref) (*dashboard.DiffResult, error) {
+	entryA, refA, err := s.resolveRef(a)
+	if err != nil {
+		return nil, fmt.Errorf("loading %q: %w", a.Name, err)
+	}
+	entryB, refB, err := s.resolveRef(b)
+	if err != nil {
+		return nil, fmt.Errorf("loading %q: %w", b.Name, err)
+	}
+	return dashboard.ComputeDiff(refA, refB, entryA.bundle, entryB.bundle), nil
+}
+
+// resolveRef finds the bundle for a ref, defaulting an empty version to latest,
+// and returns the concrete ref (with the resolved version filled in).
+func (s *EmbedSource) resolveRef(r dashboard.Ref) (*versionEntry, dashboard.Ref, error) {
+	if r.Version == "" {
+		entry, latest, err := s.latestEntry(r.Name)
+		if err != nil {
+			return nil, r, err
+		}
+		r.Version = latest
+		return entry, r, nil
+	}
+	m := s.byName[r.Name]
+	entry, ok := m[r.Version]
+	if !ok {
+		return nil, r, fmt.Errorf("version %q of %q not found", r.Version, r.Name)
+	}
+	return entry, r, nil
+}
+
+// contractStatus mirrors the dashboard's unexported contractStatusFromBundle:
+// validate the bundle and map the result to a ContractStatus. It uses the
+// exported validator so no upstream change is needed.
+func contractStatus(b *contract.Bundle) dashboard.ContractStatus {
+	if b.RawYAML == nil {
+		return dashboard.StatusUnknown
+	}
+	res := validation.Validate(b.Contract, b.RawYAML, b.FS)
+	if res.IsValid() {
+		return dashboard.StatusCompliant
+	}
+	return dashboard.StatusNonCompliant
+}

--- a/examples/demo/source_embed_test.go
+++ b/examples/demo/source_embed_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/trianalab/pacto/pkg/dashboard"
+)
+
+// bundlesFS loads the same bundles the wasm binary embeds. Bundles live in
+// ./bundles relative to this package, so go test (cwd = package dir) finds them.
+func bundlesFS(t *testing.T) *EmbedSource {
+	t.Helper()
+	src, err := NewEmbedSource(os.DirFS("bundles"))
+	if err != nil {
+		t.Fatalf("NewEmbedSource: %v", err)
+	}
+	return src
+}
+
+func TestListServices(t *testing.T) {
+	src := bundlesFS(t)
+	svcs, err := src.ListServices(context.Background())
+	if err != nil {
+		t.Fatalf("ListServices: %v", err)
+	}
+	if len(svcs) < 10 {
+		t.Fatalf("expected the demo's full fleet, got %d services", len(svcs))
+	}
+	want := map[string]bool{"pacto-demo": false, "frontend": false, "payments-service": false}
+	for _, s := range svcs {
+		if _, ok := want[s.Name]; ok {
+			want[s.Name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("expected service %q in fleet", name)
+		}
+	}
+}
+
+func TestGetServiceReturnsLatest(t *testing.T) {
+	src := bundlesFS(t)
+	d, err := src.GetService(context.Background(), "payments-service")
+	if err != nil {
+		t.Fatalf("GetService: %v", err)
+	}
+	if d.Version != "2.1.0" {
+		t.Errorf("payments-service current version = %q, want 2.1.0", d.Version)
+	}
+}
+
+func TestGetVersionsDescendingWithClassification(t *testing.T) {
+	src := bundlesFS(t)
+	vs, err := src.GetVersions(context.Background(), "payments-service")
+	if err != nil {
+		t.Fatalf("GetVersions: %v", err)
+	}
+	wantOrder := []string{"2.1.0", "2.0.0", "1.2.0", "1.1.0", "1.0.0"}
+	if len(vs) != len(wantOrder) {
+		t.Fatalf("got %d versions, want %d", len(vs), len(wantOrder))
+	}
+	for i, w := range wantOrder {
+		if vs[i].Version != w {
+			t.Errorf("version[%d] = %q, want %q", i, vs[i].Version, w)
+		}
+		if vs[i].ContractHash == "" {
+			t.Errorf("version %q missing contract hash", vs[i].Version)
+		}
+	}
+	for _, v := range vs {
+		if v.Version == "2.0.0" && v.Classification != "BREAKING" {
+			t.Errorf("2.0.0 classification = %q, want BREAKING", v.Classification)
+		}
+	}
+}
+
+func TestGetDiffBreaking(t *testing.T) {
+	src := bundlesFS(t)
+	d, err := src.GetDiff(context.Background(),
+		dashboard.Ref{Name: "payments-service", Version: "1.2.0"},
+		dashboard.Ref{Name: "payments-service", Version: "2.0.0"})
+	if err != nil {
+		t.Fatalf("GetDiff: %v", err)
+	}
+	if d.Classification != "BREAKING" {
+		t.Errorf("classification = %q, want BREAKING", d.Classification)
+	}
+	var sawChargesRemoved bool
+	for _, c := range d.Changes {
+		if c.Path == "openapi.paths[/charges]" {
+			sawChargesRemoved = true
+		}
+	}
+	if !sawChargesRemoved {
+		t.Errorf("expected removal of /charges path among %d changes", len(d.Changes))
+	}
+}
+
+func TestGetDiffDefaultsToLatest(t *testing.T) {
+	src := bundlesFS(t)
+	d, err := src.GetDiff(context.Background(),
+		dashboard.Ref{Name: "payments-service", Version: "1.0.0"},
+		dashboard.Ref{Name: "payments-service", Version: ""})
+	if err != nil {
+		t.Fatalf("GetDiff: %v", err)
+	}
+	if d.To.Version != "2.1.0" {
+		t.Errorf("to version = %q, want resolved latest 2.1.0", d.To.Version)
+	}
+}
+
+// TestReadinessShowcase pins the two readiness fixtures: payments-service 2.1.0
+// fails its gate (Score 70 < minScore 80) and orders-service 1.2.0 passes. Dates
+// are durable sentinels, so these hold regardless of when the test runs.
+func TestReadinessShowcase(t *testing.T) {
+	src := bundlesFS(t)
+
+	pay, err := src.GetService(context.Background(), "payments-service")
+	if err != nil {
+		t.Fatalf("GetService(payments-service): %v", err)
+	}
+	if pay.Readiness == nil {
+		t.Fatal("payments-service 2.1.0 should expose readiness")
+	}
+	if pay.Readiness.MinScore != 80 {
+		t.Errorf("payments minScore = %d, want 80", pay.Readiness.MinScore)
+	}
+	if pay.Readiness.Score != 70 {
+		t.Errorf("payments score = %d, want 70", pay.Readiness.Score)
+	}
+	if pay.Readiness.Passing {
+		t.Error("payments readiness gate should FAIL (70 < 80)")
+	}
+
+	ord, err := src.GetService(context.Background(), "orders-service")
+	if err != nil {
+		t.Fatalf("GetService(orders-service): %v", err)
+	}
+	if ord.Readiness == nil || !ord.Readiness.Passing {
+		t.Errorf("orders-service 1.2.0 readiness should PASS, got %+v", ord.Readiness)
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
       - Kubernetes operator: operator.md
   - Examples:
       - Overview: examples/index.md
+      - Live dashboard demo: examples/dashboard-demo.md
       - Cron worker: examples/cron-worker.md
       - Event processor: examples/event-processor.md
       - gRPC service: examples/grpc-service.md


### PR DESCRIPTION
Folds the standalone `pacto-demo` repo into this repo as a fully client-side **WebAssembly build of `pacto dashboard`**, hosted under the existing docs GitHub Pages site at **https://trianalab.github.io/pacto/demo/**. No backend, no live OCI — the engine and demo contracts are compiled to wasm and served as static files.

## What's here
- **`examples/demo/`** (new in-module `package main`):
  - `source_embed.go` — `EmbedSource` implementing `dashboard.DataSource` over `//go:embed bundles` (multi-version + offline diff classification), using only exported `pkg/dashboard` symbols.
  - `main_wasm.go` — builds the dashboard's Huma API in memory (no listener) and exposes `__pactoServe` to JS; `main_host.go` is the non-wasm stub.
  - `boot.js` — fetch shim routing `/api/*`, `/health`, `/metrics` into wasm; everything else hits the network. Base-path agnostic.
  - `Makefile` — `preflight` (root-owned-artifact guard) → UI rebuild (separate outDir) → wasm → wasm_exec → inject (loader + 404 + version) ; plus offline CLI targets `breaking-change`/`evolution`/`explain`.
  - `smoke.mjs` — drives `app.wasm` in Node and asserts every UI endpoint.
  - `bundles/` — the curated demo contracts (~dozen services across edge/domain/infra/external; payments-service spans 5 versions with a BREAKING 1.2.0→2.0.0 that removes `/charges`).
- **Readiness showcase** (uses this repo's readiness feature): payments-service 2.1.0 **fails** its gate (an expired check drops the score to 70 < 80), orders-service 1.2.0 **passes** (100). Durable sentinel dates keep these stable.
- **Hosting** folded into `docs.yml`: after `mkdocs build`, the demo builds into `site/demo/` and one Pages artifact publishes docs + demo (two Pages deploys in one repo conflict). Trigger also fires on `pkg/dashboard/**` so the live demo can't drift from the dashboard code it embeds. Nav link added (`docs/examples/dashboard-demo.md`).
- **Coverage gate**: `examples/` excluded from the 100% gate (the host stub `main()` is uncoverable); `ci-test` runs `go test ./examples/...` separately so the EmbedSource tests still execute in CI.
- README demo link repointed from the old `pacto-demo` repo to the live site.

## In-repo simplifications vs the standalone build
- Same Go module → import `pkg/dashboard` directly (no `go.mod`/`go.sum` change; `humago` already a dep).
- `//go:embed bundles` directly (no copy step).
- UI built from local `pkg/dashboard/frontend` with `--base=/pacto/demo/` into a **separate outDir** — the committed `pkg/dashboard/ui` (used by the real server) is never touched.
- Deploy is part of the docs deploy (no poll-latest-release logic); `workflow_dispatch` kept for manual syncs.

## Verification
- `go test ./examples/demo/...` — EmbedSource + readiness tests pass.
- `make -C examples/demo build BASE=/pacto/demo/ && make -C examples/demo smoke` — wasm builds (≈52 MB raw / ~9.6 MB gz); **18/18 smoke checks pass**, incl. payments readiness Score 70 / gate FAIL, orders PASS, and the BREAKING diff removing `openapi.paths[/charges]`.
- Full CI gate locally: `ci-fmt`, `ci-vet`, `ci-cyclo`, `ci-lint` (golangci-lint: 0 issues), `ci-test` (**coverage 100.0%** + examples + 270 frontend tests), **`ci-ui-drift` (pkg/dashboard/ui untouched)**.
- Offline CLI narrative confirmed: `make breaking-change` and `make explain` work on local bundles.

## Decisions worth noting
- **OCI:** bundles ship as-is (refs are inert in the embedded demo — the graph matches dependencies by name). `make validate`/`make graph` are deliberately omitted from the offline narrative: they resolve refs over the network, and the demo must not depend on a registry slated for retirement. The dashboard itself stays Compliant offline because local-only `validation.Validate` treats `oci://` policy refs as warnings.
- **wasm vet:** `main_wasm.go` is `js && wasm`-tagged, so `go vet ./...` skips it on the host; the cross-compile in `make build` catches compile errors. A dedicated `GOOS=js GOARCH=wasm go vet` was considered and skipped as not worth the CI complexity for a small faithfully-ported file.

## One-time Pages check (post-merge)
Pages source is already "GitHub Actions" (the docs site). On the first run after merge, confirm both **https://trianalab.github.io/pacto/** and **https://trianalab.github.io/pacto/demo/** resolve.

## Follow-up (separate repo)
Leave `trianalab/pacto-demo` a pointer/redirect to the live demo and archive it.