### PR TITLE
ci(docs): redeploy demo on published release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,12 @@ on:
       # The demo embeds the dashboard UI + engine, so redeploy when they change.
       - 'pkg/dashboard/**'
       - '.github/workflows/docs.yml'
+  # Redeploy on every published release. The demo bakes in the Pacto version via
+  # `git describe` at build time; the release tag is created moments AFTER the
+  # merge-to-main push that triggered the path-filtered build above, so that
+  # build still saw the previous tag. This re-runs once the new tag exists.
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem

The WASM demo at `/pacto/demo/` was stuck showing **v1.9.0** in the navbar after v1.10.0 shipped.

The demo bakes its Pacto version via `git describe --tags --abbrev=0` at build time (`examples/demo/Makefile`), but `docs.yml` only triggered on path-filtered pushes to `main`. The release tag is created *moments after* the merge-to-main push that triggers that build, so the build resolves the **previous** tag. Confirmed from the run history: the last deploy fired at 16:52:21Z (push of #194), and the v1.10.0 Release published at 16:52:31Z — 10s later.

## Fix

Add a `release: types: [published]` trigger. It fires once the new tag exists, and — unlike `push: tags` — is not subject to the `paths` filter, so it reliably rebuilds the demo with the correct version on every release. The existing `fetch-depth: 0` checkout already provides tags for `git describe`.

The currently-live demo was already corrected to v1.10.0 via a manual `workflow_dispatch`; this PR prevents the drift from recurring.
