### PR TITLE
fix: correct demo doc links, serve the demo via make docs, and fix Auto release publish

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -124,9 +124,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Download all artifacts
+      - name: Download release binaries
         uses: actions/download-artifact@v8
         with:
+          # Only the platform binaries — NOT the docker digest-* / *.dockerbuild
+          # artifacts, which include 0-byte files the release asset API rejects.
+          pattern: pacto_*
           path: dist
           merge-multiple: true
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,15 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check conventional commit format
+        # Pass the title via env, never interpolated into the script, so titles
+        # containing backticks or $(...) can't be executed by the shell.
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
         run: |
-          title="${{ github.event.pull_request.title }}"
           pattern='^(feat|fix|docs|chore|refactor|test|ci|perf|build|style)(\(.+\))?\!?: .+'
-          if [[ ! "$title" =~ $pattern ]]; then
+          if [[ ! "$TITLE" =~ $pattern ]]; then
             echo "::error::PR title must follow conventional commit format:"
             echo "::error::  <type>[optional scope][!]: <description>"
             echo "::error::Allowed types: feat, fix, docs, chore, refactor, test, ci, perf, build, style"
             echo "::error::Add '!' before ':' for breaking changes (e.g., 'feat!: redesign API')"
-            echo "::error::Got: '$title'"
+            echo "::error::Got: '$TITLE'"
             exit 1
           fi
-          echo "PR title is valid: $title"
+          echo "PR title is valid: $TITLE"

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ coverage.html
 # MkDocs build output
 /site/
 
+# Local docs preview build of the WASM demo (CI builds it into site/demo)
+/docs/demo/
+
 # TODO
 TODO.md
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,10 @@ endif
 
 IMAGE := ghcr.io/trianalab/pacto-dashboard
 
-.PHONY: build test e2e coverage lint clean docs docs-build gen-cli-docs docker-build docker-run
+.PHONY: build test e2e coverage lint clean docs docs-build demo-preview-clean gen-cli-docs docker-build docker-run
+
+# Local docs preview includes the in-browser WASM dashboard demo at /demo/.
+DOCS_DEMO := docs/demo
 
 build:
 	rm -f "$(GOBIN)/pacto"
@@ -38,12 +41,24 @@ gen-cli-docs:
 	go run ./cmd/gendocs/
 
 # Documentation (MkDocs Material). Install via `brew install mkdocs-material`
-# or `pip install -r docs/requirements.txt`.
-docs:
+# or `pip install -r docs/requirements.txt`. Both targets first build the
+# in-browser WASM demo into docs/demo/ so the local preview exposes it, mirroring
+# the deployed site. mkdocs honors site_url, so it serves under /pacto/ locally
+# and the demo lives at /pacto/demo/ both locally and in production.
+docs: $(DOCS_DEMO)/app.wasm
 	mkdocs serve
 
-docs-build:
+docs-build: $(DOCS_DEMO)/app.wasm
 	mkdocs build
+
+# Build the WASM dashboard demo into docs/demo/ (gitignored) at the same base as
+# production (/pacto/demo/) so `mkdocs serve`/`build` serve it correctly. Only
+# rebuilt when missing; force a refresh with `make demo-preview-clean`.
+$(DOCS_DEMO)/app.wasm:
+	$(MAKE) -C examples/demo build BASE=/pacto/demo/ DIST=$(CURDIR)/$(DOCS_DEMO)
+
+demo-preview-clean:
+	rm -rf $(DOCS_DEMO)
 
 docker-build:
 	docker build --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg BUILD_DATE=$(BUILD_DATE) -t $(IMAGE):$(VERSION) .

--- a/docs/examples/dashboard-demo.md
+++ b/docs/examples/dashboard-demo.md
@@ -4,7 +4,7 @@ The Pacto dashboard runs entirely in your browser as a static WebAssembly build 
 the Pacto engine and a curated set of demo contracts are compiled to WASM and
 served with no backend.
 
-**[Open the live dashboard demo →](/pacto/demo/)**
+<a href="../../demo/" class="md-button md-button--primary">Open the live dashboard demo →</a>
 
 It showcases the full UI against a realistic fleet:
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,7 +1,7 @@
 # Example Contracts
 This section provides ready-to-use Pacto contracts for common infrastructure services. Use these as references when writing your own contracts or as dependencies in your service contracts.
 
-For a complete working demo repository, see [pacto-demo](https://github.com/TrianaLab/pacto-demo).
+For a complete, runnable demo, see the [live dashboard demo](dashboard-demo.md) — its source and curated contract set live in [`examples/demo`](https://github.com/TrianaLab/pacto/tree/main/examples/demo).
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 [Get Started](quickstart.md){ .md-button .md-button--primary }
 [Specification](contract-reference.md){ .md-button }
 [Examples](examples/index.md){ .md-button }
-[Demo](https://github.com/TrianaLab/pacto-demo){ .md-button }
+[Demo](examples/dashboard-demo.md){ .md-button }
 
 ---
 ## What is Pacto?


### PR DESCRIPTION
Post-merge follow-up to #186 (the WASM dashboard demo).

## 1. Stale `pacto-demo` links in the docs
The home page and the examples index still linked to the retired `github.com/TrianaLab/pacto-demo` repo. Repointed both to the in-repo **Live dashboard demo** page (`docs/examples/dashboard-demo.md`), which links to the live site and to `examples/demo/`. No references to the old repo remain in the published docs (the only `pacto-demo` left is the demo's root *service name* in a test).

## 2. `make docs` now exposes the WASM demo
Previously `make docs` (`mkdocs serve`) only served the markdown — the demo was built separately in CI, so locally `/demo/` was missing. Now `make docs` and `make docs-build` first build the demo into `docs/demo/` (gitignored) and mkdocs serves it. mkdocs honors `site_url`, so it serves under `/pacto/` locally and the demo lives at **`/pacto/demo/`** both locally and in production (so the demo is built with the same `BASE=/pacto/demo/` as CI). The demo build is cached; force a refresh with `make demo-preview-clean`. The landing-page "Open the live demo" link is root-relative so it resolves in both environments.

Verified locally: `make docs` → `GET /pacto/demo/` 200, `app.wasm` 200 `application/wasm`, `boot.js`/assets 200, dashboard-demo page 200.

## 3. Auto release publish failure (pre-existing, unrelated to the demo)
The `Auto release` `publish` job failed with `ReleaseAsset ... size must be greater than or equal to 1`. Root cause: it downloaded **all** artifacts (`merge-multiple`, no pattern) and uploaded `dist/*`, sweeping in the docker `digest-*` artifacts — **0-byte files** created by `touch` — which GitHub's release-asset API rejects. The platform binaries themselves uploaded fine, so **v1.7.0 is complete** (all 7 binaries + `checksums.txt` present) — nothing to re-run. Same failure occurred earlier on an unrelated PR, confirming it predates the demo work.

Fix: scope the publish download to `pattern: pacto_*` so only the platform binaries (+ generated checksums) are attached to releases; docker `digest-*`/`*.dockerbuild` artifacts are no longer uploaded as release assets.

Optional tidy (not done here, modifies a published release): the leftover `TrianaLab.pacto.1E9DL1.dockerbuild` asset on v1.7.0 can be removed with `gh release delete-asset v1.7.0 'TrianaLab.pacto.1E9DL1.dockerbuild'`.

## Verification
- `mkdocs build` clean; `make docs` serves `/pacto/demo/` (200, `application/wasm`).
- No stale `pacto-demo` repo links in `docs/`, `README.md`, `mkdocs.yml`.
- `auto-release.yml` YAML valid; download now scoped to the binaries.