### PR TITLE
fix(diff): granular field diffing + complete classification coverage

### DIFF
--- a/docs/contract-reference.md
+++ b/docs/contract-reference.md
@@ -1284,11 +1284,21 @@ Each change is classified as:
 
 | Field | Change | Classification |
 |-------|--------|----------------|
+| `pactoVersion` | Added / Modified / Removed | NON_BREAKING |
 | `service.name` | Modified | **BREAKING** |
 | `service.version` | Modified | NON_BREAKING |
-| `service.owner` | Added / Modified / Removed | NON_BREAKING |
+| `service.owner.team` | Added / Modified / Removed | NON_BREAKING |
+| `service.owner.dri` | Added / Modified / Removed | NON_BREAKING |
+| `service.owner.contacts[]` | Added / Modified / Removed | NON_BREAKING |
 | `service.image` | Added / Modified / Removed | NON_BREAKING |
 | `service.chart` | Added / Modified / Removed | NON_BREAKING |
+
+The owner block is compared field by field, so changing a `dri` or adding a
+contact while the `team` is unchanged surfaces the specific change rather than an
+opaque whole-owner modification. Contacts are keyed by `type:value`; a `purpose`
+change on an existing contact is a modification. The `service.image` comparison
+includes the `private` flag, so toggling image privacy is reported even when the
+`ref` is unchanged.
 
 ### Interfaces
 
@@ -1315,6 +1325,11 @@ Each change is classified as:
 | `configurations[].ref` | Added | NON_BREAKING |
 | `configurations[].ref` | Modified | POTENTIAL_BREAKING |
 | `configurations[].ref` | Removed | **BREAKING** |
+| `configurations[].values.*` | Added / Modified / Removed | NON_BREAKING |
+
+Inline configuration `values` are the provider's own defaults, not part of the
+consumer-facing contract surface, so value changes are diffed key by key (e.g.
+`configurations[app].values.replicas`) and classified `NON_BREAKING`.
 
 ### Policy
 
@@ -1339,7 +1354,7 @@ Each change is classified as:
 | `runtime.lifecycle.upgradeStrategy` | Added | NON_BREAKING |
 | `runtime.lifecycle.upgradeStrategy` | Modified | POTENTIAL_BREAKING |
 | `runtime.lifecycle.upgradeStrategy` | Removed | POTENTIAL_BREAKING |
-| `runtime.lifecycle.gracefulShutdownSeconds` | Modified | NON_BREAKING |
+| `runtime.lifecycle.gracefulShutdownSeconds` | Added / Modified / Removed | NON_BREAKING |
 | `runtime.health.interface` | Added | NON_BREAKING |
 | `runtime.health.interface` | Modified | POTENTIAL_BREAKING |
 | `runtime.health.interface` | Removed | POTENTIAL_BREAKING |
@@ -1376,6 +1391,7 @@ add or remove surfaces as the corresponding per-field changes.
 |-------|--------|----------------|
 | `dependencies` | Added | NON_BREAKING |
 | `dependencies` | Removed | **BREAKING** |
+| `dependencies.ref` | Modified | POTENTIAL_BREAKING |
 | `dependencies.compatibility` | Modified | POTENTIAL_BREAKING |
 | `dependencies.required` | Modified | POTENTIAL_BREAKING |
 
@@ -1447,19 +1463,21 @@ Schema files referenced by `configurations[].schema`, `policies[].schema`, or th
 
 | Field | Change | Classification |
 |-------|--------|----------------|
+| `readiness` | Added / Removed | NON_BREAKING |
 | `readiness.expires` | Added / Modified / Removed | NON_BREAKING |
 | `readiness.minScore` | Added / Modified / Removed | NON_BREAKING |
 | `readiness.partialCredit` | Added / Modified / Removed | NON_BREAKING |
-| `readiness.checks[]` | Added | NON_BREAKING |
-| `readiness.checks[]` | Removed | NON_BREAKING |
-| `readiness.checks[].status` | Modified | NON_BREAKING |
-| `readiness.checks[].category` | Added / Modified / Removed | NON_BREAKING |
-| `readiness.checks[].weight` | Modified | NON_BREAKING |
-| `readiness.checks[].description` | Added / Modified / Removed | NON_BREAKING |
-| `readiness.history[]` | Added / Modified / Removed | NON_BREAKING |
+| `readiness.checks[]` | Added / Modified / Removed | NON_BREAKING |
 
 All readiness changes are classified as `NON_BREAKING` — readiness tracks operational
-maturity and does not affect runtime compatibility.
+maturity and does not affect runtime compatibility. Adding or removing the whole
+`readiness` block surfaces as a single `readiness` change; otherwise the gate
+fields (`expires`, `minScore`, `partialCredit`) are compared individually. Checks
+are keyed by `id`, and a check whose `status`, `weight`, `evidence` or any other
+field changed is reported as a modification of that check (e.g.
+`readiness.checks[dashboard]`). The `readiness.history` revision log is not diffed:
+it is an append-only changelog that changes on every release and would only add
+noise.
 
 ### Not currently compared
 

--- a/pkg/diff/classification.go
+++ b/pkg/diff/classification.go
@@ -2,7 +2,7 @@ package diff
 
 import "regexp"
 
-var indexRe = regexp.MustCompile(`\[\d+\]`)
+var indexRe = regexp.MustCompile(`\[[^\]]*\]`)
 
 // classificationKey maps a field path and change type to a classification.
 type classificationKey struct {
@@ -13,18 +13,45 @@ type classificationKey struct {
 // rules is the deterministic lookup table for change classification.
 // Each entry maps (field path, change type) → classification.
 var rules = map[classificationKey]Classification{
+	// Schema version
+	{"pactoVersion", Modified}: NonBreaking,
+	{"pactoVersion", Added}:    NonBreaking,
+	{"pactoVersion", Removed}:  NonBreaking,
+
 	// Service identity
-	{"service.name", Modified}:    Breaking,
-	{"service.version", Modified}: NonBreaking,
-	{"service.owner", Modified}:   NonBreaking,
-	{"service.owner", Added}:      NonBreaking,
-	{"service.owner", Removed}:    NonBreaking,
-	{"service.image", Modified}:   NonBreaking,
-	{"service.image", Added}:      NonBreaking,
-	{"service.image", Removed}:    NonBreaking,
-	{"service.chart", Modified}:   NonBreaking,
-	{"service.chart", Added}:      NonBreaking,
-	{"service.chart", Removed}:    NonBreaking,
+	{"service.name", Modified}:           Breaking,
+	{"service.version", Modified}:        NonBreaking,
+	{"service.owner.team", Modified}:     NonBreaking,
+	{"service.owner.team", Added}:        NonBreaking,
+	{"service.owner.team", Removed}:      NonBreaking,
+	{"service.owner.dri", Modified}:      NonBreaking,
+	{"service.owner.dri", Added}:         NonBreaking,
+	{"service.owner.dri", Removed}:       NonBreaking,
+	{"service.owner.contacts", Modified}: NonBreaking,
+	{"service.owner.contacts", Added}:    NonBreaking,
+	{"service.owner.contacts", Removed}:  NonBreaking,
+	{"service.image", Modified}:          NonBreaking,
+	{"service.image", Added}:             NonBreaking,
+	{"service.image", Removed}:           NonBreaking,
+	{"service.chart", Modified}:          NonBreaking,
+	{"service.chart", Added}:             NonBreaking,
+	{"service.chart", Removed}:           NonBreaking,
+
+	// Readiness — operational maturity, never consumer-facing.
+	{"readiness", Added}:                  NonBreaking,
+	{"readiness", Removed}:                NonBreaking,
+	{"readiness.minScore", Modified}:      NonBreaking,
+	{"readiness.minScore", Added}:         NonBreaking,
+	{"readiness.minScore", Removed}:       NonBreaking,
+	{"readiness.expires", Modified}:       NonBreaking,
+	{"readiness.expires", Added}:          NonBreaking,
+	{"readiness.expires", Removed}:        NonBreaking,
+	{"readiness.partialCredit", Modified}: NonBreaking,
+	{"readiness.partialCredit", Added}:    NonBreaking,
+	{"readiness.partialCredit", Removed}:  NonBreaking,
+	{"readiness.checks", Added}:           NonBreaking,
+	{"readiness.checks", Removed}:         NonBreaking,
+	{"readiness.checks", Modified}:        NonBreaking,
 
 	// Interfaces
 	{"interfaces", Added}:   NonBreaking,
@@ -70,6 +97,8 @@ var rules = map[classificationKey]Classification{
 	{"runtime.lifecycle.upgradeStrategy", Added}:            NonBreaking,
 	{"runtime.lifecycle.upgradeStrategy", Removed}:          PotentialBreaking,
 	{"runtime.lifecycle.gracefulShutdownSeconds", Modified}: NonBreaking,
+	{"runtime.lifecycle.gracefulShutdownSeconds", Added}:    NonBreaking,
+	{"runtime.lifecycle.gracefulShutdownSeconds", Removed}:  NonBreaking,
 
 	// Runtime — health (adding a health declaration is a new capability;
 	// removing one loses a runtime check, so potentially breaking).
@@ -92,10 +121,11 @@ var rules = map[classificationKey]Classification{
 	{"runtime.metrics.path", Removed}:       PotentialBreaking,
 
 	// Scaling
-	{"scaling.min", Modified}: PotentialBreaking,
-	{"scaling.max", Modified}: NonBreaking,
-	{"scaling", Added}:        NonBreaking,
-	{"scaling", Removed}:      PotentialBreaking,
+	{"scaling.replicas", Modified}: PotentialBreaking,
+	{"scaling.min", Modified}:      PotentialBreaking,
+	{"scaling.max", Modified}:      NonBreaking,
+	{"scaling", Added}:             NonBreaking,
+	{"scaling", Removed}:           PotentialBreaking,
 
 	// Dependencies (name-indexed)
 	{"dependencies", Added}:                  NonBreaking,
@@ -129,8 +159,9 @@ var rules = map[classificationKey]Classification{
 }
 
 // classify returns the classification for a given path and change type.
-// Indexed paths like "configs[0].schema" are normalised to "configs.schema"
-// before lookup. Unknown paths default to PotentialBreaking.
+// Bracketed keys like "configs[0].schema" or "service.owner.contacts[slack:#c]"
+// are normalised to "configs.schema" / "service.owner.contacts" before lookup.
+// Unknown paths default to PotentialBreaking.
 func classify(path string, ct ChangeType) Classification {
 	if c, ok := rules[classificationKey{path, ct}]; ok {
 		return c

--- a/pkg/diff/classification_test.go
+++ b/pkg/diff/classification_test.go
@@ -86,6 +86,41 @@ func TestChangeType_MarshalJSON(t *testing.T) {
 	}
 }
 
+// TestClassify_Completeness locks the classification for every (path, change
+// type) the diff engine can actually emit, so no emitted change silently falls
+// through to the PotentialBreaking default with an unintended severity.
+func TestClassify_Completeness(t *testing.T) {
+	tests := []struct {
+		path string
+		ct   ChangeType
+		want Classification
+	}{
+		// Schema version
+		{"pactoVersion", Modified, NonBreaking},
+
+		// Owner subfields
+		{"service.owner.team", Modified, NonBreaking},
+		{"service.owner.dri", Added, NonBreaking},
+		{"service.owner.contacts", Added, NonBreaking},
+		{"service.owner.contacts[slack:#x]", Added, NonBreaking},
+
+		// Lifecycle gracefulShutdownSeconds — operational, NonBreaking for all.
+		{"runtime.lifecycle.gracefulShutdownSeconds", Added, NonBreaking},
+		{"runtime.lifecycle.gracefulShutdownSeconds", Modified, NonBreaking},
+		{"runtime.lifecycle.gracefulShutdownSeconds", Removed, NonBreaking},
+
+		// Scaling replicas — explicit, not relying on the default.
+		{"scaling.replicas", Modified, PotentialBreaking},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path+"_"+tt.ct.String(), func(t *testing.T) {
+			if got := classify(tt.path, tt.ct); got != tt.want {
+				t.Errorf("classify(%q, %s) = %s, want %s", tt.path, tt.ct, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestClassify_UnknownPath(t *testing.T) {
 	got := classify("unknown.path", Modified)
 	if got != PotentialBreaking {

--- a/pkg/diff/contract.go
+++ b/pkg/diff/contract.go
@@ -10,6 +10,11 @@ import (
 func diffContract(old, new *contract.Contract) []Change {
 	var changes []Change
 
+	// Schema version
+	if old.PactoVersion != new.PactoVersion {
+		changes = append(changes, newChange("pactoVersion", strChangeType(old.PactoVersion, new.PactoVersion), old.PactoVersion, new.PactoVersion))
+	}
+
 	// Service identity
 	if old.Service.Name != new.Service.Name {
 		changes = append(changes, newChange("service.name", Modified, old.Service.Name, new.Service.Name))
@@ -17,15 +22,7 @@ func diffContract(old, new *contract.Contract) []Change {
 	if old.Service.Version != new.Service.Version {
 		changes = append(changes, newChange("service.version", Modified, old.Service.Version, new.Service.Version))
 	}
-	if !old.Service.Owner.Equal(new.Service.Owner) {
-		ct := Modified
-		if old.Service.Owner.IsEmpty() {
-			ct = Added
-		} else if new.Service.Owner.IsEmpty() {
-			ct = Removed
-		}
-		changes = append(changes, newChange("service.owner", ct, old.Service.Owner.DisplayString(), new.Service.Owner.DisplayString()))
-	}
+	changes = append(changes, diffOwner(old.Service.Owner, new.Service.Owner)...)
 
 	// Image
 	oldImg := formatImage(old.Service.Image)
@@ -57,6 +54,67 @@ func diffContract(old, new *contract.Contract) []Change {
 	changes = append(changes, diffScaling(old.Scaling, new.Scaling)...)
 
 	return changes
+}
+
+// diffOwner emits granular per-subfield changes for the ownership block so that,
+// e.g., adding a contact while the team is unchanged surfaces the contact change
+// instead of an opaque "team -> team" modification.
+func diffOwner(old, new contract.Owner) []Change {
+	var changes []Change
+
+	if old.Team != new.Team {
+		changes = append(changes, newChange("service.owner.team", strChangeType(old.Team, new.Team), old.Team, new.Team))
+	}
+	if old.DRI != new.DRI {
+		changes = append(changes, newChange("service.owner.dri", strChangeType(old.DRI, new.DRI), old.DRI, new.DRI))
+	}
+	changes = append(changes, diffContacts(old.Contacts, new.Contacts)...)
+
+	return changes
+}
+
+// diffContacts compares ownership contacts keyed by type+value (a contact's
+// natural identity); a purpose change on an existing contact is a modification.
+func diffContacts(old, new []contract.OwnerContact) []Change {
+	var changes []Change
+	oldByKey := indexContacts(old)
+	newByKey := indexContacts(new)
+
+	for k, o := range oldByKey {
+		n, exists := newByKey[k]
+		if !exists {
+			changes = append(changes, newChange(contactPath(k), Removed, formatContact(o), nil))
+			continue
+		}
+		if o.Purpose != n.Purpose {
+			changes = append(changes, newChange(contactPath(k), Modified, formatContact(o), formatContact(n)))
+		}
+	}
+	for k, n := range newByKey {
+		if _, exists := oldByKey[k]; !exists {
+			changes = append(changes, newChange(contactPath(k), Added, nil, formatContact(n)))
+		}
+	}
+	return changes
+}
+
+func indexContacts(contacts []contract.OwnerContact) map[string]contract.OwnerContact {
+	m := make(map[string]contract.OwnerContact, len(contacts))
+	for _, c := range contacts {
+		m[c.Type+":"+c.Value] = c
+	}
+	return m
+}
+
+func contactPath(key string) string {
+	return "service.owner.contacts[" + key + "]"
+}
+
+func formatContact(c contract.OwnerContact) string {
+	if c.Purpose != "" {
+		return c.Type + ":" + c.Value + " (" + c.Purpose + ")"
+	}
+	return c.Type + ":" + c.Value
 }
 
 func diffScaling(old, new *contract.Scaling) []Change {
@@ -110,6 +168,9 @@ func formatScaling(s *contract.Scaling) string {
 func formatImage(img *contract.Image) string {
 	if img == nil {
 		return ""
+	}
+	if img.Private {
+		return img.Ref + " (private)"
 	}
 	return img.Ref
 }

--- a/pkg/diff/contract_test.go
+++ b/pkg/diff/contract_test.go
@@ -131,12 +131,12 @@ func TestDiffContract_OwnerAdded(t *testing.T) {
 	changes := diffContract(old, new)
 	found := false
 	for _, c := range changes {
-		if c.Path == "service.owner" && c.Type == Added {
+		if c.Path == "service.owner.team" && c.Type == Added && c.Classification == NonBreaking {
 			found = true
 		}
 	}
 	if !found {
-		t.Error("expected service.owner Added change")
+		t.Error("expected service.owner.team Added change")
 	}
 }
 
@@ -148,12 +148,118 @@ func TestDiffContract_OwnerRemoved(t *testing.T) {
 	changes := diffContract(old, new)
 	found := false
 	for _, c := range changes {
-		if c.Path == "service.owner" && c.Type == Removed {
+		if c.Path == "service.owner.team" && c.Type == Removed {
 			found = true
 		}
 	}
 	if !found {
-		t.Error("expected service.owner Removed change")
+		t.Error("expected service.owner.team Removed change")
+	}
+}
+
+// Reproduces the reported bug: team unchanged but a contact added must surface
+// as a granular contact change, not an opaque "team -> team" modification.
+func TestDiffContract_OwnerContactAdded(t *testing.T) {
+	old := minimalContract()
+	old.Service.Owner = contract.Owner{Team: "foundations-team"}
+	new := minimalContract()
+	new.Service.Owner = contract.Owner{
+		Team:     "foundations-team",
+		Contacts: []contract.OwnerContact{{Type: "slack", Value: "#foundations"}},
+	}
+	changes := diffContract(old, new)
+	for _, c := range changes {
+		if c.Path == "service.owner" {
+			t.Errorf("expected no opaque service.owner change, got %+v", c)
+		}
+	}
+	found := false
+	for _, c := range changes {
+		if c.Type == Added && c.Classification == NonBreaking &&
+			c.Path == "service.owner.contacts[slack:#foundations]" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected service.owner.contacts[slack:#foundations] Added, got %+v", changes)
+	}
+}
+
+func TestDiffContract_OwnerTeamModified(t *testing.T) {
+	old := minimalContract()
+	old.Service.Owner = contract.Owner{Team: "team/old"}
+	new := minimalContract()
+	new.Service.Owner = contract.Owner{Team: "team/new"}
+	changes := diffContract(old, new)
+	found := false
+	for _, c := range changes {
+		if c.Path == "service.owner.team" && c.Type == Modified &&
+			c.OldValue == "team/old" && c.NewValue == "team/new" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected service.owner.team Modified, got %+v", changes)
+	}
+}
+
+func TestDiffContract_OwnerDRIAdded(t *testing.T) {
+	old := minimalContract()
+	old.Service.Owner = contract.Owner{Team: "t"}
+	new := minimalContract()
+	new.Service.Owner = contract.Owner{Team: "t", DRI: "alice"}
+	changes := diffContract(old, new)
+	found := false
+	for _, c := range changes {
+		if c.Path == "service.owner.dri" && c.Type == Added && c.NewValue == "alice" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected service.owner.dri Added, got %+v", changes)
+	}
+}
+
+func TestDiffContract_OwnerContactRemoved(t *testing.T) {
+	old := minimalContract()
+	old.Service.Owner = contract.Owner{
+		Team:     "t",
+		Contacts: []contract.OwnerContact{{Type: "email", Value: "a@b.c"}},
+	}
+	new := minimalContract()
+	new.Service.Owner = contract.Owner{Team: "t"}
+	changes := diffContract(old, new)
+	found := false
+	for _, c := range changes {
+		if c.Path == "service.owner.contacts[email:a@b.c]" && c.Type == Removed {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected service.owner.contacts[email:a@b.c] Removed, got %+v", changes)
+	}
+}
+
+func TestDiffContract_OwnerContactPurposeModified(t *testing.T) {
+	old := minimalContract()
+	old.Service.Owner = contract.Owner{
+		Team:     "t",
+		Contacts: []contract.OwnerContact{{Type: "slack", Value: "#c", Purpose: "alerts"}},
+	}
+	new := minimalContract()
+	new.Service.Owner = contract.Owner{
+		Team:     "t",
+		Contacts: []contract.OwnerContact{{Type: "slack", Value: "#c", Purpose: "escalation"}},
+	}
+	changes := diffContract(old, new)
+	found := false
+	for _, c := range changes {
+		if c.Path == "service.owner.contacts[slack:#c]" && c.Type == Modified {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected service.owner.contacts[slack:#c] Modified, got %+v", changes)
 	}
 }
 
@@ -205,6 +311,32 @@ func TestDiffContract_ImageModified(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected service.image Modified change")
+	}
+}
+
+func TestDiffContract_ImagePrivateToggled(t *testing.T) {
+	old := minimalContract()
+	old.Service.Image = &contract.Image{Ref: "ghcr.io/acme/svc:1.0.0", Private: false}
+	new := minimalContract()
+	new.Service.Image = &contract.Image{Ref: "ghcr.io/acme/svc:1.0.0", Private: true}
+	changes := diffContract(old, new)
+	if !hasChange(changes, "service.image", Modified) {
+		t.Errorf("expected service.image Modified for private toggle, got %+v", changes)
+	}
+}
+
+func TestDiffContract_PactoVersionModified(t *testing.T) {
+	old := minimalContract()
+	old.PactoVersion = "1.1"
+	new := minimalContract()
+	new.PactoVersion = "1.2"
+	changes := diffContract(old, new)
+	c, ok := findChange(changes, "pactoVersion", Modified)
+	if !ok {
+		t.Fatalf("expected pactoVersion Modified, got %+v", changes)
+	}
+	if c.Classification != NonBreaking {
+		t.Errorf("expected NonBreaking, got %s", c.Classification)
 	}
 }
 

--- a/pkg/diff/engine.go
+++ b/pkg/diff/engine.go
@@ -90,6 +90,7 @@ func Compare(old, new *contract.Contract, oldFS, newFS fs.FS) *Result {
 	changes = append(changes, diffInterfaces(old, new, oldFS, newFS)...)
 	changes = append(changes, diffConfiguration(old, new, oldFS, newFS)...)
 	changes = append(changes, diffPolicy(old, new, oldFS, newFS)...)
+	changes = append(changes, diffReadiness(old.Readiness, new.Readiness)...)
 
 	overall := NonBreaking
 	for i := range changes {

--- a/pkg/diff/interfaces.go
+++ b/pkg/diff/interfaces.go
@@ -59,15 +59,17 @@ func diffConfiguration(old, new *contract.Contract, oldFS, newFS fs.FS) []Change
 }
 
 // refSource is the common shape of a configuration or policy source (a name with
-// an optional schema and/or ref), used by the shared diff routine.
+// an optional schema and/or ref), used by the shared diff routine. values holds a
+// configuration's inline values (nil for policies).
 type refSource struct {
 	name, schema, ref string
+	values            map[string]any
 }
 
 func configRefSources(cfgs []contract.ConfigurationSource) []refSource {
 	out := make([]refSource, len(cfgs))
 	for i, c := range cfgs {
-		out[i] = refSource{name: c.Name, schema: c.Schema, ref: c.Ref}
+		out[i] = refSource{name: c.Name, schema: c.Schema, ref: c.Ref, values: c.Values}
 	}
 	return out
 }
@@ -110,12 +112,25 @@ func diffRefSources(field string, old, new []refSource, oldFS, newFS fs.FS) []Ch
 		if o.schema != "" && n.schema != "" {
 			changes = append(changes, diffSchema(o.schema, n.schema, oldFS, newFS)...)
 		}
+		// Diff inline configuration values (provider defaults; never consumer-facing).
+		changes = append(changes, diffConfigValues(field, name, o.values, n.values)...)
 	}
 
 	for name, n := range newByName {
 		if _, exists := oldByName[name]; !exists {
 			changes = append(changes, newChange(field, Added, nil, refSourceSummary(n)))
 		}
+	}
+	return changes
+}
+
+// diffConfigValues diffs two inline configuration value maps, reusing the JSON
+// structural diff but reclassifying every change as NonBreaking: values are the
+// provider's own defaults, not part of the consumer-facing contract surface.
+func diffConfigValues(field, name string, old, new map[string]any) []Change {
+	changes := diffJSON(field+"["+name+"].values", old, new)
+	for i := range changes {
+		changes[i].Classification = NonBreaking
 	}
 	return changes
 }

--- a/pkg/diff/interfaces_test.go
+++ b/pkg/diff/interfaces_test.go
@@ -172,6 +172,41 @@ func TestDiffConfiguration_Removed(t *testing.T) {
 	}
 }
 
+func TestDiffConfiguration_ValuesChanged(t *testing.T) {
+	old := minimalContract()
+	old.Configurations = []contract.ConfigurationSource{
+		{Name: "app", Schema: "config/app.json", Values: map[string]any{"replicas": 1, "tier": "free"}},
+	}
+	new := minimalContract()
+	new.Configurations = []contract.ConfigurationSource{
+		{Name: "app", Schema: "config/app.json", Values: map[string]any{"replicas": 3, "tier": "free"}},
+	}
+	changes := diffConfiguration(old, new, nil, nil)
+	found := false
+	for _, c := range changes {
+		if c.Path == "configurations[app].values.replicas" && c.Type == Modified {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected configurations[app].values.replicas Modified, got %+v", changes)
+	}
+}
+
+func TestDiffConfiguration_ValuesUnchanged(t *testing.T) {
+	old := minimalContract()
+	old.Configurations = []contract.ConfigurationSource{
+		{Name: "app", Schema: "config/app.json", Values: map[string]any{"tier": "free"}},
+	}
+	new := minimalContract()
+	new.Configurations = []contract.ConfigurationSource{
+		{Name: "app", Schema: "config/app.json", Values: map[string]any{"tier": "free"}},
+	}
+	if changes := diffConfiguration(old, new, nil, nil); len(changes) != 0 {
+		t.Errorf("expected 0 changes, got %+v", changes)
+	}
+}
+
 func TestDiffConfiguration_SchemaChanged(t *testing.T) {
 	old := minimalContract()
 	old.Configurations = []contract.ConfigurationSource{

--- a/pkg/diff/readiness.go
+++ b/pkg/diff/readiness.go
@@ -1,0 +1,114 @@
+package diff
+
+import (
+	"fmt"
+
+	"github.com/trianalab/pacto/v2/pkg/contract"
+)
+
+// diffReadiness compares the optional readiness assessment. Readiness records
+// operational maturity, not consumer-facing contract surface, so every change is
+// NonBreaking — but changes (a check regressing, the assessment expiring, the
+// gate moving) are still surfaced rather than silently dropped. The revision
+// history is intentionally not diffed: it is an append-only changelog that
+// changes on every release and would only add noise.
+func diffReadiness(old, new *contract.Readiness) []Change {
+	if old == nil && new == nil {
+		return nil
+	}
+	if old == nil {
+		return []Change{newChange("readiness", Added, nil, "readiness")}
+	}
+	if new == nil {
+		return []Change{newChange("readiness", Removed, "readiness", nil)}
+	}
+
+	var changes []Change
+
+	if intPtrChanged(old.MinScore, new.MinScore) {
+		changes = append(changes, newChange("readiness.minScore",
+			intPtrChangeType(old.MinScore, new.MinScore), intPtrVal(old.MinScore), intPtrVal(new.MinScore)))
+	}
+	if old.Expires != new.Expires {
+		changes = append(changes, newChange("readiness.expires", strChangeType(old.Expires, new.Expires), old.Expires, new.Expires))
+	}
+	if floatPtrChanged(old.PartialCredit, new.PartialCredit) {
+		changes = append(changes, newChange("readiness.partialCredit",
+			floatPtrChangeType(old.PartialCredit, new.PartialCredit), floatPtrVal(old.PartialCredit), floatPtrVal(new.PartialCredit)))
+	}
+
+	changes = append(changes, diffReadinessChecks(old.Checks, new.Checks)...)
+
+	return changes
+}
+
+// diffReadinessChecks compares readiness checks keyed by ID (the organizational
+// requirement). A check is a comparable struct, so any field difference makes it
+// Modified, with a formatted summary showing the change.
+func diffReadinessChecks(old, new []contract.ReadinessCheck) []Change {
+	var changes []Change
+	oldByID := indexChecks(old)
+	newByID := indexChecks(new)
+
+	for id, o := range oldByID {
+		n, exists := newByID[id]
+		if !exists {
+			changes = append(changes, newChange(checkPath(id), Removed, formatCheck(o), nil))
+			continue
+		}
+		if o != n {
+			changes = append(changes, newChange(checkPath(id), Modified, formatCheck(o), formatCheck(n)))
+		}
+	}
+	for id, n := range newByID {
+		if _, exists := oldByID[id]; !exists {
+			changes = append(changes, newChange(checkPath(id), Added, nil, formatCheck(n)))
+		}
+	}
+	return changes
+}
+
+func indexChecks(checks []contract.ReadinessCheck) map[string]contract.ReadinessCheck {
+	m := make(map[string]contract.ReadinessCheck, len(checks))
+	for _, c := range checks {
+		m[c.ID] = c
+	}
+	return m
+}
+
+func checkPath(id string) string {
+	return "readiness.checks[" + id + "]"
+}
+
+func formatCheck(c contract.ReadinessCheck) string {
+	return fmt.Sprintf("status=%s weight=%d evidence=%s", c.Status, c.Weight, c.Evidence)
+}
+
+func floatPtrChanged(a, b *float64) bool {
+	if a == nil && b == nil {
+		return false
+	}
+	if a == nil || b == nil {
+		return true
+	}
+	return *a != *b
+}
+
+func floatPtrVal(p *float64) float64 {
+	if p == nil {
+		return 0
+	}
+	return *p
+}
+
+// floatPtrChangeType returns the change type for an optional float pointer
+// transition. The caller must ensure floatPtrChanged(old, new) is true.
+func floatPtrChangeType(old, new *float64) ChangeType {
+	if old == nil {
+		return Added
+	}
+	if new == nil {
+		return Removed
+	}
+	return Modified
+}

--- a/pkg/diff/readiness_test.go
+++ b/pkg/diff/readiness_test.go
@@ -1,0 +1,159 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/trianalab/pacto/v2/pkg/contract"
+)
+
+func TestDiffReadiness_BothNil(t *testing.T) {
+	if changes := diffReadiness(nil, nil); len(changes) != 0 {
+		t.Errorf("expected 0 changes, got %d", len(changes))
+	}
+}
+
+func TestDiffReadiness_Added(t *testing.T) {
+	new := &contract.Readiness{Expires: "2026-12-31"}
+	changes := diffReadiness(nil, new)
+	if len(changes) != 1 || changes[0].Path != "readiness" || changes[0].Type != Added {
+		t.Fatalf("expected single readiness Added, got %+v", changes)
+	}
+	if changes[0].Classification != NonBreaking {
+		t.Errorf("expected NonBreaking, got %s", changes[0].Classification)
+	}
+}
+
+func TestDiffReadiness_Removed(t *testing.T) {
+	old := &contract.Readiness{Expires: "2026-12-31"}
+	changes := diffReadiness(old, nil)
+	if len(changes) != 1 || changes[0].Path != "readiness" || changes[0].Type != Removed {
+		t.Fatalf("expected single readiness Removed, got %+v", changes)
+	}
+}
+
+func TestDiffReadiness_MinScoreModified(t *testing.T) {
+	o, n := 80, 90
+	old := &contract.Readiness{MinScore: &o, Expires: "2026-12-31"}
+	new := &contract.Readiness{MinScore: &n, Expires: "2026-12-31"}
+	changes := diffReadiness(old, new)
+	if !hasChange(changes, "readiness.minScore", Modified) {
+		t.Errorf("expected readiness.minScore Modified, got %+v", changes)
+	}
+}
+
+func TestDiffReadiness_ExpiresModified(t *testing.T) {
+	old := &contract.Readiness{Expires: "2026-01-01"}
+	new := &contract.Readiness{Expires: "2026-12-31"}
+	changes := diffReadiness(old, new)
+	if !hasChange(changes, "readiness.expires", Modified) {
+		t.Errorf("expected readiness.expires Modified, got %+v", changes)
+	}
+}
+
+func TestDiffReadiness_PartialCreditAdded(t *testing.T) {
+	pc := 0.5
+	old := &contract.Readiness{Expires: "2026-12-31"}
+	new := &contract.Readiness{Expires: "2026-12-31", PartialCredit: &pc}
+	changes := diffReadiness(old, new)
+	if !hasChange(changes, "readiness.partialCredit", Added) {
+		t.Errorf("expected readiness.partialCredit Added, got %+v", changes)
+	}
+}
+
+func TestDiffReadiness_PartialCreditRemoved(t *testing.T) {
+	pc := 0.5
+	old := &contract.Readiness{Expires: "2026-12-31", PartialCredit: &pc}
+	new := &contract.Readiness{Expires: "2026-12-31"}
+	changes := diffReadiness(old, new)
+	if !hasChange(changes, "readiness.partialCredit", Removed) {
+		t.Errorf("expected readiness.partialCredit Removed, got %+v", changes)
+	}
+}
+
+func TestDiffReadiness_PartialCreditModified(t *testing.T) {
+	o, n := 0.5, 0.75
+	old := &contract.Readiness{Expires: "2026-12-31", PartialCredit: &o}
+	new := &contract.Readiness{Expires: "2026-12-31", PartialCredit: &n}
+	changes := diffReadiness(old, new)
+	if !hasChange(changes, "readiness.partialCredit", Modified) {
+		t.Errorf("expected readiness.partialCredit Modified, got %+v", changes)
+	}
+}
+
+func TestDiffReadiness_CheckStatusModified(t *testing.T) {
+	old := &contract.Readiness{
+		Expires: "2026-12-31",
+		Checks:  []contract.ReadinessCheck{{ID: "dashboard", Type: "url", Status: "done", Evidence: "http://x", Weight: 10}},
+	}
+	new := &contract.Readiness{
+		Expires: "2026-12-31",
+		Checks:  []contract.ReadinessCheck{{ID: "dashboard", Type: "url", Status: "not-done", Evidence: "http://x", Weight: 10}},
+	}
+	changes := diffReadiness(old, new)
+	c, ok := findChange(changes, "readiness.checks[dashboard]", Modified)
+	if !ok {
+		t.Fatalf("expected readiness.checks[dashboard] Modified, got %+v", changes)
+	}
+	if c.Classification != NonBreaking {
+		t.Errorf("expected NonBreaking, got %s", c.Classification)
+	}
+}
+
+func TestDiffReadiness_CheckAdded(t *testing.T) {
+	old := &contract.Readiness{Expires: "2026-12-31"}
+	new := &contract.Readiness{
+		Expires: "2026-12-31",
+		Checks:  []contract.ReadinessCheck{{ID: "runbook", Type: "url", Status: "done", Evidence: "http://x", Weight: 5}},
+	}
+	changes := diffReadiness(old, new)
+	if !hasChange(changes, "readiness.checks[runbook]", Added) {
+		t.Errorf("expected readiness.checks[runbook] Added, got %+v", changes)
+	}
+}
+
+func TestDiffReadiness_CheckRemoved(t *testing.T) {
+	old := &contract.Readiness{
+		Expires: "2026-12-31",
+		Checks:  []contract.ReadinessCheck{{ID: "runbook", Type: "url", Status: "done", Evidence: "http://x", Weight: 5}},
+	}
+	new := &contract.Readiness{Expires: "2026-12-31"}
+	changes := diffReadiness(old, new)
+	if !hasChange(changes, "readiness.checks[runbook]", Removed) {
+		t.Errorf("expected readiness.checks[runbook] Removed, got %+v", changes)
+	}
+}
+
+func TestDiffReadiness_NoChange(t *testing.T) {
+	r := &contract.Readiness{
+		Expires: "2026-12-31",
+		Checks:  []contract.ReadinessCheck{{ID: "dashboard", Type: "url", Status: "done", Evidence: "http://x", Weight: 10}},
+	}
+	if changes := diffReadiness(r, r); len(changes) != 0 {
+		t.Errorf("expected 0 changes, got %+v", changes)
+	}
+}
+
+// Compare must include readiness changes end-to-end.
+func TestCompare_IncludesReadiness(t *testing.T) {
+	old := minimalContract()
+	new := minimalContract()
+	new.Readiness = &contract.Readiness{Expires: "2026-12-31"}
+	result := Compare(old, new, nil, nil)
+	if !hasChange(result.Changes, "readiness", Added) {
+		t.Errorf("expected Compare to surface readiness Added, got %+v", result.Changes)
+	}
+}
+
+func hasChange(changes []Change, path string, ct ChangeType) bool {
+	_, ok := findChange(changes, path, ct)
+	return ok
+}
+
+func findChange(changes []Change, path string, ct ChangeType) (Change, bool) {
+	for _, c := range changes {
+		if c.Path == path && c.Type == ct {
+			return c, true
+		}
+	}
+	return Change{}, false
+}

--- a/tests/e2e/diff_granularity_test.go
+++ b/tests/e2e/diff_granularity_test.go
@@ -1,0 +1,243 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+// diffGranularityBundle writes a minimal valid bundle from an inline contract,
+// used by the field-granularity diff tests below.
+func diffGranularityBundle(t *testing.T, name, contractYAML string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), name)
+	return writeBundleDir(t, dir, contractYAML, nil)
+}
+
+// TestDiffFieldGranularity exercises the contract-level field diffs that
+// previously rendered opaquely or were dropped entirely.
+func TestDiffFieldGranularity(t *testing.T) {
+	t.Parallel()
+
+	const ownerBase = `pactoVersion: "1.1"
+service:
+  name: granular-svc
+  version: 1.0.0
+  owner:
+    team: foundations-team
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+`
+
+	// Reproduces the reported bug: a contact added while the team is unchanged
+	// must surface the granular contact change, not "team -> team".
+	t.Run("owner contact added is granular", func(t *testing.T) {
+		t.Parallel()
+		v1 := diffGranularityBundle(t, "owner-v1", ownerBase)
+		v2 := diffGranularityBundle(t, "owner-v2", `pactoVersion: "1.1"
+service:
+  name: granular-svc
+  version: 1.0.0
+  owner:
+    team: foundations-team
+    contacts:
+      - type: slack
+        value: "#foundations"
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+`)
+		output, _ := runCommand(t, nil, "diff", v1, v2)
+
+		assertContains(t, output, "service.owner.contacts[slack:#foundations]")
+		assertContains(t, output, "added")
+		// The opaque whole-owner modification must no longer appear.
+		assertNotContains(t, output, "service.owner (modified)")
+	})
+
+	t.Run("owner team modified", func(t *testing.T) {
+		t.Parallel()
+		v1 := diffGranularityBundle(t, "team-v1", ownerBase)
+		v2 := diffGranularityBundle(t, "team-v2", `pactoVersion: "1.1"
+service:
+  name: granular-svc
+  version: 1.0.0
+  owner:
+    team: platform-team
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+`)
+		output, _ := runCommand(t, nil, "diff", v1, v2)
+
+		assertContains(t, output, "service.owner.team")
+		assertContains(t, output, "foundations-team")
+		assertContains(t, output, "platform-team")
+	})
+
+	t.Run("pactoVersion change detected", func(t *testing.T) {
+		t.Parallel()
+		v1 := diffGranularityBundle(t, "pv-v1", ownerBase)
+		v2 := diffGranularityBundle(t, "pv-v2", `pactoVersion: "1.2"
+service:
+  name: granular-svc
+  version: 1.0.0
+  owner:
+    team: foundations-team
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+`)
+		output, _ := runCommand(t, nil, "diff", v1, v2)
+
+		assertContains(t, output, "pactoVersion")
+		assertNotContains(t, output, "No changes detected")
+	})
+
+	t.Run("image private toggle detected", func(t *testing.T) {
+		t.Parallel()
+		base := `pactoVersion: "1.1"
+service:
+  name: granular-svc
+  version: 1.0.0
+  owner:
+    team: foundations-team
+  image:
+    ref: ghcr.io/acme/granular-svc:1.0.0
+`
+		v1 := diffGranularityBundle(t, "img-v1", base+"    private: false\n"+ownerRuntime)
+		v2 := diffGranularityBundle(t, "img-v2", base+"    private: true\n"+ownerRuntime)
+		output, _ := runCommand(t, nil, "diff", v1, v2)
+
+		assertContains(t, output, "service.image")
+		assertContains(t, output, "private")
+	})
+}
+
+// ownerRuntime is the shared runtime block appended to image-toggle contracts.
+const ownerRuntime = `runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+`
+
+// TestDiffReadinessGranularity verifies readiness changes surface in the diff,
+// which previously had no coverage at all.
+func TestDiffReadinessGranularity(t *testing.T) {
+	t.Parallel()
+
+	v1 := writeReadinessBundle(t)
+
+	// Same contract with the dashboard check regressed done -> not-done and the
+	// gate lowered.
+	const regressed = `pactoVersion: "1.2"
+service:
+  name: readiness-svc
+  version: 1.0.0
+  owner:
+    team: readiness
+interfaces:
+  - name: api
+    type: http
+    port: 8080
+    visibility: internal
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+  health:
+    interface: api
+    path: /health
+readiness:
+  expires: "2099-12-31"
+  minScore: 70
+  partialCredit: 0.5
+  checks:
+    - id: dashboard
+      type: url
+      evidence: https://grafana.example.com/d/readiness-svc
+      weight: 60
+      status: not-done
+      category: observability
+      description: Main production dashboard
+    - id: security-review
+      type: ticket
+      evidence: SEC-1842
+      weight: 40
+      status: not-done
+      category: security
+      description: Security review ticket
+`
+	v2 := diffGranularityBundle(t, "readiness-regressed", regressed)
+
+	output, _ := runCommand(t, nil, "diff", v1, v2)
+
+	assertContains(t, output, "readiness.checks[dashboard]")
+	assertContains(t, output, "readiness.minScore")
+	assertNotContains(t, output, "No changes detected")
+}
+
+// TestDiffConfigValuesGranularity verifies inline configuration value changes
+// are diffed key-by-key.
+func TestDiffConfigValuesGranularity(t *testing.T) {
+	t.Parallel()
+
+	base := `pactoVersion: "1.1"
+service:
+  name: cfgvals-svc
+  version: 1.0.0
+  owner:
+    team: foundations-team
+configurations:
+  - name: app
+    schema: configuration/schema.json
+    values:
+      replicas: %d
+runtime:
+  workload: service
+  state:
+    type: stateless
+    persistence:
+      scope: local
+      durability: ephemeral
+    dataCriticality: low
+`
+	v1 := diffGranularityBundle(t, "cfgvals-v1", fmt.Sprintf(base, 1))
+	v2 := diffGranularityBundle(t, "cfgvals-v2", fmt.Sprintf(base, 3))
+
+	output, _ := runCommand(t, nil, "diff", v1, v2)
+
+	assertContains(t, output, "configurations[app].values.replicas")
+	assertNotContains(t, output, "No changes detected")
+}


### PR DESCRIPTION
## Problem

The diff engine reported several contract fields opaquely or dropped them entirely. The reported symptom:

```
$ pacto diff oci://.../bucket:0.37.3 oci://.../bucket:0.37.4
Classification: NON_BREAKING
Changes (2):
  [NON_BREAKING] service.version (modified): ... [0.37.3 -> 0.37.4]
  [NON_BREAKING] service.owner (modified): service.owner modified [my-team -> my-team]
```

The owner change rendered as `my-team -> my-team` because detection used `Owner.Equal()` (compares team, dri and contacts) but rendering used `Owner.DisplayString()` (team-or-dri only). A full audit of every contract field found more gaps.

## Field-level diffing

- **`service.owner`** — compared field by field (`service.owner.team` / `.dri` / `.contacts[type:value]`). Adding a contact while the team is unchanged now surfaces the contact, not `team -> team`. Contact `purpose` changes are modifications.
- **`readiness`** — new diff pass (`minScore`, `expires`, `partialCredit`, `checks[]` keyed by id). The whole block was previously never diffed. The append-only `history` log is intentionally skipped.
- **`service.image.private`** — folded into the image comparison (was ignored, so privacy toggles were silent).
- **`configurations[].values`** — diffed key-by-key, reusing the JSON-schema walker; classified `NON_BREAKING` (provider defaults, not consumer surface).
- **`pactoVersion`** — now compared.

## Classification completeness

Audited every `(path, changeType)` the engine can emit so none falls through to the `PotentialBreaking` default unintentionally:

- `runtime.lifecycle.gracefulShutdownSeconds` **Added/Removed** were defaulting to `POTENTIAL_BREAKING`; now `NON_BREAKING` (matching `Modified`).
- `scaling.replicas` made explicit (`POTENTIAL_BREAKING`).
- Added rules for owner subfields, readiness, `pactoVersion`.

## Documentation

`docs/contract-reference.md` change-classification matrix reconciled with the implementation, including the readiness table (which previously described per-subfield paths the engine never emitted) and the previously missing `dependencies.ref` row.

## Tests

- Unit coverage for `pkg/diff` stays at **100%** (CI-enforced).
- New e2e tests (`tests/e2e/diff_granularity_test.go`) cover owner contacts, owner team, `pactoVersion`, image privacy, readiness regression and config values end-to-end through the `pacto diff` CLI.

