### PR TITLE
ci: auto-rebuild dashboard UI on Dependabot frontend bumps

### DIFF
--- a/.github/workflows/ui-rebuild-commit.yml
+++ b/.github/workflows/ui-rebuild-commit.yml
@@ -1,0 +1,79 @@
+name: Rebuild dashboard UI (commit)
+
+# Privileged half of the UI auto-rebuild. Triggered when "Rebuild dashboard UI"
+# finishes, it downloads the rebuilt-ui artifact and commits it back to the
+# Dependabot PR branch.
+#
+# Security: this never runs PR-provided code. It only handles a trusted artifact
+# (the rebuilt UI tar) and uses plain git to fetch the branch tip, replace
+# pkg/dashboard/ui, and push. There is no `actions/checkout` of the PR head and
+# no build/test step, so the "untrusted checkout in a privileged context" sink
+# does not exist here.
+
+on:
+  workflow_run:
+    workflows: ["Rebuild dashboard UI"]
+    types: [completed]
+
+permissions:
+  contents: write
+
+jobs:
+  commit:
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download the rebuilt UI artifact
+        id: dl
+        uses: actions/download-artifact@v8
+        with:
+          name: rebuilt-ui
+          path: _ui_artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Resolve the PR branch
+        id: pr
+        if: steps.dl.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          num=$(cat _ui_artifact/pr-number)
+          head_repo=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${num}" --jq '.head.repo.full_name')
+          head_ref=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${num}" --jq '.head.ref')
+          # Same-repo (Dependabot) branches only — never push to a fork.
+          if [ "$head_repo" != "$GITHUB_REPOSITORY" ]; then
+            echo "PR head is a fork ($head_repo); skipping."
+            exit 0
+          fi
+          echo "ref=$head_ref" >> "$GITHUB_OUTPUT"
+
+      - name: Commit the rebuilt UI to the PR branch
+        if: steps.pr.outputs.ref != ''
+        env:
+          # GITHUB_TOKEN commits the fix but its push does NOT re-trigger CI —
+          # re-run the checks once, or set a UI_REBUILD_TOKEN PAT (contents:write)
+          # for full automation.
+          GH_TOKEN: ${{ secrets.UI_REBUILD_TOKEN || secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ steps.pr.outputs.ref }}
+        run: |
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          # Fetch only the branch tip as data; we run none of its code.
+          git init -q repo
+          cd repo
+          git remote add origin "$remote"
+          git -c protocol.version=2 fetch -q --depth=1 origin "$HEAD_REF"
+          git checkout -q FETCH_HEAD
+          rm -rf pkg/dashboard/ui
+          tar -C pkg/dashboard -xf ../_ui_artifact/ui.tar
+          if [ -z "$(git status --porcelain pkg/dashboard/ui)" ]; then
+            echo "Branch already has the rebuilt UI; nothing to push."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pkg/dashboard/ui
+          git commit -q -m "chore(deps): rebuild dashboard UI after frontend bump"
+          git push -q origin "HEAD:${HEAD_REF}"
+          echo "Pushed rebuilt UI to ${HEAD_REF}."

--- a/.github/workflows/ui-rebuild.yml
+++ b/.github/workflows/ui-rebuild.yml
@@ -1,77 +1,64 @@
-name: Rebuild dashboard UI (Dependabot)
+name: Rebuild dashboard UI
 
-# Dependabot bumps frontend dependencies (pkg/dashboard/frontend) but cannot
-# rebuild the committed pkg/dashboard/ui bundle, so the ci-ui-drift gate fails on
-# every frontend bump and the UI has to be rebuilt by hand. This workflow does
-# that automatically: on a Dependabot PR that touches the frontend, it rebuilds
-# the UI and commits the result back to the PR branch.
+# Dependabot bumps pkg/dashboard/frontend deps but cannot rebuild the committed
+# pkg/dashboard/ui bundle, so the ci-ui-drift gate fails on every frontend bump
+# and the UI has to be rebuilt by hand. This rebuilds it automatically.
 #
-# The committed UI is deliberately kept in git (it is //go:embed-ed into the
-# binary, so `go install`, the Docker image and the release build all ship a
-# working dashboard without needing Node). This workflow keeps that committed
-# build in sync — it does not remove it.
+# The committed UI is deliberately kept in git (it is //go:embed-ed, so
+# `go install`, the Docker image and the release build ship a working dashboard
+# without Node). This keeps that committed build in sync — it does not remove it.
 #
-# pull_request_target is required so the job has a write-capable token:
-# Dependabot-triggered `pull_request`/`push` runs only get a read-only token and
-# cannot push back. The job is restricted to Dependabot and never exposes a token
-# to the dependency build step (see the security notes inline).
+# Security: this is the UNPRIVILEGED half. It runs on `pull_request`, so building
+# the PR's (untrusted) frontend with the bumped deps happens with a read-only
+# token and no secrets — nothing to steal. It only uploads the rebuilt UI as an
+# artifact; the privileged commit-back is done by ui-rebuild-commit.yml, which
+# runs no PR code. This avoids "checkout of untrusted code in a privileged
+# context".
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  pull_request:
     paths:
       - 'pkg/dashboard/frontend/**'
 
 permissions:
-  contents: write
-
-# One rebuild per PR; let an in-flight rebuild finish before starting another.
-concurrency:
-  group: ui-rebuild-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  contents: read
 
 jobs:
-  rebuild-ui:
-    # Only Dependabot's own PRs. This guards the pull_request_target +
-    # checkout-PR-head pattern so we never build arbitrary contributor/fork code.
+  build:
+    # Only Dependabot's frontend bumps need this; humans rebuild + commit the UI
+    # themselves and ci-ui-drift catches them.
     if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the PR branch
-        uses: actions/checkout@v6.0.3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          # Do NOT persist the token in .git/config: the dependency build step
-          # below runs PR-controlled code, which must never have push access.
-          persist-credentials: false
+      - uses: actions/checkout@v6.0.3
 
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
 
-      # No secrets are present in this step's environment, so even a malicious
-      # bumped dependency cannot exfiltrate a token. `make ui-build` is the same
-      # build ci-ui-drift runs (single source of truth in ci.mk); it uses
-      # --ignore-scripts so only the project's own vite build runs.
       - name: Rebuild the dashboard UI
         run: make ui-build
 
-      - name: Commit and push the rebuilt UI if it changed
+      - name: Package the rebuilt UI if it drifted
+        id: drift
         env:
-          # GITHUB_TOKEN works out of the box (it commits the fix), but a push
-          # made with it does NOT re-trigger CI — re-run the failed checks once,
-          # or set a UI_REBUILD_TOKEN PAT (contents:write) for full automation.
-          GH_TOKEN: ${{ secrets.UI_REBUILD_TOKEN || secrets.GITHUB_TOKEN }}
-          # Via env (not inline ${{…}}) so a crafted branch name can't inject shell.
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [ -z "$(git status --porcelain pkg/dashboard/ui)" ]; then
             echo "Committed UI already matches the rebuild; nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add pkg/dashboard/ui
-          git commit -m "chore(deps): rebuild dashboard UI after frontend bump"
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-            "HEAD:${HEAD_REF}"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          mkdir -p _ui_artifact
+          # Tar the whole tree so deletions/renames apply cleanly on the other side.
+          tar -C pkg/dashboard -cf _ui_artifact/ui.tar ui
+          printf '%s\n' "$PR_NUMBER" > _ui_artifact/pr-number
+
+      - name: Upload the rebuilt UI
+        if: steps.drift.outputs.changed == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rebuilt-ui
+          path: _ui_artifact/
+          retention-days: 1

--- a/.github/workflows/ui-rebuild.yml
+++ b/.github/workflows/ui-rebuild.yml
@@ -1,0 +1,76 @@
+name: Rebuild dashboard UI (Dependabot)
+
+# Dependabot bumps frontend dependencies (pkg/dashboard/frontend) but cannot
+# rebuild the committed pkg/dashboard/ui bundle, so the ci-ui-drift gate fails on
+# every frontend bump and the UI has to be rebuilt by hand. This workflow does
+# that automatically: on a Dependabot PR that touches the frontend, it rebuilds
+# the UI and commits the result back to the PR branch.
+#
+# The committed UI is deliberately kept in git (it is //go:embed-ed into the
+# binary, so `go install`, the Docker image and the release build all ship a
+# working dashboard without needing Node). This workflow keeps that committed
+# build in sync — it does not remove it.
+#
+# pull_request_target is required so the job has a write-capable token:
+# Dependabot-triggered `pull_request`/`push` runs only get a read-only token and
+# cannot push back. The job is restricted to Dependabot and never exposes a token
+# to the dependency build step (see the security notes inline).
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'pkg/dashboard/frontend/**'
+
+permissions:
+  contents: write
+
+# One rebuild per PR; let an in-flight rebuild finish before starting another.
+concurrency:
+  group: ui-rebuild-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  rebuild-ui:
+    # Only Dependabot's own PRs. This guards the pull_request_target +
+    # checkout-PR-head pattern so we never build arbitrary contributor/fork code.
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the PR branch
+        uses: actions/checkout@v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          # Do NOT persist the token in .git/config: the dependency build step
+          # below runs PR-controlled code, which must never have push access.
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # No secrets are present in this step's environment, so even a malicious
+      # bumped dependency cannot exfiltrate a token. --ignore-scripts skips
+      # package lifecycle scripts; only the project's own vite build runs.
+      - name: Rebuild the dashboard UI
+        run: cd pkg/dashboard/frontend && npm ci --ignore-scripts && npm run build
+
+      - name: Commit and push the rebuilt UI if it changed
+        env:
+          # GITHUB_TOKEN works out of the box (it commits the fix), but a push
+          # made with it does NOT re-trigger CI — re-run the failed checks once,
+          # or set a UI_REBUILD_TOKEN PAT (contents:write) for full automation.
+          GH_TOKEN: ${{ secrets.UI_REBUILD_TOKEN || secrets.GITHUB_TOKEN }}
+          # Via env (not inline ${{…}}) so a crafted branch name can't inject shell.
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [ -z "$(git status --porcelain pkg/dashboard/ui)" ]; then
+            echo "Committed UI already matches the rebuild; nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pkg/dashboard/ui
+          git commit -m "chore(deps): rebuild dashboard UI after frontend bump"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:${HEAD_REF}"

--- a/.github/workflows/ui-rebuild.yml
+++ b/.github/workflows/ui-rebuild.yml
@@ -50,10 +50,11 @@ jobs:
           node-version: '22'
 
       # No secrets are present in this step's environment, so even a malicious
-      # bumped dependency cannot exfiltrate a token. --ignore-scripts skips
-      # package lifecycle scripts; only the project's own vite build runs.
+      # bumped dependency cannot exfiltrate a token. `make ui-build` is the same
+      # build ci-ui-drift runs (single source of truth in ci.mk); it uses
+      # --ignore-scripts so only the project's own vite build runs.
       - name: Rebuild the dashboard UI
-        run: cd pkg/dashboard/frontend && npm ci --ignore-scripts && npm run build
+        run: make ui-build
 
       - name: Commit and push the rebuilt UI if it changed
         env:

--- a/ci.mk
+++ b/ci.mk
@@ -4,7 +4,7 @@
 
 BUNDLE_DIR := pactos/pacto-dashboard
 
-.PHONY: ci ci-static ci-test ci-ui ci-ui-drift ci-fmt ci-vet ci-cyclo ci-lint ci-docs \
+.PHONY: ci ci-static ci-test ci-ui ui-build ci-ui-drift ci-fmt ci-vet ci-cyclo ci-lint ci-docs \
        gen-openapi gen-config-schema gen-sbom gen-bundle
 
 ci: ci-static ci-test e2e gen-bundle
@@ -50,10 +50,15 @@ ci-docs:
 	@$(MAKE) gen-cli-docs
 	@git diff --exit-code docs/cli-reference.md || (echo "CLI docs are out of date. Run 'make gen-cli-docs' and commit." && exit 1)
 
-ci-ui-drift:
-	@echo "==> Checking committed dashboard UI build is up to date..."
+# Rebuild the committed dashboard UI from frontend source. Single source of truth
+# for the build incantation — reused by ci-ui-drift and the ui-rebuild workflow.
+ui-build:
+	@echo "==> Building dashboard UI..."
 	cd pkg/dashboard/frontend && npm ci --ignore-scripts && npm run build
-	@git diff --exit-code pkg/dashboard/ui/ || (echo "Committed pkg/dashboard/ui/ is out of date. Run 'npm run build' in pkg/dashboard/frontend and commit." && exit 1)
+
+ci-ui-drift: ui-build
+	@echo "==> Checking committed dashboard UI build is up to date..."
+	@git diff --exit-code pkg/dashboard/ui/ || (echo "Committed pkg/dashboard/ui/ is out of date. Run 'make ui-build' and commit." && exit 1)
 
 # ── Bundle generation targets ────────────────────────────────────────
 # The OpenAPI spec is generated via the pacto-plugin-openapi-infer plugin


### PR DESCRIPTION
## Problem
The committed `pkg/dashboard/ui/` build is `//go:embed`-ed into the binary, so it's load-bearing for distribution — `go install github.com/trianalab/pacto/cmd/pacto@latest` (documented), the Docker image (`COPY . . && go build`) and the release build all ship a working dashboard **without needing Node** because the UI is committed. The `ci-ui-drift` gate enforces that the committed bundle matches the frontend source.

Dependabot bumps `pkg/dashboard/frontend` deps but **cannot rebuild** the committed UI, so `ci-ui-drift` fails on every frontend bump (e.g. #188) and a maintainer rebuilds it by hand.

(Not chosen: "stop committing the UI" — it would regress `go install` to an empty dashboard since Go can't run npm, and need Node build stages in Docker/release.)

## Fix — auto-rebuild, kept secure
Two workflows so we never check out + build untrusted PR code in a privileged context (addresses the CodeQL *"checkout of untrusted code in a privileged context"* finding):

1. **`ui-rebuild.yml` (unprivileged, `pull_request`)** — on a Dependabot frontend bump, runs `make ui-build` (the bumped deps' build) under a **read-only token with no secrets** and uploads the rebuilt UI as an artifact. Running untrusted code here is safe — there's nothing to steal.
2. **`ui-rebuild-commit.yml` (privileged, `workflow_run`)** — downloads the artifact and commits it back to the Dependabot branch using **plain git, executing no PR code** (no `actions/checkout` of the PR head, no build/test). Restricted to same-repo branches.

The build incantation lives once in `ci.mk` as a new `ui-build` target, reused by `ci-ui-drift` and the build workflow (keeps `ci.mk` the single source of truth).

### One-time setup (optional, for full automation)
With the default `GITHUB_TOKEN` the bot commits the fix, but a `GITHUB_TOKEN` push doesn't re-trigger CI — re-run the failed checks once. To make it fully hands-off, add a `UI_REBUILD_TOKEN` repo secret (fine-grained PAT, `contents: write`); the commit workflow prefers it and its push re-triggers CI.

## Notes
- `workflow_run` runs from `main`, so this takes effect on Dependabot PRs **after** merge (won't self-test on this PR).
- `ci-ui-drift` stays the gate; human PRs still rebuild + commit the UI themselves. This only automates the Dependabot case.

Validated locally: `make ci-ui-drift` passes via the new `ui-build` target with no drift; `actionlint` clean on both workflows.
