### PR TITLE
chore(ci): add manual workflow_dispatch trigger to auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -5,6 +5,18 @@ on:
     types: [closed]
     branches:
       - main
+  # Manual escape hatch: cut a release by hand when the merged PR title did not
+  # trigger one (e.g. a chore/deps bump that should ship). Runs against main.
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump type for a manual release
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
 
 permissions:
   contents: write
@@ -13,7 +25,7 @@ permissions:
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.version.outputs.tag }}
@@ -22,6 +34,12 @@ jobs:
       - name: Determine version bump
         id: bump
         run: |
+          # Manual run: use the chosen bump directly.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "type=${{ inputs.bump }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           title="${{ github.event.pull_request.title }}"
 
           # Check for breaking change indicator


### PR DESCRIPTION
## What

Adds a `workflow_dispatch` manual trigger to `auto-release.yml`, alongside the existing PR-merge trigger.

## Why

The release workflow decides the version bump from the merged **PR title** (`feat`→minor, `fix|perf|refactor`→patch, `!`→major, everything else → skip). When a release-worthy change lands under a non-releasing title (e.g. a `chore(deps)` bump that should actually ship), there's no way to cut the release after the fact.

This adds a maintainer escape hatch: run **Actions → Auto release → Run workflow**, pick `patch`/`minor`/`major`, and the full pipeline (tag, GitHub release, binaries, docker, etc.) runs against `main`.

## Notes

- The existing PR-merge path is unchanged.
- This PR is titled `chore(ci)` on purpose so merging it does **not** itself cut a release — it only adds the capability.
- Mirrors the same addition in `pacto-operator`.

