### PR TITLE
fix(oci): fall through to the next credential source on auth rejection (+ pacto logout)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -430,6 +430,28 @@ If `gh` is not installed or not authenticated, pacto silently falls back to the 
 
 ---
 
+## `pacto logout`
+
+Removes credentials for an OCI registry from ~/.config/pacto/config.json.
+
+```
+pacto logout <registry> [flags]
+```
+
+**Examples:**
+
+```
+  pacto logout ghcr.io
+```
+
+**Flags:**
+
+```
+  -h, --help   help for logout
+```
+
+---
+
 ## `pacto mcp`
 
 Starts a Model Context Protocol (MCP) server exposing Pacto tools for AI agents. Supports stdio (default) and HTTP transports.

--- a/internal/cli/logout.go
+++ b/internal/cli/logout.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/trianalab/pacto/pkg/oci"
+)
+
+func newLogoutCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "logout <registry>",
+		Short:   "Remove stored credentials for an OCI registry",
+		Long:    "Removes credentials for an OCI registry from ~/.config/pacto/config.json.",
+		Example: "  pacto logout ghcr.io",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			registry := args[0]
+
+			removed, err := removePactoConfig(registry)
+			if err != nil {
+				return err
+			}
+
+			if removed {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Logout succeeded for %s\n", registry)
+			} else {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "No stored credentials for %s\n", registry)
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+// removePactoConfig removes credentials for a registry from ~/.config/pacto/config.json.
+// Returns true if an entry was removed, false if no entry existed.
+func removePactoConfig(registry string) (bool, error) {
+	configPath, err := oci.PactoConfigPath()
+	if err != nil {
+		return false, fmt.Errorf("failed to determine config path: %w", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		// No config file → no credentials stored
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to read %s: %w", configPath, err)
+	}
+
+	var cfg oci.PactoConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return false, fmt.Errorf("failed to parse existing %s: %w", configPath, err)
+	}
+
+	if cfg.Auths == nil {
+		return false, nil
+	}
+
+	_, exists := cfg.Auths[registry]
+	if !exists {
+		return false, nil
+	}
+
+	delete(cfg.Auths, registry)
+
+	out, err := jsonMarshalIndentFn(cfg, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	// Directory must exist since we just read the config file from it
+	if err := os.WriteFile(configPath, out, 0600); err != nil {
+		return false, fmt.Errorf("failed to write %s: %w", configPath, err)
+	}
+
+	return true, nil
+}

--- a/internal/cli/logout_test.go
+++ b/internal/cli/logout_test.go
@@ -1,0 +1,410 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/trianalab/pacto/pkg/oci"
+)
+
+func TestRemovePactoConfig_RemovesExistingEntry(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	pactoDir := filepath.Join(dir, ".config", "pacto")
+	if err := os.MkdirAll(pactoDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write initial config with two registries
+	initial := oci.PactoConfig{
+		Auths: map[string]oci.PactoAuth{
+			"ghcr.io":   {Auth: "ghcr-creds"},
+			"docker.io": {Auth: "docker-creds"},
+		},
+	}
+	data, _ := json.MarshalIndent(initial, "", "  ")
+	if err := os.WriteFile(filepath.Join(pactoDir, "config.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove ghcr.io
+	removed, err := removePactoConfig("ghcr.io")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !removed {
+		t.Error("expected removed=true")
+	}
+
+	// Read and verify
+	result, err := os.ReadFile(filepath.Join(pactoDir, "config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg oci.PactoConfig
+	if err := json.Unmarshal(result, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := cfg.Auths["ghcr.io"]; ok {
+		t.Error("expected ghcr.io to be removed")
+	}
+	if _, ok := cfg.Auths["docker.io"]; !ok {
+		t.Error("expected docker.io to still exist")
+	}
+}
+
+func TestRemovePactoConfig_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	removed, err := removePactoConfig("ghcr.io")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if removed {
+		t.Error("expected removed=false when no file exists")
+	}
+}
+
+func TestRemovePactoConfig_NoEntry(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	pactoDir := filepath.Join(dir, ".config", "pacto")
+	if err := os.MkdirAll(pactoDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write config with different registry
+	initial := oci.PactoConfig{
+		Auths: map[string]oci.PactoAuth{
+			"docker.io": {Auth: "docker-creds"},
+		},
+	}
+	data, _ := json.MarshalIndent(initial, "", "  ")
+	if err := os.WriteFile(filepath.Join(pactoDir, "config.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := removePactoConfig("ghcr.io")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if removed {
+		t.Error("expected removed=false when registry not found")
+	}
+}
+
+func TestRemovePactoConfig_EmptyAuths(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	pactoDir := filepath.Join(dir, ".config", "pacto")
+	if err := os.MkdirAll(pactoDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write config with empty auths
+	initial := oci.PactoConfig{
+		Auths: make(map[string]oci.PactoAuth),
+	}
+	data, _ := json.MarshalIndent(initial, "", "  ")
+	if err := os.WriteFile(filepath.Join(pactoDir, "config.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := removePactoConfig("ghcr.io")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if removed {
+		t.Error("expected removed=false when auths is empty")
+	}
+}
+
+func TestRemovePactoConfig_NilAuths(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	pactoDir := filepath.Join(dir, ".config", "pacto")
+	if err := os.MkdirAll(pactoDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write config with nil auths (JSON: {})
+	if err := os.WriteFile(filepath.Join(pactoDir, "config.json"), []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := removePactoConfig("ghcr.io")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if removed {
+		t.Error("expected removed=false when auths is nil")
+	}
+}
+
+func TestRemovePactoConfig_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	pactoDir := filepath.Join(dir, ".config", "pacto")
+	if err := os.MkdirAll(pactoDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write invalid JSON
+	if err := os.WriteFile(filepath.Join(pactoDir, "config.json"), []byte("{invalid"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := removePactoConfig("ghcr.io")
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestRemovePactoConfig_PactoConfigPathError(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	old := oci.ExportedUserHomeDirFn()
+	oci.SetUserHomeDirFn(func() (string, error) { return "", fmt.Errorf("no home") })
+	defer oci.SetUserHomeDirFn(old)
+
+	_, err := removePactoConfig("ghcr.io")
+	if err == nil {
+		t.Error("expected error when PactoConfigPath fails")
+	}
+}
+
+func TestRemovePactoConfig_ReadFileError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	pactoDir := filepath.Join(dir, ".config", "pacto")
+	if err := os.MkdirAll(pactoDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a directory instead of a file to trigger read error
+	configPath := filepath.Join(pactoDir, "config.json")
+	if err := os.Mkdir(configPath, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := removePactoConfig("ghcr.io")
+	if err == nil {
+		t.Error("expected error when ReadFile fails")
+	}
+}
+
+func TestRemovePactoConfig_MarshalError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	pactoDir := filepath.Join(dir, ".config", "pacto")
+	if err := os.MkdirAll(pactoDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	initial := oci.PactoConfig{
+		Auths: map[string]oci.PactoAuth{
+			"ghcr.io": {Auth: "ghcr-creds"},
+		},
+	}
+	data, _ := json.MarshalIndent(initial, "", "  ")
+	if err := os.WriteFile(filepath.Join(pactoDir, "config.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	old := jsonMarshalIndentFn
+	jsonMarshalIndentFn = func(any, string, string) ([]byte, error) {
+		return nil, fmt.Errorf("marshal failed")
+	}
+	defer func() { jsonMarshalIndentFn = old }()
+
+	_, err := removePactoConfig("ghcr.io")
+	if err == nil {
+		t.Error("expected error when MarshalIndent fails")
+	}
+}
+
+func TestRemovePactoConfig_WriteFileError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	pactoDir := filepath.Join(dir, ".config", "pacto")
+	if err := os.MkdirAll(pactoDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	initial := oci.PactoConfig{
+		Auths: map[string]oci.PactoAuth{
+			"ghcr.io": {Auth: "ghcr-creds"},
+		},
+	}
+	data, _ := json.MarshalIndent(initial, "", "  ")
+	configPath := filepath.Join(pactoDir, "config.json")
+	if err := os.WriteFile(configPath, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the config file itself read-only
+	if err := os.Chmod(configPath, 0444); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(configPath, 0644) })
+
+	_, err := removePactoConfig("ghcr.io")
+	if err == nil {
+		t.Error("expected error when WriteFile fails")
+	}
+}
+
+func TestRemovePactoConfig_XDGConfigHome(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	pactoDir := filepath.Join(dir, "pacto")
+	if err := os.MkdirAll(pactoDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	initial := oci.PactoConfig{
+		Auths: map[string]oci.PactoAuth{
+			"ghcr.io": {Auth: "ghcr-creds"},
+		},
+	}
+	data, _ := json.MarshalIndent(initial, "", "  ")
+	if err := os.WriteFile(filepath.Join(pactoDir, "config.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := removePactoConfig("ghcr.io")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !removed {
+		t.Error("expected removed=true")
+	}
+
+	// Verify the entry was removed
+	result, err := os.ReadFile(filepath.Join(pactoDir, "config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg oci.PactoConfig
+	if err := json.Unmarshal(result, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := cfg.Auths["ghcr.io"]; ok {
+		t.Error("expected ghcr.io to be removed")
+	}
+}
+
+func TestLogoutCommand_RemovesEntry(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	pactoDir := filepath.Join(dir, ".config", "pacto")
+	if err := os.MkdirAll(pactoDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	initial := oci.PactoConfig{
+		Auths: map[string]oci.PactoAuth{
+			"ghcr.io": {Auth: "ghcr-creds"},
+		},
+	}
+	data, _ := json.MarshalIndent(initial, "", "  ")
+	if err := os.WriteFile(filepath.Join(pactoDir, "config.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newLogoutCommand()
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"ghcr.io"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !bytes.Contains(out.Bytes(), []byte("Logout succeeded for ghcr.io")) {
+		t.Errorf("expected success message, got: %s", out.String())
+	}
+}
+
+func TestLogoutCommand_NoEntry(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	cmd := newLogoutCommand()
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"ghcr.io"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !bytes.Contains(out.Bytes(), []byte("No stored credentials for ghcr.io")) {
+		t.Errorf("expected no-credentials message, got: %s", out.String())
+	}
+}
+
+func TestLogoutCommand_Error(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	old := oci.ExportedUserHomeDirFn()
+	oci.SetUserHomeDirFn(func() (string, error) { return "", fmt.Errorf("no home") })
+	defer oci.SetUserHomeDirFn(old)
+
+	cmd := newLogoutCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"ghcr.io"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error when removePactoConfig fails")
+	}
+}
+
+func TestLogoutCommand_ExactArgs(t *testing.T) {
+	cmd := newLogoutCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	// No args
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error with no args")
+	}
+
+	// Too many args
+	cmd.SetArgs([]string{"ghcr.io", "extra"})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error with too many args")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -117,6 +117,7 @@ func NewRootCommand(svc *app.Service, info VersionInfo) *cobra.Command {
 	root.AddCommand(newDocCommand(svc, v))
 	root.AddCommand(newGenerateCommand(svc, v))
 	root.AddCommand(newLoginCommand())
+	root.AddCommand(newLogoutCommand())
 	root.AddCommand(newVersionCommand(info, v))
 	root.AddCommand(newUpdateCommand(info.Version))
 	root.AddCommand(newMCPCommand(svc, info.Version))

--- a/pkg/oci/auth_internal_test.go
+++ b/pkg/oci/auth_internal_test.go
@@ -1,0 +1,229 @@
+package oci
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+)
+
+// fakeCandidateKeychain is a keychain that also satisfies candidateProvider so
+// doWithAuth exercises the fall-through path without any network access.
+type fakeCandidateKeychain struct {
+	cands []CredSource
+	err   error
+}
+
+func (k fakeCandidateKeychain) Resolve(authn.Resource) (authn.Authenticator, error) {
+	if len(k.cands) == 0 {
+		return authn.Anonymous, nil
+	}
+	return k.cands[0].Authenticator, nil
+}
+
+func (k fakeCandidateKeychain) Candidates(authn.Resource) ([]CredSource, error) {
+	return k.cands, k.err
+}
+
+// scriptedOp returns an op closure that yields the next error from errs on each
+// call, and records how many times it was invoked.
+func scriptedOp(errs []error, calls *int) func(opts []remote.Option) error {
+	return func(_ []remote.Option) error {
+		i := *calls
+		*calls++
+		return errs[i]
+	}
+}
+
+func testResource(t *testing.T) authn.Resource {
+	t.Helper()
+	r, err := name.NewRepository("example.com/test/repo", name.Insecure)
+	if err != nil {
+		t.Fatalf("NewRepository() error: %v", err)
+	}
+	return r
+}
+
+func authError() error { return &transport.Error{StatusCode: 403} }
+
+// TestDoWithAuth_FallThroughToNextSource is the core regression test: the first
+// candidate is rejected (403) and the second succeeds.
+func TestDoWithAuth_FallThroughToNextSource(t *testing.T) {
+	kc := fakeCandidateKeychain{cands: []CredSource{
+		{Name: "pacto login", Authenticator: authn.Anonymous},
+		{Name: "gh", Authenticator: authn.Anonymous},
+	}}
+	c := &Client{keychain: kc}
+
+	calls := 0
+	op := scriptedOp([]error{authError(), nil}, &calls)
+	if err := c.doWithAuth(context.Background(), testResource(t), "example.com/test/repo:v1", op); err != nil {
+		t.Fatalf("doWithAuth() error: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("op calls = %d, want 2 (first rejected, second succeeds)", calls)
+	}
+}
+
+func TestDoWithAuth_AllRejected(t *testing.T) {
+	kc := fakeCandidateKeychain{cands: []CredSource{
+		{Name: "pacto login", Authenticator: authn.Anonymous},
+		{Name: "gh", Authenticator: authn.Anonymous},
+	}}
+	c := &Client{keychain: kc}
+
+	calls := 0
+	op := scriptedOp([]error{authError(), authError()}, &calls)
+	err := c.doWithAuth(context.Background(), testResource(t), "example.com/test/repo:v1", op)
+	if err == nil {
+		t.Fatal("expected error when all candidates rejected")
+	}
+	var authErr *AuthenticationError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected AuthenticationError, got %T: %v", err, err)
+	}
+	wantTried := []string{"pacto login", "gh"}
+	if fmt.Sprint(authErr.Tried) != fmt.Sprint(wantTried) {
+		t.Errorf("Tried = %v, want %v", authErr.Tried, wantTried)
+	}
+	if fmt.Sprint(authErr.Rejected) != fmt.Sprint(wantTried) {
+		t.Errorf("Rejected = %v, want %v", authErr.Rejected, wantTried)
+	}
+}
+
+func TestDoWithAuth_NonAuthErrorReturnedImmediately(t *testing.T) {
+	kc := fakeCandidateKeychain{cands: []CredSource{
+		{Name: "pacto login", Authenticator: authn.Anonymous},
+		{Name: "gh", Authenticator: authn.Anonymous},
+	}}
+	c := &Client{keychain: kc}
+
+	calls := 0
+	op := scriptedOp([]error{&transport.Error{StatusCode: 404}, nil}, &calls)
+	err := c.doWithAuth(context.Background(), testResource(t), "example.com/test/repo:v1", op)
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	var notFound *ArtifactNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("expected ArtifactNotFoundError, got %T: %v", err, err)
+	}
+	if calls != 1 {
+		t.Errorf("op calls = %d, want 1 (non-auth error stops fall-through)", calls)
+	}
+}
+
+func TestDoWithAuth_PlainErrorReturnedImmediately(t *testing.T) {
+	kc := fakeCandidateKeychain{cands: []CredSource{
+		{Name: "pacto login", Authenticator: authn.Anonymous},
+	}}
+	c := &Client{keychain: kc}
+
+	calls := 0
+	op := scriptedOp([]error{fmt.Errorf("dial tcp: refused")}, &calls)
+	err := c.doWithAuth(context.Background(), testResource(t), "example.com/test/repo:v1", op)
+	var unreachable *RegistryUnreachableError
+	if !errors.As(err, &unreachable) {
+		t.Fatalf("expected RegistryUnreachableError, got %T: %v", err, err)
+	}
+}
+
+func TestDoWithAuth_EmptyCandidatesAnonymousAttempt(t *testing.T) {
+	kc := fakeCandidateKeychain{cands: nil}
+	c := &Client{keychain: kc}
+
+	calls := 0
+	op := scriptedOp([]error{nil}, &calls)
+	if err := c.doWithAuth(context.Background(), testResource(t), "example.com/test/repo:v1", op); err != nil {
+		t.Fatalf("doWithAuth() error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("op calls = %d, want 1 anonymous attempt", calls)
+	}
+}
+
+func TestDoWithAuth_EmptyCandidatesAnonymousRejected(t *testing.T) {
+	kc := fakeCandidateKeychain{cands: nil}
+	c := &Client{keychain: kc}
+
+	calls := 0
+	op := scriptedOp([]error{authError()}, &calls)
+	err := c.doWithAuth(context.Background(), testResource(t), "example.com/test/repo:v1", op)
+	var authErr *AuthenticationError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected AuthenticationError, got %T: %v", err, err)
+	}
+	if fmt.Sprint(authErr.Rejected) != fmt.Sprint([]string{"anonymous"}) {
+		t.Errorf("Rejected = %v, want [anonymous]", authErr.Rejected)
+	}
+}
+
+func TestDoWithAuth_CandidatesError_FallsBack(t *testing.T) {
+	kc := fakeCandidateKeychain{err: fmt.Errorf("resolve boom")}
+	c := &Client{keychain: kc}
+
+	calls := 0
+	op := scriptedOp([]error{nil}, &calls)
+	if err := c.doWithAuth(context.Background(), testResource(t), "example.com/test/repo:v1", op); err != nil {
+		t.Fatalf("doWithAuth() error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("op calls = %d, want 1 back-compat attempt", calls)
+	}
+}
+
+func TestDoWithAuth_BackCompatNonProvider(t *testing.T) {
+	// authn.DefaultKeychain is not a candidateProvider → single back-compat path.
+	c := &Client{keychain: authn.DefaultKeychain}
+
+	calls := 0
+	op := scriptedOp([]error{authError()}, &calls)
+	err := c.doWithAuth(context.Background(), testResource(t), "example.com/test/repo:v1", op)
+	// Back-compat path wraps via wrapRemoteError → AuthenticationError (no Tried/Rejected).
+	var authErr *AuthenticationError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected AuthenticationError, got %T: %v", err, err)
+	}
+	if len(authErr.Tried) != 0 || len(authErr.Rejected) != 0 {
+		t.Errorf("back-compat path should not name sources, got Tried=%v Rejected=%v", authErr.Tried, authErr.Rejected)
+	}
+	if calls != 1 {
+		t.Errorf("op calls = %d, want 1 back-compat attempt", calls)
+	}
+}
+
+func TestDoWithAuth_BackCompatSuccess(t *testing.T) {
+	c := &Client{keychain: authn.DefaultKeychain}
+
+	calls := 0
+	op := scriptedOp([]error{nil}, &calls)
+	if err := c.doWithAuth(context.Background(), testResource(t), "example.com/test/repo:v1", op); err != nil {
+		t.Fatalf("doWithAuth() error: %v", err)
+	}
+}
+
+func TestIsAuthError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"401", &transport.Error{StatusCode: 401}, true},
+		{"403", &transport.Error{StatusCode: 403}, true},
+		{"404", &transport.Error{StatusCode: 404}, false},
+		{"500", &transport.Error{StatusCode: 500}, false},
+		{"non-transport", fmt.Errorf("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAuthError(tt.err); got != tt.want {
+				t.Errorf("isAuthError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -56,6 +56,56 @@ func (c *Client) remoteOptions(ctx context.Context) []remote.Option {
 	return []remote.Option{remote.WithAuthFromKeychain(c.keychain), remote.WithContext(ctx)}
 }
 
+// candidateProvider is implemented by keychains that can enumerate all
+// credential sources for a registry so the Client can fall through on rejection.
+type candidateProvider interface {
+	Candidates(authn.Resource) ([]CredSource, error)
+}
+
+// wrapIfErr wraps a non-nil remote error into a domain error, passing nil through.
+func wrapIfErr(ref string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return wrapRemoteError(ref, err)
+}
+
+// doWithAuth runs op against each credential source in priority order, falling
+// through to the next source when the registry returns 401/403. The first source
+// that succeeds wins. Non-auth errors are returned immediately (wrapped). If all
+// sources are rejected, a source-named AuthenticationError is returned.
+func (c *Client) doWithAuth(ctx context.Context, res authn.Resource, ref string, op func(opts []remote.Option) error) error {
+	cp, ok := c.keychain.(candidateProvider)
+	if !ok {
+		return wrapIfErr(ref, op(c.remoteOptions(ctx)))
+	}
+
+	cands, err := cp.Candidates(res)
+	if err != nil {
+		return wrapIfErr(ref, op(c.remoteOptions(ctx)))
+	}
+	if len(cands) == 0 {
+		cands = []CredSource{{Name: "anonymous", Authenticator: authn.Anonymous}}
+	}
+
+	var tried, rejected []string
+	var lastErr error
+	for _, cand := range cands {
+		tried = append(tried, cand.Name)
+		err := op([]remote.Option{remote.WithAuth(cand.Authenticator), remote.WithContext(ctx)})
+		switch {
+		case err == nil:
+			return nil
+		case isAuthError(err):
+			rejected = append(rejected, cand.Name)
+			lastErr = err
+		default:
+			return wrapRemoteError(ref, err)
+		}
+	}
+	return &AuthenticationError{Ref: ref, Err: lastErr, Tried: tried, Rejected: rejected}
+}
+
 // parseRef parses an OCI reference string with the client's name options.
 func (c *Client) parseRef(ref string) (name.Reference, error) {
 	r, err := name.ParseReference(ref, c.nameOpts...)
@@ -80,8 +130,10 @@ func (c *Client) Push(ctx context.Context, ref string, bundle *contract.Bundle) 
 	}
 
 	slog.Debug("writing image to registry", "ref", ref)
-	if err := remote.Write(r, img, c.remoteOptions(ctx)...); err != nil {
-		return "", wrapRemoteError(ref, err)
+	if err := c.doWithAuth(ctx, r.Context(), ref, func(opts []remote.Option) error {
+		return remote.Write(r, img, opts...)
+	}); err != nil {
+		return "", err
 	}
 
 	digest, err := imageDigestFn(img)
@@ -101,9 +153,13 @@ func (c *Client) Pull(ctx context.Context, ref string) (*contract.Bundle, error)
 	}
 
 	slog.Debug("fetching image from registry", "ref", ref)
-	img, err := remote.Image(r, c.remoteOptions(ctx)...)
-	if err != nil {
-		return nil, wrapRemoteError(ref, err)
+	var img v1.Image
+	if err := c.doWithAuth(ctx, r.Context(), ref, func(opts []remote.Option) error {
+		var opErr error
+		img, opErr = remote.Image(r, opts...)
+		return opErr
+	}); err != nil {
+		return nil, err
 	}
 
 	slog.Debug("extracting bundle from image", "ref", ref)
@@ -123,9 +179,13 @@ func (c *Client) Resolve(ctx context.Context, ref string) (string, error) {
 	}
 
 	slog.Debug("resolving digest", "ref", ref)
-	desc, err := remote.Head(r, c.remoteOptions(ctx)...)
-	if err != nil {
-		return "", wrapRemoteError(ref, err)
+	var desc *v1.Descriptor
+	if err := c.doWithAuth(ctx, r.Context(), ref, func(opts []remote.Option) error {
+		var opErr error
+		desc, opErr = remote.Head(r, opts...)
+		return opErr
+	}); err != nil {
+		return "", err
 	}
 
 	slog.Debug("resolved digest", "ref", ref, "digest", desc.Digest.String())
@@ -140,9 +200,13 @@ func (c *Client) ListTags(ctx context.Context, repo string) ([]string, error) {
 	}
 
 	slog.Debug("listing tags", "repo", repo)
-	tags, err := remote.List(r, c.remoteOptions(ctx)...)
-	if err != nil {
-		return nil, wrapRemoteError(repo, err)
+	var tags []string
+	if err := c.doWithAuth(ctx, r, repo, func(opts []remote.Option) error {
+		var opErr error
+		tags, opErr = remote.List(r, opts...)
+		return opErr
+	}); err != nil {
+		return nil, err
 	}
 
 	slog.Debug("tags listed", "repo", repo, "count", len(tags))

--- a/pkg/oci/credentials.go
+++ b/pkg/oci/credentials.go
@@ -53,25 +53,74 @@ func PactoConfigPath() (string, error) {
 	return filepath.Join(dir, "config.json"), nil
 }
 
+// CredSource is a named credential source resolved for a registry.
+type CredSource struct {
+	Name          string
+	Authenticator authn.Authenticator
+}
+
+// namedKeychain pairs a keychain with a human-readable source name.
+type namedKeychain struct {
+	name string
+	kc   authn.Keychain
+}
+
+// PactoKeychain resolves credentials across ordered named sources and supports
+// falling through to the next source when the registry rejects the current one.
+type PactoKeychain struct {
+	sources []namedKeychain
+}
+
+// Resolve returns the first non-anonymous authenticator, preserving back-compat
+// with go-containerregistry's remote.WithAuthFromKeychain callers.
+func (k *PactoKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	for _, src := range k.sources {
+		auth, err := src.kc.Resolve(target)
+		if err != nil {
+			return nil, err
+		}
+		if auth != authn.Anonymous {
+			return auth, nil
+		}
+	}
+	return authn.Anonymous, nil
+}
+
+// Candidates returns all non-anonymous credential sources for the target,
+// in priority order, each tagged with its source name.
+func (k *PactoKeychain) Candidates(target authn.Resource) ([]CredSource, error) {
+	var cands []CredSource
+	for _, src := range k.sources {
+		auth, err := src.kc.Resolve(target)
+		if err != nil {
+			return nil, err
+		}
+		if auth != authn.Anonymous {
+			cands = append(cands, CredSource{Name: src.name, Authenticator: auth})
+		}
+	}
+	return cands, nil
+}
+
 // NewKeychain builds a keychain that tries, in order:
 // 1. Explicit credentials (flags/env vars)
 // 2. Pacto config (~/.config/pacto/config.json)
 // 3. gh CLI token (for GitHub registries)
 // 4. Docker config, credential helpers, and cloud auto-detection
 func NewKeychain(opts CredentialOptions) authn.Keychain {
-	keychains := make([]authn.Keychain, 0, 4)
+	sources := make([]namedKeychain, 0, 4)
 
 	if opts.Token != "" {
-		keychains = append(keychains, staticKeychain{auth: &authn.AuthConfig{RegistryToken: opts.Token}})
+		sources = append(sources, namedKeychain{name: "env token", kc: staticKeychain{auth: &authn.AuthConfig{RegistryToken: opts.Token}}})
 	} else if opts.Username != "" && opts.Password != "" {
-		keychains = append(keychains, staticKeychain{auth: &authn.AuthConfig{Username: opts.Username, Password: opts.Password}})
+		sources = append(sources, namedKeychain{name: "env user/pass", kc: staticKeychain{auth: &authn.AuthConfig{Username: opts.Username, Password: opts.Password}}})
 	}
 
-	keychains = append(keychains, &pactoConfigKeychain{})
-	keychains = append(keychains, &ghKeychain{execCommandFn: exec.Command})
-	keychains = append(keychains, authn.DefaultKeychain)
+	sources = append(sources, namedKeychain{name: "pacto login", kc: &pactoConfigKeychain{}})
+	sources = append(sources, namedKeychain{name: "gh", kc: &ghKeychain{execCommandFn: exec.Command}})
+	sources = append(sources, namedKeychain{name: "docker", kc: authn.DefaultKeychain})
 
-	return authn.NewMultiKeychain(keychains...)
+	return &PactoKeychain{sources: sources}
 }
 
 // staticKeychain returns the same credentials for any registry.

--- a/pkg/oci/credentials_internal_test.go
+++ b/pkg/oci/credentials_internal_test.go
@@ -1,6 +1,7 @@
 package oci
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -9,6 +10,29 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 )
+
+// errKeychain always returns an error from Resolve.
+type errKeychain struct{}
+
+func (errKeychain) Resolve(authn.Resource) (authn.Authenticator, error) {
+	return nil, fmt.Errorf("resolve boom")
+}
+
+func TestPactoKeychain_Resolve_PropagatesError(t *testing.T) {
+	kc := &PactoKeychain{sources: []namedKeychain{{name: "boom", kc: errKeychain{}}}}
+	reg, _ := name.NewRegistry("example.com", name.Insecure)
+	if _, err := kc.Resolve(reg); err == nil {
+		t.Error("expected error from Resolve when a source errors")
+	}
+}
+
+func TestPactoKeychain_Candidates_PropagatesError(t *testing.T) {
+	kc := &PactoKeychain{sources: []namedKeychain{{name: "boom", kc: errKeychain{}}}}
+	reg, _ := name.NewRegistry("example.com", name.Insecure)
+	if _, err := kc.Candidates(reg); err == nil {
+		t.Error("expected error from Candidates when a source errors")
+	}
+}
 
 func TestGhKeychain_TokenAvailable(t *testing.T) {
 	dir := t.TempDir()

--- a/pkg/oci/credentials_test.go
+++ b/pkg/oci/credentials_test.go
@@ -86,6 +86,135 @@ func TestNewKeychain_Default(t *testing.T) {
 	}
 }
 
+func TestNewKeychain_ReturnsPactoKeychain(t *testing.T) {
+	kc := oci.NewKeychain(oci.CredentialOptions{})
+	if _, ok := kc.(*oci.PactoKeychain); !ok {
+		t.Errorf("NewKeychain() = %T, want *oci.PactoKeychain", kc)
+	}
+}
+
+func TestPactoKeychain_Candidates_EnvToken(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	kc := oci.NewKeychain(oci.CredentialOptions{Token: "tok"}).(*oci.PactoKeychain)
+	reg, _ := name.NewRegistry("example.com", name.Insecure)
+
+	cands, err := kc.Candidates(reg)
+	if err != nil {
+		t.Fatalf("Candidates() error: %v", err)
+	}
+	if len(cands) != 1 {
+		t.Fatalf("len(Candidates) = %d, want 1, got %v", len(cands), candNames(cands))
+	}
+	if cands[0].Name != "env token" {
+		t.Errorf("Candidates[0].Name = %q, want %q", cands[0].Name, "env token")
+	}
+}
+
+func TestPactoKeychain_Candidates_EnvUserPass(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	kc := oci.NewKeychain(oci.CredentialOptions{Username: "u", Password: "p"}).(*oci.PactoKeychain)
+	reg, _ := name.NewRegistry("example.com", name.Insecure)
+
+	cands, err := kc.Candidates(reg)
+	if err != nil {
+		t.Fatalf("Candidates() error: %v", err)
+	}
+	if len(cands) != 1 || cands[0].Name != "env user/pass" {
+		t.Errorf("Candidates = %v, want one [env user/pass]", candNames(cands))
+	}
+}
+
+func TestPactoKeychain_Candidates_OrderingAndNames(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	// Write a pacto login entry AND env token so we get two named candidates in order.
+	pactoDir := filepath.Join(dir, ".config", "pacto")
+	if err := os.MkdirAll(pactoDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	encoded := base64.StdEncoding.EncodeToString([]byte("u:p"))
+	cfg := map[string]any{"auths": map[string]any{"example.com": map[string]any{"auth": encoded}}}
+	data, _ := json.Marshal(cfg)
+	if err := os.WriteFile(filepath.Join(pactoDir, "config.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	kc := oci.NewKeychain(oci.CredentialOptions{Token: "tok"}).(*oci.PactoKeychain)
+	reg, _ := name.NewRegistry("example.com", name.Insecure)
+
+	cands, err := kc.Candidates(reg)
+	if err != nil {
+		t.Fatalf("Candidates() error: %v", err)
+	}
+	got := candNames(cands)
+	want := []string{"env token", "pacto login"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("Candidates order = %v, want %v", got, want)
+	}
+}
+
+func TestPactoKeychain_Candidates_NoneNonAnon(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	kc := oci.NewKeychain(oci.CredentialOptions{}).(*oci.PactoKeychain)
+	reg, _ := name.NewRegistry("unknown.example.com", name.Insecure)
+
+	cands, err := kc.Candidates(reg)
+	if err != nil {
+		t.Fatalf("Candidates() error: %v", err)
+	}
+	if len(cands) != 0 {
+		t.Errorf("len(Candidates) = %d, want 0, got %v", len(cands), candNames(cands))
+	}
+}
+
+func TestPactoKeychain_Resolve_FirstNonAnon(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	// pacto login present; token also present → Resolve returns the FIRST (env token).
+	pactoDir := filepath.Join(dir, ".config", "pacto")
+	if err := os.MkdirAll(pactoDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	encoded := base64.StdEncoding.EncodeToString([]byte("u:p"))
+	cfg := map[string]any{"auths": map[string]any{"example.com": map[string]any{"auth": encoded}}}
+	data, _ := json.Marshal(cfg)
+	if err := os.WriteFile(filepath.Join(pactoDir, "config.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	kc := oci.NewKeychain(oci.CredentialOptions{Token: "tok"})
+	reg, _ := name.NewRegistry("example.com", name.Insecure)
+	auth, err := kc.Resolve(reg)
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	authCfg, _ := auth.Authorization()
+	if authCfg.RegistryToken != "tok" {
+		t.Errorf("Resolve() returned %+v, want env token first", authCfg)
+	}
+}
+
+func candNames(cands []oci.CredSource) []string {
+	names := make([]string, len(cands))
+	for i, c := range cands {
+		names[i] = c.Name
+	}
+	return names
+}
+
 func TestPactoConfigPath_Default(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)

--- a/pkg/oci/errors.go
+++ b/pkg/oci/errors.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
@@ -22,15 +23,35 @@ func (e *RegistryUnreachableError) Unwrap() error { return e.Err }
 
 // AuthenticationError indicates credential rejection (401/403).
 type AuthenticationError struct {
-	Ref string
-	Err error
+	Ref      string
+	Err      error
+	Tried    []string
+	Rejected []string
 }
 
 func (e *AuthenticationError) Error() string {
-	return fmt.Sprintf("authentication failed for %s: %v — run `pacto login` or check PACTO_REGISTRY_TOKEN", e.Ref, e.Err)
+	var b strings.Builder
+	fmt.Fprintf(&b, "authentication failed for %s", e.Ref)
+	if len(e.Rejected) > 0 {
+		fmt.Fprintf(&b, " (rejected: %s)", strings.Join(e.Rejected, ", "))
+	}
+	if len(e.Tried) > 0 {
+		fmt.Fprintf(&b, " (tried: %s)", strings.Join(e.Tried, ", "))
+	}
+	fmt.Fprintf(&b, ": %v — run `pacto login`, `pacto logout <registry>`, switch your `gh` account, or set PACTO_REGISTRY_TOKEN", e.Err)
+	return b.String()
 }
 
 func (e *AuthenticationError) Unwrap() error { return e.Err }
+
+// isAuthError reports whether err is a transport error with a 401 or 403 status.
+func isAuthError(err error) bool {
+	var transportErr *transport.Error
+	if !errors.As(err, &transportErr) {
+		return false
+	}
+	return transportErr.StatusCode == http.StatusUnauthorized || transportErr.StatusCode == http.StatusForbidden
+}
 
 // ArtifactNotFoundError indicates the reference does not exist (404).
 type ArtifactNotFoundError struct {

--- a/pkg/oci/errors_test.go
+++ b/pkg/oci/errors_test.go
@@ -48,6 +48,49 @@ func TestAuthenticationError(t *testing.T) {
 	}
 }
 
+func TestAuthenticationError_WithSources(t *testing.T) {
+	cause := fmt.Errorf("forbidden")
+	tests := []struct {
+		name        string
+		err         *AuthenticationError
+		wantContain []string
+		wantOmit    []string
+	}{
+		{
+			name:        "tried and rejected",
+			err:         &AuthenticationError{Ref: "reg.io/img:v1", Err: cause, Tried: []string{"pacto login", "gh"}, Rejected: []string{"pacto login", "gh"}},
+			wantContain: []string{"rejected: pacto login, gh", "tried: pacto login, gh", "pacto logout <registry>"},
+		},
+		{
+			name:        "rejected only",
+			err:         &AuthenticationError{Ref: "reg.io/img:v1", Err: cause, Rejected: []string{"pacto login"}},
+			wantContain: []string{"rejected: pacto login"},
+			wantOmit:    []string{"tried:"},
+		},
+		{
+			name:        "tried only",
+			err:         &AuthenticationError{Ref: "reg.io/img:v1", Err: cause, Tried: []string{"anonymous"}},
+			wantContain: []string{"tried: anonymous"},
+			wantOmit:    []string{"rejected:"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			for _, want := range tt.wantContain {
+				if !strings.Contains(msg, want) {
+					t.Errorf("Error() = %q, want to contain %q", msg, want)
+				}
+			}
+			for _, omit := range tt.wantOmit {
+				if strings.Contains(msg, omit) {
+					t.Errorf("Error() = %q, should not contain %q", msg, omit)
+				}
+			}
+		})
+	}
+}
+
 func TestArtifactNotFoundError(t *testing.T) {
 	cause := fmt.Errorf("not found")
 	err := &ArtifactNotFoundError{Ref: "example.com/repo:v1", Err: cause}


### PR DESCRIPTION
## Summary

Fixes a pre-existing OCI auth bug: pacto's keychain returns the first non-anonymous credential (env → `pacto login` → `gh` → docker) and go-containerregistry never retries on rejection, so a stale `pacto login` credential silently **shadows** a working `gh` login — every registry call uses the stale token, gets `403`, and the good `gh` token is never tried. This affects `lock`, `graph`, `dashboard`, `validate` and `pull` alike (lock surfaced it because pinning forces a live `tags/list`, the one call that isn't disk-cached).

## What changed

- **Fall-through on auth rejection** — the OCI client now tries each credential source in priority order and advances to the next on `401`/`403`, so the first source that *succeeds* wins. Non-auth errors (`404`, network) are returned immediately and never masked. Same priority order as before.
- **`pacto logout <registry>`** — removes a stored `pacto login` credential.
- **Source-named auth errors** — the failure now reports which sources were tried/rejected, so it is self-diagnosing.

Back-compat: a plain `MultiKeychain` (e.g. the e2e harness) keeps the single-attempt path.

## Example

```
$ pacto lock           # stale `pacto login` token rejected -> falls through to gh -> succeeds

# clear a stale credential so pacto uses your gh login:
$ pacto logout ghcr.io
Logout succeeded for ghcr.io

# when everything is rejected, the error names the sources:
authentication failed for ghcr.io/... (rejected: pacto login, gh): ... —
run `pacto login`, `pacto logout <registry>`, switch your `gh` account, or set PACTO_REGISTRY_TOKEN
```

## Verification

Go coverage 100%, race clean, golangci-lint/gofmt/gocyclo clean, e2e green. Design: `docs/superpowers/plans/2026-06-18-oci-auth-fallthrough.md`.
