### PR TITLE
feat(lock): embed pacto.lock in the bundle so the dashboard shows drift for OCI/k8s services

### DIFF
--- a/docs/lockfile.md
+++ b/docs/lockfile.md
@@ -1,8 +1,10 @@
 # Lockfile
 
-Pacto lockfiles enable reproducible dependency resolution and supply-chain pinning for contract bundles. Like `go.sum` and `Chart.lock`, `pacto.lock` captures the exact resolved state of your contract's dependency closure and reference closure, committed to git and enforced by the CLI.
+Pacto lockfiles enable reproducible dependency resolution and supply-chain pinning for contract bundles. Like `go.sum` and `Chart.lock`, `pacto.lock` captures the exact resolved state of your contract's dependency closure and reference closure, committed to git, shipped inside the pushed bundle and enforced by the CLI.
 
 When a `pacto.lock` file is present, Pacto verifies that every resolved dependency and every config/policy reference matches the digest pinned in the lock. Any mismatch is a hard error — you cannot validate, graph, diff or push a bundle whose lock has drifted.
+
+The lockfile is **embedded in the pushed bundle** when `pacto push` runs, so the dashboard can surface pinned digests and drift for services sourced from OCI registries or Kubernetes clusters (not just local directories). Shipping the lock remains opt-in: if no `pacto.lock` exists next to `pacto.yaml`, nothing extra is included in the bundle.
 
 ---
 
@@ -143,7 +145,6 @@ The `references[]` section records config and policy refs with their `kind`, `so
 ## Non-goals
 
 - **The operator does not gate on the lock.** The lockfile is a CLI-side reproducibility guarantee. The Kubernetes operator resolves contracts independently from CRD specs and does not consult the lockfile.
-- **The lock is not embedded in the pushed bundle.** When you `pacto push`, the lock stays in your git repo. It is not packaged into the OCI artifact. This keeps bundles clean of development-time artifacts.
 
 ---
 

--- a/docs/pactoignore.md
+++ b/docs/pactoignore.md
@@ -30,10 +30,11 @@ These patterns are always applied, even when no `.pactoignore` file exists:
 
 - `.git/`
 - `.pactoignore`
-- `pacto.lock`
 - `.DS_Store`
 
 You do not need to list these in your `.pactoignore` — they are excluded automatically.
+
+**Note:** `pacto.lock` is **not** in the default ignore list. When a lockfile is present, it ships inside the bundle by default so the dashboard can surface pinned digests and drift for OCI-sourced and Kubernetes-sourced services. If you do not want the lock in your pushed bundle, add an explicit `pacto.lock` line to `.pactoignore`.
 
 ---
 

--- a/examples/demo/bundles/api-gateway/v1.0.0/.pactoignore
+++ b/examples/demo/bundles/api-gateway/v1.0.0/.pactoignore
@@ -1,3 +1,0 @@
-# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-!pacto.lock

--- a/examples/demo/bundles/api-gateway/v1.1.0/.pactoignore
+++ b/examples/demo/bundles/api-gateway/v1.1.0/.pactoignore
@@ -1,3 +1,0 @@
-# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-!pacto.lock

--- a/examples/demo/bundles/api-gateway/v1.2.0/.pactoignore
+++ b/examples/demo/bundles/api-gateway/v1.2.0/.pactoignore
@@ -1,3 +1,0 @@
-# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-!pacto.lock

--- a/examples/demo/bundles/auth-service/.pactoignore
+++ b/examples/demo/bundles/auth-service/.pactoignore
@@ -1,3 +1,0 @@
-# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-!pacto.lock

--- a/examples/demo/bundles/fraud-service/.pactoignore
+++ b/examples/demo/bundles/fraud-service/.pactoignore
@@ -1,3 +1,0 @@
-# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-!pacto.lock

--- a/examples/demo/bundles/frontend/.pactoignore
+++ b/examples/demo/bundles/frontend/.pactoignore
@@ -1,3 +1,0 @@
-# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-!pacto.lock

--- a/examples/demo/bundles/notification-worker/.pactoignore
+++ b/examples/demo/bundles/notification-worker/.pactoignore
@@ -1,3 +1,0 @@
-# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-!pacto.lock

--- a/examples/demo/bundles/orders-service/v1.0.0/.pactoignore
+++ b/examples/demo/bundles/orders-service/v1.0.0/.pactoignore
@@ -1,3 +1,0 @@
-# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-!pacto.lock

--- a/examples/demo/bundles/orders-service/v1.1.0/.pactoignore
+++ b/examples/demo/bundles/orders-service/v1.1.0/.pactoignore
@@ -1,3 +1,0 @@
-# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-!pacto.lock

--- a/examples/demo/bundles/orders-service/v1.2.0/.pactoignore
+++ b/examples/demo/bundles/orders-service/v1.2.0/.pactoignore
@@ -1,3 +1,0 @@
-# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-!pacto.lock

--- a/examples/demo/bundles/pacto-demo/.pactoignore
+++ b/examples/demo/bundles/pacto-demo/.pactoignore
@@ -1,3 +1,0 @@
-# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-!pacto.lock

--- a/examples/demo/bundles/payments-service/v1.0.0/.pactoignore
+++ b/examples/demo/bundles/payments-service/v1.0.0/.pactoignore
@@ -1,3 +1,0 @@
-# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-!pacto.lock

--- a/examples/demo/bundles/payments-service/v1.1.0/.pactoignore
+++ b/examples/demo/bundles/payments-service/v1.1.0/.pactoignore
@@ -1,3 +1,0 @@
-# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-!pacto.lock

--- a/examples/demo/bundles/payments-service/v1.2.0/.pactoignore
+++ b/examples/demo/bundles/payments-service/v1.2.0/.pactoignore
@@ -1,3 +1,0 @@
-# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-!pacto.lock

--- a/examples/demo/bundles/payments-service/v2.0.0/.pactoignore
+++ b/examples/demo/bundles/payments-service/v2.0.0/.pactoignore
@@ -1,3 +1,0 @@
-# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-!pacto.lock

--- a/examples/demo/bundles/payments-service/v2.1.0/.pactoignore
+++ b/examples/demo/bundles/payments-service/v2.1.0/.pactoignore
@@ -1,3 +1,0 @@
-# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-!pacto.lock

--- a/examples/demo/genlocks/main.go
+++ b/examples/demo/genlocks/main.go
@@ -1,5 +1,5 @@
-// Command genlocks generates committed pacto.lock + .pactoignore files for the
-// dependency-bearing demo bundles, OFFLINE and DETERMINISTICALLY.
+// Command genlocks generates committed pacto.lock files for the dependency-bearing
+// demo bundles, OFFLINE and DETERMINISTICALLY.
 //
 // Why offline: the demo's refs point at oci://ghcr.io/trianalab/pacto-demo/<svc>,
 // which does not resolve without a live registry, and an ephemeral throwaway host
@@ -20,7 +20,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -80,7 +79,7 @@ func run() error {
 			if err != nil {
 				return fmt.Errorf("%s@%s: %w", name, ver, err)
 			}
-			if err := writeLockFiles(sv.dir, l); err != nil {
+			if err := writeLock(sv.dir, l); err != nil {
 				return err
 			}
 			written = append(written, sv.dir)
@@ -89,7 +88,7 @@ func run() error {
 
 	sort.Strings(written)
 	for _, d := range written {
-		fmt.Println("wrote", filepath.Join(d, lock.FileName), "+", filepath.Join(d, ignore.IgnoreFileName))
+		fmt.Println("wrote", filepath.Join(d, lock.FileName))
 	}
 	fmt.Printf("genlocks: wrote %d lock(s)\n", len(written))
 	return nil
@@ -132,15 +131,15 @@ func buildIndex(root string) (index, error) {
 	return idx, nil
 }
 
-// hashBundle returns the deterministic content hash of the bundle at dir, over the
-// DEFAULT ignore set only — it deliberately does NOT honor the bundle's own
-// .pactoignore. The default set excludes pacto.lock and .pactoignore, so the hash
-// is over the pristine bundle content and is unaffected by the lock files this tool
-// writes. Honoring a bundle's .pactoignore (which re-includes pacto.lock) would
-// fold the lock back into its own hash and break regeneration determinism.
+// hashBundle returns the deterministic content hash of the bundle at dir over its
+// pristine content. pacto.lock now ships by default (it is no longer in the
+// DefaultPatterns ignore set), so the hash must EXPLICITLY exclude pacto.lock —
+// otherwise the lock this tool writes would fold back into its own hash and break
+// regeneration determinism. The bundle's own .pactoignore is deliberately not
+// honored (we pass an explicit pattern, not ignore.Load).
 func hashBundle(dir string) (string, error) {
 	dirFS := os.DirFS(dir)
-	return lock.HashFS(ignore.FS(dirFS, ignore.New(nil)))
+	return lock.HashFS(ignore.FS(dirFS, ignore.New([]string{lock.FileName})))
 }
 
 // depBearing reports whether a contract declares any dependency or any config/
@@ -317,54 +316,13 @@ func serviceName(ref string) string {
 	return name
 }
 
-// writeLockFiles writes pacto.lock (deterministically marshaled) and a
-// .pactoignore that re-includes it (!pacto.lock) into dir, so the committed lock
-// travels with the bundle when it is packed/embedded.
-func writeLockFiles(dir string, l *lock.Lock) error {
+// writeLock writes pacto.lock (deterministically marshaled) into dir. The lock now
+// ships inside the bundle by default (no .pactoignore re-include needed), so the
+// committed lock travels with the bundle when it is packed or embedded.
+func writeLock(dir string, l *lock.Lock) error {
 	data, err := l.Marshal()
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(dir, lock.FileName), data, 0o644); err != nil {
-		return err
-	}
-	return ensurePactoignore(filepath.Join(dir, ignore.IgnoreFileName))
-}
-
-// ignoreHeader documents why the demo re-includes pacto.lock in its bundles.
-const ignoreHeader = `# Re-include the committed lockfile in packed/embedded bundles.
-# pacto.lock is default-ignored; the demo ships it so the dashboard can show pins.
-`
-
-// ensurePactoignore writes a .pactoignore whose effective rules un-ignore
-// pacto.lock. If a .pactoignore already exists without an "!pacto.lock" rule, the
-// rule is appended; otherwise the canonical file is written. The result is stable
-// across runs.
-func ensurePactoignore(path string) error {
-	existing, err := os.ReadFile(path)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return err
-	}
-	if hasUnignoreRule(string(existing)) {
-		return nil
-	}
-	if len(existing) == 0 {
-		return os.WriteFile(path, []byte(ignoreHeader+"!pacto.lock\n"), 0o644)
-	}
-	content := string(existing)
-	if !strings.HasSuffix(content, "\n") {
-		content += "\n"
-	}
-	content += "!pacto.lock\n"
-	return os.WriteFile(path, []byte(content), 0o644)
-}
-
-// hasUnignoreRule reports whether content already re-includes pacto.lock.
-func hasUnignoreRule(content string) bool {
-	for _, line := range strings.Split(content, "\n") {
-		if strings.TrimSpace(line) == "!pacto.lock" {
-			return true
-		}
-	}
-	return false
+	return os.WriteFile(filepath.Join(dir, lock.FileName), data, 0o644)
 }

--- a/examples/demo/source_embed.go
+++ b/examples/demo/source_embed.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/trianalab/pacto/pkg/contract"
 	"github.com/trianalab/pacto/pkg/dashboard"
-	"github.com/trianalab/pacto/pkg/lock"
 	"github.com/trianalab/pacto/pkg/semver"
 	"github.com/trianalab/pacto/pkg/validation"
 )
@@ -30,8 +29,7 @@ const embedSourceName = "local"
 // versionEntry is one parsed contract version held in memory.
 type versionEntry struct {
 	bundle *contract.Bundle
-	hash   string     // sha256 of the raw YAML, used as the version's contract hash
-	lock   *lock.Lock // parsed pacto.lock from the bundle dir, nil when absent
+	hash   string // sha256 of the raw YAML, used as the version's contract hash
 }
 
 // EmbedSource implements dashboard.DataSource over an embedded filesystem of
@@ -78,19 +76,12 @@ func NewEmbedSource(fsys fs.FS) (*EmbedSource, error) {
 		if s.byName[name] == nil {
 			s.byName[name] = make(map[string]*versionEntry)
 		}
-		// Read an embedded pacto.lock sitting alongside pacto.yaml. The lockfile is
-		// default-ignored by .pactoignore, but //go:embed bypasses that filter, so a
-		// committed lock IS present in the embedded FS and read directly from fsys
-		// (the bundle's ignore-filtered sub-FS would hide it). A malformed lock is
-		// skipped so one bad file never breaks the demo.
-		l, err := readEmbeddedLock(fsys, path.Dir(p))
-		if err != nil {
-			l = nil
-		}
+		// The sub-FS rooted at the contract dir carries the committed pacto.lock,
+		// so ServiceDetailsFromBundle applies its pins for the demo too — no manual
+		// lock reading here.
 		s.byName[name][ver] = &versionEntry{
 			bundle: &contract.Bundle{Contract: c, RawYAML: raw, FS: sub},
 			hash:   hex.EncodeToString(h[:]),
-			lock:   l,
 		}
 		return nil
 	})
@@ -103,17 +94,6 @@ func NewEmbedSource(fsys fs.FS) (*EmbedSource, error) {
 	}
 	sort.Strings(s.names)
 	return s, nil
-}
-
-// readEmbeddedLock reads pacto.lock from dir inside fsys. Returns (nil, nil) when
-// the file is absent (a lock is optional). Mirrors dashboard.readLock, but reads
-// from the embedded FS rather than the OS filesystem.
-func readEmbeddedLock(fsys fs.FS, dir string) (*lock.Lock, error) {
-	raw, err := fs.ReadFile(fsys, path.Join(dir, lock.FileName))
-	if err != nil {
-		return nil, nil // absent (or unreadable) → no lock
-	}
-	return lock.Parse(raw)
 }
 
 // versionsDesc returns a service's versions sorted latest-first.
@@ -162,24 +142,16 @@ func (s *EmbedSource) ListServices(_ context.Context) ([]dashboard.Service, erro
 	return services, nil
 }
 
-// GetService returns full details for a service's latest version, with any
-// embedded pacto.lock pins applied so the demo dashboard shows resolved digests.
+// GetService returns full details for a service's latest version. The embedded
+// pacto.lock travels in the bundle FS, so ServiceDetailsFromBundle surfaces its
+// pins. The demo has no k8s runtime, so DriftStatus stays empty (pins shown, no
+// drift assertion) — which is correct offline.
 func (s *EmbedSource) GetService(_ context.Context, name string) (*dashboard.ServiceDetails, error) {
 	entry, _, err := s.latestEntry(name)
 	if err != nil {
 		return nil, err
 	}
-	return s.detailsWithLock(entry), nil
-}
-
-// detailsWithLock builds ServiceDetails for an entry and applies its lock (if any)
-// through the exported dashboard hook, so the demo surfaces pins via the same code
-// path the on-disk LocalSource uses. The demo has no k8s runtime, so DriftStatus
-// stays empty (pins are shown, no drift assertion) — which is correct offline.
-func (s *EmbedSource) detailsWithLock(entry *versionEntry) *dashboard.ServiceDetails {
-	details := dashboard.ServiceDetailsFromBundle(entry.bundle, embedSourceName)
-	dashboard.ApplyLock(details, entry.lock)
-	return details
+	return dashboard.ServiceDetailsFromBundle(entry.bundle, embedSourceName), nil
 }
 
 // GetVersions returns every indexed version for a service, latest first, each
@@ -237,7 +209,7 @@ func (s *EmbedSource) GetServiceVersion(_ context.Context, ref dashboard.Ref) (*
 	if err != nil {
 		return nil, fmt.Errorf("loading %q version %q: %w", ref.Name, ref.Version, err)
 	}
-	return s.detailsWithLock(entry), nil
+	return dashboard.ServiceDetailsFromBundle(entry.bundle, embedSourceName), nil
 }
 
 // resolveRef finds the bundle for a ref, defaulting an empty version to latest,

--- a/pkg/dashboard/lock.go
+++ b/pkg/dashboard/lock.go
@@ -3,8 +3,6 @@ package dashboard
 import (
 	"errors"
 	"io/fs"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/trianalab/pacto/pkg/lock"
@@ -18,12 +16,16 @@ const (
 	driftUnknown  = "unknown"  // locked, but no runtime digest available to compare
 )
 
-// readLock reads pacto.lock from the bundle directory on disk. The lockfile is
-// default-ignored, so it is absent from the ignore-filtered Bundle.FS and must be
-// read directly. Returns (nil, nil) when the file does not exist (a lockfile is
+// lockFromFS reads pacto.lock from a bundle FS. Since pacto.lock now ships inside
+// the bundle (no longer default-ignored), it is present in every source's bundle
+// FS — local, OCI and cache — so this single reader covers them all. Returns
+// (nil, nil) when the FS is nil or the lockfile is absent (a lockfile is
 // optional); a parse/schema error is returned so callers surface it.
-func readLock(dir string) (*lock.Lock, error) {
-	data, err := os.ReadFile(filepath.Join(dir, lock.FileName))
+func lockFromFS(fsys fs.FS) (*lock.Lock, error) {
+	if fsys == nil {
+		return nil, nil
+	}
+	data, err := fs.ReadFile(fsys, lock.FileName)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil, nil

--- a/pkg/dashboard/lock_test.go
+++ b/pkg/dashboard/lock_test.go
@@ -1,11 +1,14 @@
 package dashboard
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 
+	"github.com/trianalab/pacto/pkg/contract"
 	"github.com/trianalab/pacto/pkg/lock"
 )
 
@@ -50,13 +53,12 @@ func writeLockFile(t *testing.T, dir, content string) {
 	}
 }
 
-func TestReadLock_Present(t *testing.T) {
-	dir := t.TempDir()
-	writeLockFile(t, dir, sampleLockYAML)
+func TestLockFromFS_Present(t *testing.T) {
+	fsys := fstest.MapFS{lock.FileName: {Data: []byte(sampleLockYAML)}}
 
-	l, err := readLock(dir)
+	l, err := lockFromFS(fsys)
 	if err != nil {
-		t.Fatalf("readLock: %v", err)
+		t.Fatalf("lockFromFS: %v", err)
 	}
 	if l == nil {
 		t.Fatal("expected non-nil lock")
@@ -69,9 +71,8 @@ func TestReadLock_Present(t *testing.T) {
 	}
 }
 
-func TestReadLock_Absent(t *testing.T) {
-	dir := t.TempDir()
-	l, err := readLock(dir)
+func TestLockFromFS_Absent(t *testing.T) {
+	l, err := lockFromFS(fstest.MapFS{})
 	if err != nil {
 		t.Fatalf("expected nil error for absent lock, got %v", err)
 	}
@@ -80,25 +81,103 @@ func TestReadLock_Absent(t *testing.T) {
 	}
 }
 
-func TestReadLock_ParseError(t *testing.T) {
-	dir := t.TempDir()
+func TestLockFromFS_NilFS(t *testing.T) {
+	l, err := lockFromFS(nil)
+	if err != nil {
+		t.Fatalf("expected nil error for nil FS, got %v", err)
+	}
+	if l != nil {
+		t.Fatalf("expected nil lock for nil FS, got %+v", l)
+	}
+}
+
+func TestLockFromFS_ParseError(t *testing.T) {
 	// Valid YAML but wrong lockVersion → lock.Parse returns an error.
-	writeLockFile(t, dir, "lockVersion: 99\nroot:\n  name: x\n")
-	_, err := readLock(dir)
+	fsys := fstest.MapFS{lock.FileName: {Data: []byte("lockVersion: 99\nroot:\n  name: x\n")}}
+	_, err := lockFromFS(fsys)
 	if err == nil {
 		t.Fatal("expected error for unsupported lockVersion")
 	}
 }
 
-func TestReadLock_ReadError(t *testing.T) {
-	dir := t.TempDir()
-	// Make pacto.lock a directory so os.ReadFile fails with a non-ErrNotExist error.
-	if err := os.MkdirAll(filepath.Join(dir, lock.FileName), 0o755); err != nil {
+func TestLockFromFS_ReadError(t *testing.T) {
+	// A non-ErrNotExist read error (here: pacto.lock is a directory) is surfaced.
+	fsys := fstest.MapFS{lock.FileName + "/nested": {Data: []byte("x")}}
+	_, err := lockFromFS(fsys)
+	if err == nil {
+		t.Fatal("expected error when pacto.lock is not a regular file")
+	}
+}
+
+// TestServiceDetailsFromBundle_EmbeddedLock proves the uniform lock read: an
+// OCI/cache-style bundle whose in-memory FS carries pacto.lock has its pins
+// surfaced (Lock + dependency LockedDigest) by ServiceDetailsFromBundle, exactly
+// like a local on-disk bundle. This is what lights up drift for non-local sources.
+func TestServiceDetailsFromBundle_EmbeddedLock(t *testing.T) {
+	c, err := contract.Parse(bytes.NewReader([]byte(`pactoVersion: "1.0"
+service:
+  name: api
+  version: 1.0.0
+dependencies:
+  - name: billing
+    ref: ghcr.io/org/billing-pacto
+    required: true
+`)))
+	if err != nil {
 		t.Fatal(err)
 	}
-	_, err := readLock(dir)
-	if err == nil {
-		t.Fatal("expected error when pacto.lock is unreadable")
+	fsys := fstest.MapFS{lock.FileName: {Data: []byte(sampleLockYAML)}}
+	details := ServiceDetailsFromBundle(&contract.Bundle{Contract: c, FS: fsys}, "oci")
+
+	if details.Lock == nil || !details.Lock.Present {
+		t.Fatal("expected embedded lock to be applied for an OCI/cache bundle")
+	}
+	if len(details.Dependencies) != 1 {
+		t.Fatalf("expected 1 dependency, got %d", len(details.Dependencies))
+	}
+	if details.Dependencies[0].LockedDigest != "sha256:dep111" {
+		t.Errorf("billing locked digest = %q, want sha256:dep111", details.Dependencies[0].LockedDigest)
+	}
+}
+
+// TestServiceDetailsFromBundle_NoEmbeddedLock proves an FS without pacto.lock
+// leaves Lock nil (unchanged behavior).
+func TestServiceDetailsFromBundle_NoEmbeddedLock(t *testing.T) {
+	c, err := contract.Parse(bytes.NewReader([]byte("pactoVersion: \"1.0\"\nservice:\n  name: api\n  version: 1.0.0\n")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	details := ServiceDetailsFromBundle(&contract.Bundle{Contract: c, FS: fstest.MapFS{}}, "oci")
+	if details.Lock != nil {
+		t.Errorf("expected nil Lock without an embedded lockfile, got %+v", details.Lock)
+	}
+}
+
+// TestServiceDetailsFromBundle_NilFSNoPanic proves a bundle with a nil FS does
+// not panic and surfaces no lock.
+func TestServiceDetailsFromBundle_NilFSNoPanic(t *testing.T) {
+	c, err := contract.Parse(bytes.NewReader([]byte("pactoVersion: \"1.0\"\nservice:\n  name: api\n  version: 1.0.0\n")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	details := ServiceDetailsFromBundle(&contract.Bundle{Contract: c}, "oci")
+	if details.Lock != nil {
+		t.Errorf("expected nil Lock for nil FS, got %+v", details.Lock)
+	}
+}
+
+// TestServiceDetailsFromBundle_MalformedEmbeddedLockIgnored proves a malformed
+// embedded lock is best-effort: it is ignored (nil Lock) rather than dropping the
+// whole service from the dashboard.
+func TestServiceDetailsFromBundle_MalformedEmbeddedLockIgnored(t *testing.T) {
+	c, err := contract.Parse(bytes.NewReader([]byte("pactoVersion: \"1.0\"\nservice:\n  name: api\n  version: 1.0.0\n")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fsys := fstest.MapFS{lock.FileName: {Data: []byte("lockVersion: 99\nroot:\n  name: api\n")}}
+	details := ServiceDetailsFromBundle(&contract.Bundle{Contract: c, FS: fsys}, "oci")
+	if details.Lock != nil {
+		t.Errorf("expected nil Lock for malformed embedded lock, got %+v", details.Lock)
 	}
 }
 
@@ -647,29 +726,36 @@ func TestBuildGraph_CarriesLockPins(t *testing.T) {
 	}
 }
 
-func TestLocalSource_GetService_ParseLockError(t *testing.T) {
+func TestLocalSource_GetService_MalformedLockIgnored(t *testing.T) {
 	root := t.TempDir()
 	dir := filepath.Join(root, "api")
 	writeLocalPactoYAML(t, dir, "api", "1.0.0")
-	// Unsupported lockVersion → readLock returns an error; GetService must surface it.
+	// A malformed lock (unsupported lockVersion) is best-effort: it is treated as
+	// absent so a bad embedded lock never breaks the dashboard for that service.
 	writeLockFile(t, dir, "lockVersion: 99\nroot:\n  name: api\n")
 
 	src := NewLocalSource(root)
-	_, err := src.GetService(context.Background(), "api")
-	if err == nil {
-		t.Fatal("expected error for invalid lockfile")
+	details, err := src.GetService(context.Background(), "api")
+	if err != nil {
+		t.Fatalf("expected no error for malformed lockfile, got %v", err)
+	}
+	if details.Lock != nil {
+		t.Errorf("expected nil Lock for malformed lockfile, got %+v", details.Lock)
 	}
 }
 
-func TestLocalSource_GetServiceVersion_ParseLockError(t *testing.T) {
+func TestLocalSource_GetServiceVersion_MalformedLockIgnored(t *testing.T) {
 	root := t.TempDir()
 	dir := filepath.Join(root, "api")
 	writeLocalPactoYAML(t, dir, "api", "1.0.0")
 	writeLockFile(t, dir, "lockVersion: 99\nroot:\n  name: api\n")
 
 	src := NewLocalSource(root)
-	_, err := src.GetServiceVersion(context.Background(), Ref{Name: "api", Version: "1.0.0"})
-	if err == nil {
-		t.Fatal("expected error for invalid lockfile on versioned read")
+	details, err := src.GetServiceVersion(context.Background(), Ref{Name: "api", Version: "1.0.0"})
+	if err != nil {
+		t.Fatalf("expected no error for malformed lockfile on versioned read, got %v", err)
+	}
+	if details.Lock != nil {
+		t.Errorf("expected nil Lock for malformed lockfile, got %+v", details.Lock)
 	}
 }

--- a/pkg/dashboard/mapping.go
+++ b/pkg/dashboard/mapping.go
@@ -85,6 +85,14 @@ func ServiceDetailsFromBundle(bundle *contract.Bundle, source string) *ServiceDe
 	// Compute compliance for non-k8s sources (no conditions available).
 	svc.Compliance = ComputeCompliance(svc.ContractStatus, svc.Conditions)
 
+	// Apply the embedded lockfile (pacto.lock) when the bundle FS carries one.
+	// Since the lock now ships inside the bundle for every source (local, OCI,
+	// cache), this single read surfaces pins and lights up dependency drift
+	// cluster-wide. A nil FS or absent/malformed lock leaves svc untouched.
+	if l, err := lockFromFS(bundle.FS); err == nil {
+		ApplyLock(svc, l)
+	}
+
 	return svc
 }
 

--- a/pkg/dashboard/source_local.go
+++ b/pkg/dashboard/source_local.go
@@ -104,19 +104,17 @@ func (s *LocalSource) ListServices(_ context.Context) ([]Service, error) {
 }
 
 func (s *LocalSource) GetService(_ context.Context, name string) (*ServiceDetails, error) {
-	bundle, dir, err := s.findBundle(name)
+	bundle, err := s.findBundle(name)
 	if err != nil {
 		return nil, err
 	}
-	details := ServiceDetailsFromBundle(bundle, "local")
-	if err := applyLockFromDir(details, dir); err != nil {
-		return nil, err
-	}
-	return details, nil
+	// ServiceDetailsFromBundle reads the embedded pacto.lock from bundle.FS
+	// (os.DirFS over the bundle dir), so lock pins are applied uniformly.
+	return ServiceDetailsFromBundle(bundle, "local"), nil
 }
 
 func (s *LocalSource) GetVersions(_ context.Context, name string) ([]Version, error) {
-	bundle, _, err := s.findBundle(name)
+	bundle, err := s.findBundle(name)
 	if err != nil {
 		return nil, err
 	}
@@ -130,11 +128,11 @@ func (s *LocalSource) GetVersions(_ context.Context, name string) ([]Version, er
 }
 
 func (s *LocalSource) GetDiff(_ context.Context, a, b Ref) (*DiffResult, error) {
-	bundleA, _, err := s.findBundle(a.Name)
+	bundleA, err := s.findBundle(a.Name)
 	if err != nil {
 		return nil, fmt.Errorf("loading %q: %w", a.Name, err)
 	}
-	bundleB, _, err := s.findBundle(b.Name)
+	bundleB, err := s.findBundle(b.Name)
 	if err != nil {
 		return nil, fmt.Errorf("loading %q: %w", b.Name, err)
 	}
@@ -142,7 +140,7 @@ func (s *LocalSource) GetDiff(_ context.Context, a, b Ref) (*DiffResult, error) 
 }
 
 func (s *LocalSource) GetServiceVersion(_ context.Context, ref Ref) (*ServiceDetails, error) {
-	bundle, dir, err := s.findBundle(ref.Name)
+	bundle, err := s.findBundle(ref.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -150,36 +148,20 @@ func (s *LocalSource) GetServiceVersion(_ context.Context, ref Ref) (*ServiceDet
 		return nil, fmt.Errorf("version %q of %q not found in local source (on-disk version is %q)",
 			ref.Version, ref.Name, bundle.Contract.Service.Version)
 	}
-	details := ServiceDetailsFromBundle(bundle, "local")
-	if err := applyLockFromDir(details, dir); err != nil {
-		return nil, err
-	}
-	return details, nil
+	return ServiceDetailsFromBundle(bundle, "local"), nil
 }
 
-// applyLockFromDir reads pacto.lock from dir (if present) and maps its pins onto
-// details. A missing lockfile is a no-op (backward compatible); a malformed one
-// is surfaced as an error.
-func applyLockFromDir(details *ServiceDetails, dir string) error {
-	l, err := readLock(dir)
-	if err != nil {
-		return err
-	}
-	ApplyLock(details, l)
-	return nil
-}
-
-func (s *LocalSource) findBundle(name string) (*contract.Bundle, string, error) {
+func (s *LocalSource) findBundle(name string) (*contract.Bundle, error) {
 	for _, dir := range localBundleDirs(s.root) {
 		bundle, err := loadLocalBundle(dir)
 		if err != nil {
 			continue
 		}
 		if bundle.Contract.Service.Name == name {
-			return bundle, dir, nil
+			return bundle, nil
 		}
 	}
-	return nil, "", fmt.Errorf("service %q not found in %s", name, s.root)
+	return nil, fmt.Errorf("service %q not found in %s", name, s.root)
 }
 
 func loadLocalBundle(dir string) (*contract.Bundle, error) {

--- a/pkg/dashboard/source_local_test.go
+++ b/pkg/dashboard/source_local_test.go
@@ -258,7 +258,7 @@ func TestLocalSource_ImplementsDataSource(t *testing.T) {
 func TestLocalSource_FindBundle_ReadDirError(t *testing.T) {
 	// Use a non-existent root so that ReadDir fails.
 	src := NewLocalSource("/nonexistent/path/that/does/not/exist")
-	_, _, err := src.findBundle("any-service")
+	_, err := src.findBundle("any-service")
 	if err == nil {
 		t.Fatal("expected error when root directory does not exist")
 	}

--- a/pkg/ignore/ignore.go
+++ b/pkg/ignore/ignore.go
@@ -15,11 +15,13 @@ import (
 // IgnoreFileName is the name of the per-bundle ignore file.
 const IgnoreFileName = ".pactoignore"
 
-// DefaultPatterns are always ignored when building a bundle.
+// DefaultPatterns are always ignored when building a bundle. pacto.lock is NOT
+// among them: a committed lockfile ships inside the bundle by default so the
+// dashboard can surface its pins and drift for every source (local, OCI, cache).
+// Shipping stays opt-in — with no lock on disk nothing extra is included.
 var DefaultPatterns = []string{
 	".git/",
 	".pactoignore",
-	"pacto.lock",
 	".DS_Store",
 }
 

--- a/pkg/ignore/ignore_test.go
+++ b/pkg/ignore/ignore_test.go
@@ -12,7 +12,8 @@ func TestMatcherIgnored(t *testing.T) {
 	}{
 		{"default git dir", nil, ".git", true, true},
 		{"default ds_store at depth", nil, "docs/.DS_Store", false, true},
-		{"default lock", nil, "pacto.lock", false, true},
+		{"lock shipped by default", nil, "pacto.lock", false, false},
+		{"lock still ignorable when opted out", []string{"pacto.lock"}, "pacto.lock", false, true},
 		{"default ignore file", nil, ".pactoignore", false, true},
 		{"pacto.yaml never ignored", []string{"*.yaml"}, "pacto.yaml", false, false},
 		{"basename glob any depth", []string{"*.tmp"}, "build/x.tmp", false, true},

--- a/tests/e2e/lock_test.go
+++ b/tests/e2e/lock_test.go
@@ -561,20 +561,15 @@ func TestLockDependencyShippingOwnLockIsIgnored(t *testing.T) {
 	t.Parallel()
 	reg := newTestRegistry(t)
 
-	// dep-X bundle ships its OWN pacto.lock. The default .pactoignore drops
-	// pacto.lock; re-include it via `!pacto.lock` so it travels in the artifact.
-	// NOTE: a shipped lock is enforced at push time (push runs verifyLockIfPresent),
-	// so the lock must be VALID for dep-x — we generate it with `pacto lock`. The
-	// point of the scenario is still proven below: the root resolves dep-x's digest
-	// independently and never consults dep-x's shipped lock.
+	// dep-X bundle ships its OWN pacto.lock. Locks are embedded in pushed bundles
+	// by default, so we just generate a valid lock (push runs verifyLockIfPresent).
+	// The point of the scenario: the root resolves dep-x's digest independently and
+	// never consults dep-x's shipped lock.
 	xDir := writeDepBundle(t, "dep-x", "1.0.0", "", "")
-	if err := os.WriteFile(filepath.Join(xDir, ".pactoignore"), []byte("!pacto.lock\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
 	if _, err := runCommand(t, reg, "lock", xDir); err != nil {
 		t.Fatalf("lock dep-x: %v", err)
 	}
-	// Confirm dep-x really did ship a lock (re-include via !pacto.lock worked).
+	// Confirm the lock was generated.
 	if _, err := os.Stat(filepath.Join(xDir, lock.FileName)); err != nil {
 		t.Fatalf("expected dep-x to ship a pacto.lock: %v", err)
 	}
@@ -736,6 +731,57 @@ runtime:
 	}
 	if _, ok := after.Dependency("remove-a"); !ok {
 		t.Errorf("expected remove-a to remain after reconcile, got %+v", after.Dependencies)
+	}
+}
+
+// TestLockEmbeddedInPushedBundle proves pacto.lock is embedded in the pushed
+// bundle and survives the OCI round-trip. A bundle with pacto.yaml, an interface
+// file and a valid pacto.lock is pushed to the registry, then pulled to a fresh
+// directory. The pulled tree must contain all three files: pacto.yaml, the
+// interface and the lock.
+func TestLockEmbeddedInPushedBundle(t *testing.T) {
+	t.Parallel()
+	reg := newTestRegistry(t)
+
+	// Create a bundle dir with a minimal contract, an interface file and a lock.
+	dir := filepath.Join(t.TempDir(), "lock-embed")
+	contractYAML := depServiceContract("lock-embed", "1.0.0", "", "")
+	writeBundleDir(t, dir, contractYAML, map[string]string{
+		"api.proto": fmt.Sprintf(protoTemplate, "lock-embed", "LockEmbed"),
+	})
+
+	// Generate a valid pacto.lock for this bundle (empty dependencies, but valid).
+	lockContent := `lockVersion: 1
+pacto:
+  version: 1.4.0
+root:
+  name: lock-embed
+  version: 1.0.0
+dependencies: []
+references: []
+`
+	if err := os.WriteFile(filepath.Join(dir, "pacto.lock"), []byte(lockContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Push the bundle to the registry.
+	ref := "oci://" + reg.host + "/lock-embed:1.0.0"
+	if _, err := runCommand(t, reg, "push", ref, "-p", dir); err != nil {
+		t.Fatalf("push failed: %v", err)
+	}
+
+	// Pull to a fresh directory.
+	pullDir := filepath.Join(t.TempDir(), "lock-embed-pulled")
+	if _, err := runCommand(t, reg, "pull", ref, "-o", pullDir); err != nil {
+		t.Fatalf("pull failed: %v", err)
+	}
+
+	// Assert all three files survived the round-trip.
+	for _, file := range []string{"pacto.yaml", "interfaces/api.proto", "pacto.lock"} {
+		path := filepath.Join(pullDir, filepath.FromSlash(file))
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected %s in pulled tree: %v", file, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Ships `pacto.lock` inside the pushed OCI bundle and reads it across all dashboard sources, so the dashboard's observed-vs-locked **drift** now works for services seen via OCI/k8s — not just local.

- `pkg/ignore`: `pacto.lock` is no longer in the default-ignore set, so `pack`/`push` include it when present (still opt-in; no lock file → nothing extra shipped). `pacto.yaml` is still never ignorable.
- `pkg/dashboard`: `ServiceDetailsFromBundle` reads the embedded lock from the bundle FS and applies it for every source (local, OCI, cache). The existing drift logic (a dependency's locked digest vs that dependency's running digest from k8s) then lights up cluster-wide. Removed the redundant local-only disk read and the demo's manual lock apply.
- Demo: dropped the now-unnecessary `!pacto.lock` `.pactoignore` files; the generator stops emitting them and excludes the lock from its own content hash for deterministic regeneration.

## Why no operator change

The operator records only *declared* dependencies and resolves only the root contract, so it never observes dependency digests — it cannot compute dependency drift. The dashboard has the cluster-wide view and already does the cross-service join; it only needed each service's lock, which embedding now provides.

## Verification

Go coverage 100%, race clean, golangci-lint/gofmt/gocyclo clean, `make e2e` green (incl. a new push→pull embed test), dashboard vitest green, `make ci-static` exit 0.
