### PR TITLE
ci(docs): redeploy demo after Auto release completes (fix stale navbar version)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,10 +10,20 @@ on:
       # The demo embeds the dashboard UI + engine, so redeploy when they change.
       - 'pkg/dashboard/**'
       - '.github/workflows/docs.yml'
-  # Redeploy on every published release. The demo bakes in the Pacto version via
-  # `git describe` at build time; the release tag is created moments AFTER the
-  # merge-to-main push that triggered the path-filtered build above, so that
-  # build still saw the previous tag. This re-runs once the new tag exists.
+  # The demo bakes in the Pacto version via `git describe` at build time. The
+  # merge-to-main push above runs ~seconds BEFORE Auto release creates the tag,
+  # so it bakes the PREVIOUS version. We must redeploy once the new tag exists.
+  #
+  # Auto release creates the GitHub release with the default GITHUB_TOKEN, and
+  # GitHub does NOT fire the `release` event for token-created releases (anti-
+  # recursion) — so an `on: release` trigger never runs for our automated tags.
+  # Instead, redeploy when the "Auto release" workflow itself COMPLETES: by then
+  # the tag exists and `git describe` resolves it. `workflow_run` is not subject
+  # to the token restriction.
+  workflow_run:
+    workflows: ["Auto release"]
+    types: [completed]
+  # Still covers releases published manually by a human (those DO fire `release`).
   release:
     types: [published]
   workflow_dispatch:
@@ -30,6 +40,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # On the workflow_run trigger, only deploy when Auto release actually
+    # succeeded (skip cancelled/failed release runs). All other triggers proceed.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v7.0.0
         # Full history + tags so the demo build's `git describe` resolves the
@@ -56,6 +69,23 @@ jobs:
         run: make -C examples/demo build BASE=/pacto/demo/
       - name: Smoke test the wasm engine
         run: make -C examples/demo smoke
+      # Guardrail: on a release-driven deploy the baked navbar version MUST match
+      # the latest published release. If it doesn't (e.g. `git describe` resolved
+      # a stale tag), fail loudly instead of silently shipping the wrong version.
+      # Skipped on plain `push`/`workflow_dispatch`, where the build may
+      # intentionally predate the tag.
+      - name: Guardrail — baked demo version matches the latest release
+        if: ${{ github.event_name == 'workflow_run' || github.event_name == 'release' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          baked="$(jq -r .version examples/demo/dist/version.json)"
+          latest="$(gh release view --json tagName -q .tagName)"
+          echo "baked navbar version: '$baked' · latest release: '$latest'"
+          if [ "${baked#v}" != "${latest#v}" ]; then
+            echo "::error::Demo navbar version '$baked' != latest release '$latest' — stale demo deploy."
+            exit 1
+          fi
       - name: Fold the demo into the docs site
         run: |
           mkdir -p site/demo


### PR DESCRIPTION
## Problem
The deployed WASM demo navbar showed **v2.0.0** even after **v2.1.0** shipped.

The demo bakes the Pacto version via `git describe` at build time. On merge to `main`, docs.yml builds the demo via the `push` trigger — but that runs **~seconds before** `Auto release` creates the tag, so `git describe` resolves the *previous* tag.

The `on: release` redeploy added in #195 was meant to fix this, but it **never fires**: `Auto release` creates the release with the default `GITHUB_TOKEN`, and GitHub does not trigger workflows from token-created events (anti-recursion). docs.yml run history confirms it only ever ran on `push`/`workflow_dispatch` — never `release`.

## Fix
- **`on: workflow_run` for "Auto release"** — not subject to the token restriction, so the demo redeploys once Auto release *completes*; by then the tag exists and `git describe` resolves it. Build job gated on `conclusion == 'success'`.
- Keep **`on: release`** for releases a human publishes manually (those do fire).
- **Real guardrail step**: on release/workflow_run deploys, assert the baked `version.json` matches the latest published release and **fail loudly** otherwise — so a stale demo can never ship silently again.

## Notes
- YAML validated; no behavior change for normal `push`/`workflow_dispatch` deploys.
- This complements the manual `workflow_dispatch` rerun already done for v2.1.0.