### PR TITLE
fix: migrate module path to github.com/trianalab/pacto/v2 so v2 is installable

### DIFF
--- a/cmd/genbundle/main.go
+++ b/cmd/genbundle/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/trianalab/pacto/pkg/dashboard"
+	"github.com/trianalab/pacto/v2/pkg/dashboard"
 )
 
 func main() {

--- a/cmd/gendocs/main.go
+++ b/cmd/gendocs/main.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra/doc"
-	"github.com/trianalab/pacto/internal/app"
-	"github.com/trianalab/pacto/internal/cli"
-	"github.com/trianalab/pacto/pkg/oci"
-	"github.com/trianalab/pacto/pkg/plugin"
+	"github.com/trianalab/pacto/v2/internal/app"
+	"github.com/trianalab/pacto/v2/internal/cli"
+	"github.com/trianalab/pacto/v2/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/plugin"
 )
 
 const frontMatter = `# CLI Reference

--- a/cmd/pacto/main.go
+++ b/cmd/pacto/main.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/trianalab/pacto/internal/app"
-	"github.com/trianalab/pacto/internal/cli"
-	"github.com/trianalab/pacto/pkg/oci"
-	"github.com/trianalab/pacto/pkg/plugin"
+	"github.com/trianalab/pacto/v2/internal/app"
+	"github.com/trianalab/pacto/v2/internal/cli"
+	"github.com/trianalab/pacto/v2/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/plugin"
 )
 
 // Build-time variables set via ldflags.

--- a/examples/demo/genlocks/main.go
+++ b/examples/demo/genlocks/main.go
@@ -27,11 +27,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/graph"
-	"github.com/trianalab/pacto/pkg/ignore"
-	"github.com/trianalab/pacto/pkg/lock"
-	"github.com/trianalab/pacto/pkg/semver"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/ignore"
+	"github.com/trianalab/pacto/v2/pkg/lock"
+	"github.com/trianalab/pacto/v2/pkg/semver"
 )
 
 const (

--- a/examples/demo/main_wasm.go
+++ b/examples/demo/main_wasm.go
@@ -12,7 +12,7 @@ import (
 	"syscall/js"
 
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
-	"github.com/trianalab/pacto/pkg/dashboard"
+	"github.com/trianalab/pacto/v2/pkg/dashboard"
 )
 
 // embeddedBundles holds the demo contracts baked into the wasm binary at build

--- a/examples/demo/source_embed.go
+++ b/examples/demo/source_embed.go
@@ -13,10 +13,10 @@ import (
 	"path"
 	"sort"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/dashboard"
-	"github.com/trianalab/pacto/pkg/semver"
-	"github.com/trianalab/pacto/pkg/validation"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/dashboard"
+	"github.com/trianalab/pacto/v2/pkg/semver"
+	"github.com/trianalab/pacto/v2/pkg/validation"
 )
 
 const contractFile = "pacto.yaml"

--- a/examples/demo/source_embed_test.go
+++ b/examples/demo/source_embed_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/pkg/dashboard"
+	"github.com/trianalab/pacto/v2/pkg/dashboard"
 )
 
 // bundlesFS loads the same bundles the wasm binary embeds. Bundles live in

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/trianalab/pacto
+module github.com/trianalab/pacto/v2
 
 go 1.26.0
 

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -8,11 +8,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/diff"
-	"github.com/trianalab/pacto/pkg/graph"
-	"github.com/trianalab/pacto/pkg/override"
-	"github.com/trianalab/pacto/pkg/sbom"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/diff"
+	"github.com/trianalab/pacto/v2/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/override"
+	"github.com/trianalab/pacto/v2/pkg/sbom"
 )
 
 // DiffOptions holds options for the diff command.

--- a/internal/app/diff_test.go
+++ b/internal/app/diff_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/graph"
 )
 
 func TestDiff_LocalFiles(t *testing.T) {

--- a/internal/app/doc.go
+++ b/internal/app/doc.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/doc"
-	"github.com/trianalab/pacto/pkg/graph"
-	"github.com/trianalab/pacto/pkg/override"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/doc"
+	"github.com/trianalab/pacto/v2/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/override"
 )
 
 // generateDoc is the function used to generate documentation. It is a variable

--- a/internal/app/doc_test.go
+++ b/internal/app/doc_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/graph"
 )
 
 func TestDoc_Local(t *testing.T) {

--- a/internal/app/explain.go
+++ b/internal/app/explain.go
@@ -5,9 +5,9 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/override"
-	"github.com/trianalab/pacto/pkg/readiness"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/override"
+	"github.com/trianalab/pacto/v2/pkg/readiness"
 )
 
 // timeNow is the clock used to derive readiness freshness. It is a variable so

--- a/internal/app/explain_test.go
+++ b/internal/app/explain_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 // writeReadinessBundle writes a pactoVersion 1.2 bundle with a readiness section

--- a/internal/app/generate.go
+++ b/internal/app/generate.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/trianalab/pacto/pkg/override"
-	"github.com/trianalab/pacto/pkg/plugin"
+	"github.com/trianalab/pacto/v2/pkg/override"
+	"github.com/trianalab/pacto/v2/pkg/plugin"
 )
 
 // PluginRunner abstracts plugin execution so the app layer does not depend

--- a/internal/app/generate_test.go
+++ b/internal/app/generate_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/plugin"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/plugin"
 )
 
 func TestGenerate_Success(t *testing.T) {

--- a/internal/app/graph.go
+++ b/internal/app/graph.go
@@ -6,10 +6,10 @@ import (
 	"log/slog"
 	"path/filepath"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/graph"
-	"github.com/trianalab/pacto/pkg/oci"
-	"github.com/trianalab/pacto/pkg/override"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/override"
 )
 
 // GraphOptions holds options for the graph command.

--- a/internal/app/graph_test.go
+++ b/internal/app/graph_test.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/trianalab/pacto/internal/testutil"
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/internal/testutil"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func TestGraph_Local(t *testing.T) {

--- a/internal/app/init_test.go
+++ b/internal/app/init_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/validation"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/validation"
 )
 
 func TestInit_ReadOnlyDir(t *testing.T) {

--- a/internal/app/lock.go
+++ b/internal/app/lock.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/lock"
-	"github.com/trianalab/pacto/pkg/override"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/lock"
+	"github.com/trianalab/pacto/v2/pkg/override"
 )
 
 // LockOptions configures the lock command.

--- a/internal/app/lock_build.go
+++ b/internal/app/lock_build.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"path/filepath"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/graph"
-	"github.com/trianalab/pacto/pkg/lock"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/lock"
 )
 
 // buildLock resolves the full dependency + reference closure for a contract and

--- a/internal/app/lock_build_test.go
+++ b/internal/app/lock_build_test.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/trianalab/pacto/internal/testutil"
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/lock"
+	"github.com/trianalab/pacto/v2/internal/testutil"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/lock"
 )
 
 // rootBundleWithDep returns a local root contract that declares one OCI dep.

--- a/internal/app/lock_resolve.go
+++ b/internal/app/lock_resolve.go
@@ -3,8 +3,8 @@ package app
 import (
 	"context"
 
-	"github.com/trianalab/pacto/pkg/graph"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 // resolveDigest resolves a bare OCI location under a constraint to a concrete

--- a/internal/app/lock_resolve_test.go
+++ b/internal/app/lock_resolve_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/trianalab/pacto/internal/testutil"
-	"github.com/trianalab/pacto/pkg/graph"
+	"github.com/trianalab/pacto/v2/internal/testutil"
+	"github.com/trianalab/pacto/v2/pkg/graph"
 )
 
 func TestResolveDigest(t *testing.T) {

--- a/internal/app/lock_test.go
+++ b/internal/app/lock_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/trianalab/pacto/internal/testutil"
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/lock"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/internal/testutil"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/lock"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 // writeRoot writes a minimal local root contract declaring one OCI dep and

--- a/internal/app/mocks_test.go
+++ b/internal/app/mocks_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/internal/testutil"
+	"github.com/trianalab/pacto/v2/internal/testutil"
 )
 
 // Type aliases for shared mocks so existing tests in this package compile

--- a/internal/app/pack.go
+++ b/internal/app/pack.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/trianalab/pacto/pkg/oci"
-	"github.com/trianalab/pacto/pkg/override"
+	"github.com/trianalab/pacto/v2/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/override"
 )
 
 // PackOptions holds options for the pack command.

--- a/internal/app/pull.go
+++ b/internal/app/pull.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/trianalab/pacto/pkg/graph"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 // PullOptions holds options for the pull command.

--- a/internal/app/pull_test.go
+++ b/internal/app/pull_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func TestPull_Success(t *testing.T) {

--- a/internal/app/push.go
+++ b/internal/app/push.go
@@ -7,10 +7,10 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/graph"
-	"github.com/trianalab/pacto/pkg/oci"
-	"github.com/trianalab/pacto/pkg/override"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/override"
 )
 
 // ErrArtifactAlreadyExists is returned when a push is attempted for a

--- a/internal/app/push_test.go
+++ b/internal/app/push_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/oci"
-	"github.com/trianalab/pacto/pkg/override"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/override"
 )
 
 func TestPush_Success(t *testing.T) {

--- a/internal/app/resolve.go
+++ b/internal/app/resolve.go
@@ -10,12 +10,12 @@ import (
 	"path/filepath"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/graph"
-	"github.com/trianalab/pacto/pkg/ignore"
-	"github.com/trianalab/pacto/pkg/oci"
-	"github.com/trianalab/pacto/pkg/override"
-	"github.com/trianalab/pacto/pkg/validation"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/ignore"
+	"github.com/trianalab/pacto/v2/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/override"
+	"github.com/trianalab/pacto/v2/pkg/validation"
 )
 
 // DefaultContractPath is the default filename looked up when no path is given.

--- a/internal/app/resolve_test.go
+++ b/internal/app/resolve_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/override"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/override"
 )
 
 func TestLoadLocalBundleAppliesPactoignore(t *testing.T) {

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 // Package-level function variables for filesystem operations,

--- a/internal/app/validate.go
+++ b/internal/app/validate.go
@@ -6,10 +6,10 @@ import (
 	"io/fs"
 	"log/slog"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/override"
-	"github.com/trianalab/pacto/pkg/readiness"
-	"github.com/trianalab/pacto/pkg/validation"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/override"
+	"github.com/trianalab/pacto/v2/pkg/readiness"
+	"github.com/trianalab/pacto/v2/pkg/validation"
 )
 
 // ValidateOptions holds options for the validate command.

--- a/internal/app/validate_test.go
+++ b/internal/app/validate_test.go
@@ -9,7 +9,7 @@ import (
 	"testing/fstest"
 	"time"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func TestValidate_LocalValid(t *testing.T) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -15,10 +15,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/trianalab/pacto/internal/app"
-	"github.com/trianalab/pacto/internal/cli"
-	"github.com/trianalab/pacto/internal/testutil"
-	"github.com/trianalab/pacto/internal/update"
+	"github.com/trianalab/pacto/v2/internal/app"
+	"github.com/trianalab/pacto/v2/internal/cli"
+	"github.com/trianalab/pacto/v2/internal/testutil"
+	"github.com/trianalab/pacto/v2/internal/update"
 )
 
 // platformAsset returns the release asset name for the current platform, matching

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/internal/app"
-	"github.com/trianalab/pacto/internal/cli"
-	"github.com/trianalab/pacto/internal/testutil"
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/oci"
-	"github.com/trianalab/pacto/pkg/plugin"
+	"github.com/trianalab/pacto/v2/internal/app"
+	"github.com/trianalab/pacto/v2/internal/cli"
+	"github.com/trianalab/pacto/v2/internal/testutil"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/plugin"
 )
 
 func TestPackCommand(t *testing.T) {

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/trianalab/pacto/internal/app"
-	"github.com/trianalab/pacto/pkg/dashboard"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/internal/app"
+	"github.com/trianalab/pacto/v2/pkg/dashboard"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 func newDashboardCommand(svc *app.Service, v *viper.Viper, version string) *cobra.Command {

--- a/internal/cli/dashboard_internal_test.go
+++ b/internal/cli/dashboard_internal_test.go
@@ -12,10 +12,10 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
-	"github.com/trianalab/pacto/internal/app"
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/dashboard"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/internal/app"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/dashboard"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 // dummyStore satisfies oci.BundleStore for CLI tests.

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/trianalab/pacto/internal/app"
+	"github.com/trianalab/pacto/v2/internal/app"
 )
 
 func newDiffCommand(svc *app.Service, v *viper.Viper) *cobra.Command {

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/trianalab/pacto/internal/app"
-	"github.com/trianalab/pacto/pkg/doc"
+	"github.com/trianalab/pacto/v2/internal/app"
+	"github.com/trianalab/pacto/v2/pkg/doc"
 )
 
 func newDocCommand(svc *app.Service, v *viper.Viper) *cobra.Command {

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/trianalab/pacto/internal/app"
+	"github.com/trianalab/pacto/v2/internal/app"
 )
 
 func newExplainCommand(svc *app.Service, v *viper.Viper) *cobra.Command {

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/trianalab/pacto/internal/app"
+	"github.com/trianalab/pacto/v2/internal/app"
 )
 
 func newGenerateCommand(svc *app.Service, v *viper.Viper) *cobra.Command {

--- a/internal/cli/graph.go
+++ b/internal/cli/graph.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/trianalab/pacto/internal/app"
+	"github.com/trianalab/pacto/v2/internal/app"
 )
 
 func newGraphCommand(svc *app.Service, v *viper.Viper) *cobra.Command {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/trianalab/pacto/internal/app"
+	"github.com/trianalab/pacto/v2/internal/app"
 )
 
 func newInitCommand(svc *app.Service, v *viper.Viper) *cobra.Command {

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/trianalab/pacto/internal/app"
+	"github.com/trianalab/pacto/v2/internal/app"
 )
 
 func newLockCommand(svc *app.Service, v *viper.Viper) *cobra.Command {

--- a/internal/cli/lock_test.go
+++ b/internal/cli/lock_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/trianalab/pacto/internal/app"
-	"github.com/trianalab/pacto/internal/cli"
-	"github.com/trianalab/pacto/internal/testutil"
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/internal/app"
+	"github.com/trianalab/pacto/v2/internal/cli"
+	"github.com/trianalab/pacto/v2/internal/testutil"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func TestLockCommandWritesFile(t *testing.T) {

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 	"golang.org/x/term"
 )
 

--- a/internal/cli/login_test.go
+++ b/internal/cli/login_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 func TestEncodeAuth(t *testing.T) {

--- a/internal/cli/logout.go
+++ b/internal/cli/logout.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 func newLogoutCommand() *cobra.Command {

--- a/internal/cli/logout_test.go
+++ b/internal/cli/logout_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 func TestRemovePactoConfig_RemovesExistingEntry(t *testing.T) {

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -9,8 +9,8 @@ import (
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/spf13/cobra"
-	"github.com/trianalab/pacto/internal/app"
-	pactomcp "github.com/trianalab/pacto/internal/mcp"
+	"github.com/trianalab/pacto/v2/internal/app"
+	pactomcp "github.com/trianalab/pacto/v2/internal/mcp"
 )
 
 func newMCPCommand(svc *app.Service, version string) *cobra.Command {

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/trianalab/pacto/internal/app"
-	pactomcp "github.com/trianalab/pacto/internal/mcp"
+	"github.com/trianalab/pacto/v2/internal/app"
+	pactomcp "github.com/trianalab/pacto/v2/internal/mcp"
 )
 
 func TestMCPCommand_Help(t *testing.T) {

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -6,10 +6,10 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-	"github.com/trianalab/pacto/internal/app"
-	"github.com/trianalab/pacto/pkg/diff"
-	"github.com/trianalab/pacto/pkg/graph"
-	"github.com/trianalab/pacto/pkg/sbom"
+	"github.com/trianalab/pacto/v2/internal/app"
+	"github.com/trianalab/pacto/v2/pkg/diff"
+	"github.com/trianalab/pacto/v2/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/sbom"
 )
 
 // formatResult dispatches between JSON, markdown and text output.

--- a/internal/cli/output_internal_test.go
+++ b/internal/cli/output_internal_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-	"github.com/trianalab/pacto/internal/app"
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/diff"
-	"github.com/trianalab/pacto/pkg/graph"
-	"github.com/trianalab/pacto/pkg/sbom"
+	"github.com/trianalab/pacto/v2/internal/app"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/diff"
+	"github.com/trianalab/pacto/v2/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/sbom"
 )
 
 type errWriter struct{}

--- a/internal/cli/overrides.go
+++ b/internal/cli/overrides.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/trianalab/pacto/pkg/override"
+	"github.com/trianalab/pacto/v2/pkg/override"
 )
 
 // optionalArg returns args[0] if present, otherwise "".

--- a/internal/cli/pack.go
+++ b/internal/cli/pack.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/trianalab/pacto/internal/app"
+	"github.com/trianalab/pacto/v2/internal/app"
 )
 
 func newPackCommand(svc *app.Service, v *viper.Viper) *cobra.Command {

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/trianalab/pacto/internal/app"
+	"github.com/trianalab/pacto/v2/internal/app"
 )
 
 func newPullCommand(svc *app.Service, v *viper.Viper) *cobra.Command {

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/trianalab/pacto/internal/app"
+	"github.com/trianalab/pacto/v2/internal/app"
 )
 
 func newPushCommand(svc *app.Service, v *viper.Viper) *cobra.Command {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/trianalab/pacto/internal/app"
-	"github.com/trianalab/pacto/internal/logger"
-	"github.com/trianalab/pacto/internal/update"
+	"github.com/trianalab/pacto/v2/internal/app"
+	"github.com/trianalab/pacto/v2/internal/logger"
+	"github.com/trianalab/pacto/v2/internal/update"
 )
 
 const outputFormatKey = "output-format"

--- a/internal/cli/root_internal_test.go
+++ b/internal/cli/root_internal_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/trianalab/pacto/internal/app"
-	"github.com/trianalab/pacto/internal/update"
+	"github.com/trianalab/pacto/v2/internal/app"
+	"github.com/trianalab/pacto/v2/internal/update"
 )
 
 func TestNewRootCommand_PanicRecovery(t *testing.T) {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/trianalab/pacto/internal/update"
+	"github.com/trianalab/pacto/v2/internal/update"
 )
 
 func newUpdateCommand(version string) *cobra.Command {

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/trianalab/pacto/internal/app"
+	"github.com/trianalab/pacto/v2/internal/app"
 )
 
 func newValidateCommand(svc *app.Service, v *viper.Viper) *cobra.Command {

--- a/internal/mcp/create.go
+++ b/internal/mcp/create.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/validation"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/validation"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/mcp/create_test.go
+++ b/internal/mcp/create_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/internal/app"
-	"github.com/trianalab/pacto/internal/testutil"
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/internal/app"
+	"github.com/trianalab/pacto/v2/internal/testutil"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func TestCreate_Minimal(t *testing.T) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/trianalab/pacto/internal/app"
+	"github.com/trianalab/pacto/v2/internal/app"
 )
 
 // NewServer creates a new MCP server with all Pacto tools registered.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/trianalab/pacto/pkg/validation"
+	"github.com/trianalab/pacto/v2/pkg/validation"
 )
 
 // --- pacto_create ---

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/trianalab/pacto/internal/app"
-	"github.com/trianalab/pacto/internal/testutil"
+	"github.com/trianalab/pacto/v2/internal/app"
+	"github.com/trianalab/pacto/v2/internal/testutil"
 )
 
 // callTool connects an MCP client to the server and calls the named tool.

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/plugin"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/plugin"
 )
 
 // MockBundleStore implements oci.BundleStore for testing.

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 // CheckResult holds the outcome of a version check.

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 // errorTransport is an http.RoundTripper that always returns a connection error.

--- a/pkg/contract/errors_test.go
+++ b/pkg/contract/errors_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func TestParseError_Error_WithPath(t *testing.T) {

--- a/pkg/contract/ociref_test.go
+++ b/pkg/contract/ociref_test.go
@@ -3,7 +3,7 @@ package contract_test
 import (
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 // hex64 is a syntactically valid 64-char lowercase hex sha256 digest body.

--- a/pkg/contract/parse_test.go
+++ b/pkg/contract/parse_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func TestParse_ValidMinimal(t *testing.T) {

--- a/pkg/contract/range_test.go
+++ b/pkg/contract/range_test.go
@@ -3,7 +3,7 @@ package contract_test
 import (
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func TestParseRange(t *testing.T) {

--- a/pkg/dashboard/detect.go
+++ b/pkg/dashboard/detect.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 // userHomeDir is a package-level variable so tests can override os.UserHomeDir.

--- a/pkg/dashboard/graph.go
+++ b/pkg/dashboard/graph.go
@@ -3,7 +3,7 @@ package dashboard
 import (
 	"strings"
 
-	depgraph "github.com/trianalab/pacto/pkg/graph"
+	depgraph "github.com/trianalab/pacto/v2/pkg/graph"
 )
 
 // DependentInfo describes a service that depends on another service.

--- a/pkg/dashboard/lock.go
+++ b/pkg/dashboard/lock.go
@@ -5,7 +5,7 @@ import (
 	"io/fs"
 	"strings"
 
-	"github.com/trianalab/pacto/pkg/lock"
+	"github.com/trianalab/pacto/v2/pkg/lock"
 )
 
 // Drift status values for a locked dependency edge.

--- a/pkg/dashboard/lock_test.go
+++ b/pkg/dashboard/lock_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/lock"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/lock"
 )
 
 const sampleLockYAML = `lockVersion: 1

--- a/pkg/dashboard/mapping.go
+++ b/pkg/dashboard/mapping.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/diff"
-	"github.com/trianalab/pacto/pkg/doc"
-	"github.com/trianalab/pacto/pkg/graph"
-	"github.com/trianalab/pacto/pkg/readiness"
-	"github.com/trianalab/pacto/pkg/schemax"
-	"github.com/trianalab/pacto/pkg/validation"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/diff"
+	"github.com/trianalab/pacto/v2/pkg/doc"
+	"github.com/trianalab/pacto/v2/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/readiness"
+	"github.com/trianalab/pacto/v2/pkg/schemax"
+	"github.com/trianalab/pacto/v2/pkg/validation"
 )
 
 // timeNow is the clock used to derive readiness freshness. It is a variable so

--- a/pkg/dashboard/mapping_test.go
+++ b/pkg/dashboard/mapping_test.go
@@ -8,10 +8,10 @@ import (
 	"testing/fstest"
 	"time"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/diff"
-	"github.com/trianalab/pacto/pkg/graph"
-	"github.com/trianalab/pacto/pkg/validation"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/diff"
+	"github.com/trianalab/pacto/v2/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/validation"
 )
 
 func TestServiceFromContract(t *testing.T) {

--- a/pkg/dashboard/model.go
+++ b/pkg/dashboard/model.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/schemax"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/schemax"
 )
 
 // ContractStatus represents the contract compliance status of a service.

--- a/pkg/dashboard/resolve_e2e_test.go
+++ b/pkg/dashboard/resolve_e2e_test.go
@@ -12,8 +12,8 @@ import (
 	"testing/fstest"
 	"time"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 // pullCountingStore tracks pull calls and returns a configurable bundle.

--- a/pkg/dashboard/sectionmeta_test.go
+++ b/pkg/dashboard/sectionmeta_test.go
@@ -3,7 +3,7 @@ package dashboard
 import (
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func sectionState(d *ServiceDetails, id string) SectionInfo { return d.SectionMeta[id] }

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 // Server serves the dashboard web UI and REST API.

--- a/pkg/dashboard/server_test.go
+++ b/pkg/dashboard/server_test.go
@@ -13,8 +13,8 @@ import (
 	"testing/fstest"
 	"time"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 type mockSource struct {

--- a/pkg/dashboard/source_cache.go
+++ b/pkg/dashboard/source_cache.go
@@ -17,8 +17,8 @@ import (
 	"sync"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/semver"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/semver"
 )
 
 // CacheSource implements DataSource by reading materialized OCI bundles from

--- a/pkg/dashboard/source_k8s.go
+++ b/pkg/dashboard/source_k8s.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/semver"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/semver"
 )
 
 // K8sSource implements DataSource by reading Pacto CRD status from a Kubernetes cluster.

--- a/pkg/dashboard/source_k8s_test.go
+++ b/pkg/dashboard/source_k8s_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 // ---------------------------------------------------------------------------

--- a/pkg/dashboard/source_local.go
+++ b/pkg/dashboard/source_local.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 const contractFile = "pacto.yaml"

--- a/pkg/dashboard/source_oci.go
+++ b/pkg/dashboard/source_oci.go
@@ -10,9 +10,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/oci"
-	"github.com/trianalab/pacto/pkg/semver"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/semver"
 )
 
 // ociRediscoverInterval controls how often background discovery re-runs

--- a/pkg/dashboard/source_oci_test.go
+++ b/pkg/dashboard/source_oci_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 // mockBundleStore implements oci.BundleStore for testing.

--- a/pkg/dashboard/source_resolver.go
+++ b/pkg/dashboard/source_resolver.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/trianalab/pacto/pkg/semver"
+	"github.com/trianalab/pacto/v2/pkg/semver"
 )
 
 // ResolvedSource implements DataSource by combining a contract source

--- a/pkg/dashboard/source_resolver_test.go
+++ b/pkg/dashboard/source_resolver_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 type stubSource struct {

--- a/pkg/dashboard/version_classify.go
+++ b/pkg/dashboard/version_classify.go
@@ -1,8 +1,8 @@
 package dashboard
 
 import (
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/diff"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/diff"
 )
 
 // BundlePair associates a version tag with its parsed bundle for classification.

--- a/pkg/dashboard/version_tracking.go
+++ b/pkg/dashboard/version_tracking.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 // Version policy constants describe how a service tracks its contract version.

--- a/pkg/diff/contract.go
+++ b/pkg/diff/contract.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"fmt"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 // diffContract compares root-level fields: service identity, scaling, metadata.

--- a/pkg/diff/contract_test.go
+++ b/pkg/diff/contract_test.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func TestDiffScaling_BothNil(t *testing.T) {

--- a/pkg/diff/dependency.go
+++ b/pkg/diff/dependency.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"strconv"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 // diffDependencies compares dependency lists between old and new contracts by name.

--- a/pkg/diff/dependency_test.go
+++ b/pkg/diff/dependency_test.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func TestDiffDependencies_Added(t *testing.T) {

--- a/pkg/diff/engine.go
+++ b/pkg/diff/engine.go
@@ -5,8 +5,8 @@ import (
 	"io/fs"
 	"log/slog"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/sbom"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/sbom"
 )
 
 // Classification represents the severity of a change.

--- a/pkg/diff/engine_test.go
+++ b/pkg/diff/engine_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func minimalContract() *contract.Contract {

--- a/pkg/diff/interfaces.go
+++ b/pkg/diff/interfaces.go
@@ -3,8 +3,8 @@ package diff
 import (
 	"io/fs"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/validation"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/validation"
 )
 
 // diffInterfaces compares interface lists and delegates to OpenAPI diff

--- a/pkg/diff/interfaces_test.go
+++ b/pkg/diff/interfaces_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func TestDiffInterfaces_TypeChanged(t *testing.T) {

--- a/pkg/diff/runtime.go
+++ b/pkg/diff/runtime.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 // diffRuntime compares runtime semantics: workload, state, persistence,

--- a/pkg/diff/runtime_test.go
+++ b/pkg/diff/runtime_test.go
@@ -3,7 +3,7 @@ package diff
 import (
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func TestDiffLifecycle_BothNil(t *testing.T) {

--- a/pkg/doc/generate.go
+++ b/pkg/doc/generate.go
@@ -9,9 +9,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/graph"
-	"github.com/trianalab/pacto/pkg/validation"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/validation"
 )
 
 // sectionNumberer tracks hierarchical section numbers (1, 1.1, 1.1.1, etc.).

--- a/pkg/doc/generate_test.go
+++ b/pkg/doc/generate_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/graph"
 )
 
 func intPtr(v int) *int { return &v }

--- a/pkg/doc/swagger.go
+++ b/pkg/doc/swagger.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 
 	"gopkg.in/yaml.v3"
 )

--- a/pkg/doc/swagger_test.go
+++ b/pkg/doc/swagger_test.go
@@ -13,7 +13,7 @@ import (
 	"testing/fstest"
 	"time"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func TestCollectSwaggerSpecs(t *testing.T) {

--- a/pkg/graph/resolver.go
+++ b/pkg/graph/resolver.go
@@ -9,7 +9,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 // ContractFetcher fetches a contract bundle for a dependency.

--- a/pkg/graph/resolver_test.go
+++ b/pkg/graph/resolver_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 // mockFetcher returns pre-configured contracts by ref.

--- a/pkg/oci/bundle.go
+++ b/pkg/oci/bundle.go
@@ -16,7 +16,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/stream"
 	"github.com/google/go-containerregistry/pkg/v1/types"
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 const (

--- a/pkg/oci/bundle_test.go
+++ b/pkg/oci/bundle_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 type tarErrWriter struct{}

--- a/pkg/oci/cache.go
+++ b/pkg/oci/cache.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 // CachedStore wraps a BundleStore with in-memory and disk caching. Pulled

--- a/pkg/oci/cache_test.go
+++ b/pkg/oci/cache_test.go
@@ -13,8 +13,8 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 type countingStore struct {

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 // BundleStore handles push and pull of contract bundles to/from OCI registries.

--- a/pkg/oci/client_internal_test.go
+++ b/pkg/oci/client_internal_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func TestClient_Push_BuildImageError(t *testing.T) {

--- a/pkg/oci/client_test.go
+++ b/pkg/oci/client_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 func newTestClient(t *testing.T) (*oci.Client, string) {

--- a/pkg/oci/credentials_test.go
+++ b/pkg/oci/credentials_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 func TestNewKeychain_WithToken(t *testing.T) {

--- a/pkg/oci/resolve_test.go
+++ b/pkg/oci/resolve_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 func TestHasExplicitTag(t *testing.T) {

--- a/pkg/oci/resolver.go
+++ b/pkg/oci/resolver.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/semver"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/semver"
 )
 
 // ResolveMode controls whether remote fetching is allowed.

--- a/pkg/oci/resolver_test.go
+++ b/pkg/oci/resolver_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/oci"
 )
 
 // mockStore implements oci.BundleStore for resolver tests.

--- a/pkg/plugin/protocol.go
+++ b/pkg/plugin/protocol.go
@@ -1,6 +1,6 @@
 package plugin
 
-import "github.com/trianalab/pacto/pkg/contract"
+import "github.com/trianalab/pacto/v2/pkg/contract"
 
 // ProtocolVersion is the current plugin protocol version.
 const ProtocolVersion = "1"

--- a/pkg/readiness/readiness.go
+++ b/pkg/readiness/readiness.go
@@ -10,7 +10,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 const (

--- a/pkg/readiness/readiness_test.go
+++ b/pkg/readiness/readiness_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 var refNow = time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)

--- a/pkg/validation/crossfield.go
+++ b/pkg/validation/crossfield.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/santhosh-tekuri/jsonschema/v6"
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/graph"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/graph"
 	"gopkg.in/yaml.v3"
 )
 

--- a/pkg/validation/crossfield_test.go
+++ b/pkg/validation/crossfield_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func validContract() *contract.Contract {

--- a/pkg/validation/policy.go
+++ b/pkg/validation/policy.go
@@ -8,7 +8,7 @@ import (
 	"slices"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 // ResolvedPolicy holds a compiled policy schema and its origin for error reporting.

--- a/pkg/validation/policy_test.go
+++ b/pkg/validation/policy_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 // mockBundleResolver implements BundleResolver for tests.

--- a/pkg/validation/result.go
+++ b/pkg/validation/result.go
@@ -1,6 +1,6 @@
 package validation
 
-import "github.com/trianalab/pacto/pkg/contract"
+import "github.com/trianalab/pacto/v2/pkg/contract"
 
 // ValidationResult aggregates errors and warnings from all validation layers.
 type ValidationResult struct {

--- a/pkg/validation/runtime.go
+++ b/pkg/validation/runtime.go
@@ -3,7 +3,7 @@ package validation
 import (
 	"fmt"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 // RuntimeContext represents observed runtime state collected from the

--- a/pkg/validation/runtime_test.go
+++ b/pkg/validation/runtime_test.go
@@ -3,8 +3,8 @@ package validation_test
 import (
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/validation"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/validation"
 )
 
 func intPtr(v int) *int { return &v }

--- a/pkg/validation/semantic.go
+++ b/pkg/validation/semantic.go
@@ -1,7 +1,7 @@
 package validation
 
 import (
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 // ValidateSemantic performs Layer 3 validation: semantic consistency checks

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 	"gopkg.in/yaml.v3"
 )
 

--- a/pkg/validation/validator_internal_test.go
+++ b/pkg/validation/validator_internal_test.go
@@ -3,7 +3,7 @@ package validation
 import (
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 func TestYamlToGeneric_InvalidYAML(t *testing.T) {

--- a/pkg/validation/validator_test.go
+++ b/pkg/validation/validator_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/trianalab/pacto/pkg/contract"
-	"github.com/trianalab/pacto/pkg/validation"
+	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/validation"
 )
 
 // testBundleResolver implements validation.BundleResolver for external tests.

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
-	"github.com/trianalab/pacto/internal/app"
-	"github.com/trianalab/pacto/internal/cli"
-	"github.com/trianalab/pacto/pkg/oci"
-	"github.com/trianalab/pacto/pkg/plugin"
+	"github.com/trianalab/pacto/v2/internal/app"
+	"github.com/trianalab/pacto/v2/internal/cli"
+	"github.com/trianalab/pacto/v2/pkg/oci"
+	"github.com/trianalab/pacto/v2/pkg/plugin"
 )
 
 // chdirMu serialises tests that need to change the working directory so they

--- a/tests/e2e/lock_test.go
+++ b/tests/e2e/lock_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/lock"
+	"github.com/trianalab/pacto/v2/pkg/lock"
 )
 
 // readLock parses the pacto.lock written next to a local contract dir.

--- a/tests/e2e/mcp_test.go
+++ b/tests/e2e/mcp_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/trianalab/pacto/internal/app"
-	pactomcp "github.com/trianalab/pacto/internal/mcp"
+	"github.com/trianalab/pacto/v2/internal/app"
+	pactomcp "github.com/trianalab/pacto/v2/internal/mcp"
 )
 
 // mcpCallTool sets up an in-memory MCP server+client and calls the named tool.

--- a/tests/e2e/policy_test.go
+++ b/tests/e2e/policy_test.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/trianalab/pacto/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/contract"
 )
 
 // pushRawBundle pushes a bundle directly via the OCI client, bypassing the CLI's


### PR DESCRIPTION
## Problem
The v1.2 contract changes (#198) were auto-released as **v2.0.0**, but the Go module path was never updated to the required `/v2` suffix. Per Go's module rules a v2+ tag on a v1 module path is **uninstallable**:
- `go get github.com/trianalab/pacto@v2.0.0` → rejected ("module path must match major version github.com/trianalab/pacto/v2")
- `go get github.com/trianalab/pacto@latest` → silently returns the old **v1.10.0**

So no downstream consumer (the operator, pacto-actions, anyone importing `pkg/oci`) can actually pull the v1.2 code.

## Change
- `go.mod`: `module github.com/trianalab/pacto` → `github.com/trianalab/pacto/v2`.
- Rewrite all internal import paths `github.com/trianalab/pacto/…` → `github.com/trianalab/pacto/v2/…` (140 Go files). Mechanical; no behavior change.

## Verification
- `go build ./...`, `go vet ./...` clean.
- `make ci-test`: **100.0%** coverage, examples pass.
- `make ci-static`: fmt, vet, cyclo, lint, docs and committed-UI drift all green (the dashboard build is unaffected by a Go-only change).

## Release / follow-ups
- Titled `fix:` so Auto release tags **v2.0.1** on this `/v2` commit — the first *installable* v2 (the dangling v2.0.0 tag points at a v1-path commit and is invisible to the `/v2` module).
- The broken **v2.0.0** GitHub release/tag should be deleted (or marked) for cleanliness.
- Downstream consumers must move to `/v2` import paths: **pacto-operator** (PR incoming), `pacto-actions`, `pacto-plugins`, and any external importers of `pkg/oci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)