### PR TITLE
fix(demo): cache-bust the wasm engine and show the Pacto version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.3
+        # Full history + tags so the demo build's `git describe` resolves the
+        # real Pacto version to bake into the dashboard (shown in the navbar).
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'

--- a/examples/demo/Makefile
+++ b/examples/demo/Makefile
@@ -18,6 +18,11 @@ GOROOT      := $(shell go env GOROOT)
 SERVE_PORT  ?= 8088
 FRONTEND    := $(abspath ../../pkg/dashboard/frontend)
 UI_BUILD    := $(abspath .ui-build)
+# Pacto version this demo is built from — the latest release tag, surfaced in the
+# dashboard navbar via -ldflags into the wasm. Uses --abbrev=0 for a clean
+# "vX.Y.Z" label. Needs tags available (CI must checkout with fetch-depth: 0);
+# falls back to a short SHA, then "dev", when no tags are present.
+VERSION     ?= $(shell git describe --tags --abbrev=0 2>/dev/null || git rev-parse --short HEAD 2>/dev/null || echo dev)
 
 .PHONY: build preflight ui wasm wasmexec inject serve test smoke clean diff breaking-change evolution explain
 
@@ -46,10 +51,11 @@ ui:
 	@echo "==> Built UI (base $(BASE))"
 
 ## Compile the engine to wasm. Bundles are embedded via //go:embed bundles.
+## The Pacto version is baked in so /health (and thus the navbar) reports it.
 wasm:
 	@mkdir -p $(DIST)
-	GOOS=js GOARCH=wasm go build -ldflags="-s -w" -o $(DIST)/app.wasm .
-	@echo "==> Built $(DIST)/app.wasm ($$(du -h $(DIST)/app.wasm | cut -f1))"
+	GOOS=js GOARCH=wasm go build -ldflags="-s -w -X main.version=$(VERSION)" -o $(DIST)/app.wasm .
+	@echo "==> Built $(DIST)/app.wasm ($$(du -h $(DIST)/app.wasm | cut -f1), version $(VERSION))"
 
 ## Copy Go's wasm runtime glue (Go 1.24+ lib/wasm location).
 wasmexec:
@@ -58,18 +64,23 @@ wasmexec:
 	@echo "==> Copied wasm_exec.js"
 
 ## Inject the wasm loader before the app's module script, add the SPA 404
-## fallback, and stamp the build. Idempotent: skips if already done.
+## fallback, and stamp the build. The engine assets (app.wasm, boot.js,
+## wasm_exec.js) have stable names, so without a cache-bust query a browser would
+## serve a stale cached engine against a freshly-hashed UI after a redeploy (new
+## UI calling an old wasm). A content token derived from the built wasm busts all
+## three together, so a new engine is picked up immediately. Idempotent.
 inject:
-	@cp boot.js $(DIST)/boot.js
-	@grep -q 'boot.js' $(DIST)/index.html || awk -v base="$(BASE)" '\
-	  /<script type="module"/ && !done { \
-	    print "  <script src=\"" base "wasm_exec.js\"></script>"; \
-	    print "  <script src=\"" base "boot.js\"></script>"; \
-	    done=1 \
-	  } { print }' $(DIST)/index.html > $(DIST)/index.html.tmp && mv -f $(DIST)/index.html.tmp $(DIST)/index.html
-	@cp $(DIST)/index.html $(DIST)/404.html
-	@printf '{"base":"%s"}\n' "$(BASE)" > $(DIST)/version.json
-	@echo "==> Injected loader, 404.html, version.json"
+	@bust=$$(git hash-object $(DIST)/app.wasm | cut -c1-12); \
+	  sed "s|\"app.wasm\"|\"app.wasm?v=$$bust\"|" boot.js > $(DIST)/boot.js; \
+	  grep -q 'boot.js' $(DIST)/index.html || awk -v base="$(BASE)" -v bust="$$bust" '\
+	    /<script type="module"/ && !done { \
+	      print "  <script src=\"" base "wasm_exec.js?v=" bust "\"></script>"; \
+	      print "  <script src=\"" base "boot.js?v=" bust "\"></script>"; \
+	      done=1 \
+	    } { print }' $(DIST)/index.html > $(DIST)/index.html.tmp && mv -f $(DIST)/index.html.tmp $(DIST)/index.html; \
+	  cp $(DIST)/index.html $(DIST)/404.html; \
+	  printf '{"base":"%s","version":"%s","build":"%s"}\n' "$(BASE)" "$(VERSION)" "$$bust" > $(DIST)/version.json
+	@echo "==> Injected loader (version $(VERSION)), 404.html, cache-busted engine, version.json"
 
 ## Run the EmbedSource host tests.
 test:

--- a/examples/demo/main_wasm.go
+++ b/examples/demo/main_wasm.go
@@ -25,6 +25,11 @@ var embeddedBundles embed.FS
 // `pacto dashboard` server serves), driven per request from JavaScript.
 var handler http.Handler
 
+// version is the Pacto version this demo was built from. Injected at build time
+// via -ldflags "-X main.version=..." (see the Makefile) and surfaced through
+// /health so the dashboard navbar shows it, exactly like the real server.
+var version = "dev"
+
 func main() {
 	root, err := fs.Sub(embeddedBundles, "bundles")
 	if err != nil {
@@ -38,6 +43,7 @@ func main() {
 	// nil UI fs and nil resolver: the static host serves the UI, and the graph
 	// resolves from the embedded contracts' declared dependencies — no OCI.
 	srv := dashboard.NewServer(src, nil)
+	srv.SetVersion(version) // surfaced via /health → shown in the navbar
 	mux := http.NewServeMux()
 	api := humago.New(mux, dashboard.APIConfig())
 	srv.RegisterOperations(api)


### PR DESCRIPTION
## Problem
On GitHub Pages the demo could load **an old version** even after a fresh deploy (it worked locally). Root cause: the Vite UI bundles are content-hashed, but the demo's engine assets — `app.wasm`, `boot.js`, `wasm_exec.js` — have **stable filenames** served with `cache-control: max-age=600`. After a redeploy a browser kept the cached **old `app.wasm`** and ran it against the freshly-hashed **new UI**, so the new UI's calls (e.g. the new `GET /api/services/{name}/versions/{version}` endpoint) hit the stale engine and the dashboard behaved like the previous version.

## Fix
- **Cache-bust the engine.** Derive a content token from the built `app.wasm` (`git hash-object`) and append it as a `?v=<token>` query to all three engine assets (`app.wasm` in `boot.js`, and the `boot.js`/`wasm_exec.js` script tags in `index.html`). A new engine is now picked up immediately on redeploy; an unchanged engine keeps its cached copy.
- **Show the Pacto version (Issue 2).** The demo never displayed a version because the WASM build never set one. Bake the latest release tag into the wasm via `-ldflags -X main.version=...` and expose it through `/health` (`srv.SetVersion`), so the navbar shows it — exactly like the real `pacto dashboard` server.
- `docs.yml` now checks out with `fetch-depth: 0` so `git describe` can resolve the tag in CI.

## Verification (local, via the demo's node harness)
- `/health` returns the version (`v1.8.0`).
- `boot.js` loads `app.wasm?v=<hash>`; `index.html` loads `boot.js?v=<hash>` and `wasm_exec.js?v=<hash>`.
- `version.json` records `{base, version, build}`.
- Existing `make -C examples/demo smoke` still passes.
