### PR TITLE
feat(cli): TTY-gated UX — animated banner, progress, colored results, init reveal

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -11,6 +11,7 @@ All commands support `--output-format json` for programmatic consumption, `--out
 ```
       --config string          config file path
   -h, --help                   help for pacto
+      --no-anim                disable animations
       --no-cache               disable OCI bundle cache
       --output-format string   output format (text, json, markdown) (default "text")
   -v, --verbose                enable verbose output

--- a/internal/app/graph.go
+++ b/internal/app/graph.go
@@ -18,6 +18,9 @@ type GraphOptions struct {
 	Overrides         override.Overrides
 	IncludeReferences bool
 	OnlyReferences    bool
+	// OnDepResolved, if non-nil, fires once per unique resolved dependency for
+	// progress reporting. Must be goroutine-safe. nil = no-op.
+	OnDepResolved func()
 }
 
 // GraphResult is the result of the graph command.
@@ -42,6 +45,7 @@ func (s *Service) Graph(ctx context.Context, opts GraphOptions) (*GraphResult, e
 	result := graph.ResolveWithOptions(ctx, bundle.Contract, fetcher, graph.ResolveOptions{
 		IncludeReferences: opts.IncludeReferences,
 		OnlyReferences:    opts.OnlyReferences,
+		OnResolved:        opts.OnDepResolved,
 	})
 	slog.Debug("graph resolution complete", "dependencies", len(result.Root.Dependencies), "cycles", len(result.Cycles), "conflicts", len(result.Conflicts))
 	return result, nil

--- a/internal/app/lock.go
+++ b/internal/app/lock.go
@@ -20,6 +20,9 @@ type LockOptions struct {
 	UpdateNames []string
 	Check       bool
 	Overrides   override.Overrides
+	// OnDepResolved, if non-nil, fires once per unique resolved dependency for
+	// progress reporting. Must be goroutine-safe. nil = no-op.
+	OnDepResolved func()
 }
 
 // LockResult reports the outcome of a lock operation.
@@ -58,7 +61,7 @@ func (s *Service) Lock(ctx context.Context, opts LockOptions) (*LockResult, erro
 		return nil, err
 	}
 
-	fresh, err := s.buildLock(ctx, ref, bundle)
+	fresh, err := s.buildLock(ctx, ref, bundle, opts.OnDepResolved)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +214,9 @@ func (s *Service) verifyLockIfPresent(ctx context.Context, ref string, bundle *c
 		}
 		return err
 	}
-	fresh, err := s.buildLock(ctx, ref, bundle)
+	// The verify path re-resolves the closure; pass nil so it never fires the
+	// progress callback (the user-facing resolve owns the count).
+	fresh, err := s.buildLock(ctx, ref, bundle, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/app/lock_build.go
+++ b/internal/app/lock_build.go
@@ -19,9 +19,12 @@ import (
 // buildLock fails closed: a graph conflict yields *lock.ConflictError, and any
 // required edge that failed to resolve (non-empty Error, nil Node) or any digest
 // / content-hash resolution failure yields *lock.UnresolvedError.
-func (s *Service) buildLock(ctx context.Context, ref string, bundle *contract.Bundle) (*lock.Lock, error) {
+//
+// onResolved, if non-nil, fires once per unique fetched dependency node (for
+// progress reporting). The verify path passes nil so it does not double-count.
+func (s *Service) buildLock(ctx context.Context, ref string, bundle *contract.Bundle, onResolved func()) (*lock.Lock, error) {
 	fetcher := s.newDepFetcher(ref)
-	res := graph.ResolveWithOptions(ctx, bundle.Contract, fetcher, graph.ResolveOptions{IncludeReferences: true})
+	res := graph.ResolveWithOptions(ctx, bundle.Contract, fetcher, graph.ResolveOptions{IncludeReferences: true, OnResolved: onResolved})
 
 	if len(res.Conflicts) > 0 {
 		return nil, &lock.ConflictError{Service: res.Conflicts[0].Name}

--- a/internal/app/lock_build_test.go
+++ b/internal/app/lock_build_test.go
@@ -37,7 +37,7 @@ func TestBuildLockCapturesDigest(t *testing.T) {
 	}
 	s := NewService(store, nil)
 
-	l, err := s.buildLock(context.Background(), "testdata/root", rootBundleWithDep())
+	l, err := s.buildLock(context.Background(), "testdata/root", rootBundleWithDep(), nil)
 	if err != nil {
 		t.Fatalf("buildLock: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestBuildLockDependsOn(t *testing.T) {
 			{Name: "auth", Ref: "oci://ghcr.io/acme/auth:1.0.0", Compatibility: "^1.0.0", Required: true},
 		},
 	}}
-	l, err := s.buildLock(context.Background(), "testdata/root", root)
+	l, err := s.buildLock(context.Background(), "testdata/root", root, nil)
 	if err != nil {
 		t.Fatalf("buildLock: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestBuildLockLocalDep(t *testing.T) {
 			{Name: "local-dep", Ref: dir, Compatibility: "", Required: true},
 		},
 	}}
-	l, err := s.buildLock(context.Background(), ".", root)
+	l, err := s.buildLock(context.Background(), ".", root, nil)
 	if err != nil {
 		t.Fatalf("buildLock: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestBuildLockReferences(t *testing.T) {
 			{Name: "sec", Ref: "oci://ghcr.io/acme/sec:2.0.0"},
 		},
 	}}
-	l, err := s.buildLock(context.Background(), "testdata/root", root)
+	l, err := s.buildLock(context.Background(), "testdata/root", root, nil)
 	if err != nil {
 		t.Fatalf("buildLock: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestBuildLockLocalReference(t *testing.T) {
 			{Name: "localcfg", Ref: dir},
 		},
 	}}
-	l, err := s.buildLock(context.Background(), ".", root)
+	l, err := s.buildLock(context.Background(), ".", root, nil)
 	if err != nil {
 		t.Fatalf("buildLock: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestBuildLockLocalReference(t *testing.T) {
 func TestBuildLockConflict(t *testing.T) {
 	store := conflictStore()
 	s := NewService(store, nil)
-	_, err := s.buildLock(context.Background(), "testdata/root", conflictRootBundle())
+	_, err := s.buildLock(context.Background(), "testdata/root", conflictRootBundle(), nil)
 	var ce *lock.ConflictError
 	if !errors.As(err, &ce) {
 		t.Fatalf("expected *lock.ConflictError, got %v", err)
@@ -284,7 +284,7 @@ func TestBuildLockUnresolvedFailedEdge(t *testing.T) {
 			{Name: "auth", Ref: "oci://ghcr.io/acme/auth:1.0.0", Compatibility: "^1.0.0", Required: true},
 		},
 	}}
-	_, err := s.buildLock(context.Background(), "testdata/root", root)
+	_, err := s.buildLock(context.Background(), "testdata/root", root, nil)
 	var ue *lock.UnresolvedError
 	if !errors.As(err, &ue) {
 		t.Fatalf("expected *lock.UnresolvedError, got %v", err)
@@ -312,7 +312,7 @@ func TestBuildLockUnresolvedDigestError(t *testing.T) {
 			{Name: "auth", Ref: "oci://ghcr.io/acme/auth:1.0.0", Compatibility: "^1.0.0", Required: true},
 		},
 	}}
-	_, err := s.buildLock(context.Background(), "testdata/root", root)
+	_, err := s.buildLock(context.Background(), "testdata/root", root, nil)
 	var ue *lock.UnresolvedError
 	if !errors.As(err, &ue) {
 		t.Fatalf("expected *lock.UnresolvedError, got %v", err)
@@ -334,7 +334,7 @@ func TestBuildLockUnresolvedReferenceDigestError(t *testing.T) {
 			{Name: "sec", Ref: "oci://ghcr.io/acme/sec:2.0.0"},
 		},
 	}}
-	_, err := s.buildLock(context.Background(), "testdata/root", root)
+	_, err := s.buildLock(context.Background(), "testdata/root", root, nil)
 	var ue *lock.UnresolvedError
 	if !errors.As(err, &ue) {
 		t.Fatalf("expected *lock.UnresolvedError, got %v", err)
@@ -353,7 +353,7 @@ func TestBuildLockUnresolvedReferenceLoadError(t *testing.T) {
 			{Name: "missing-local", Ref: "/nonexistent/path/xyz", Compatibility: "", Required: true},
 		},
 	}}
-	_, err := s.buildLock(context.Background(), ".", root)
+	_, err := s.buildLock(context.Background(), ".", root, nil)
 	var ue *lock.UnresolvedError
 	if !errors.As(err, &ue) {
 		t.Fatalf("expected *lock.UnresolvedError, got %v", err)
@@ -383,7 +383,7 @@ func TestBuildLockUnresolvedHashError(t *testing.T) {
 			{Name: "local-dep", Ref: dir, Compatibility: "", Required: true},
 		},
 	}}
-	_, err := s.buildLock(context.Background(), ".", root)
+	_, err := s.buildLock(context.Background(), ".", root, nil)
 	var ue *lock.UnresolvedError
 	if !errors.As(err, &ue) {
 		t.Fatalf("expected *lock.UnresolvedError, got %v", err)
@@ -417,7 +417,7 @@ func TestBuildLockTransitiveFailure(t *testing.T) {
 			{Name: "auth", Ref: "oci://ghcr.io/acme/auth:1.0.0", Compatibility: "^1.0.0", Required: true},
 		},
 	}}
-	_, err := s.buildLock(context.Background(), "testdata/root", root)
+	_, err := s.buildLock(context.Background(), "testdata/root", root, nil)
 	var ue *lock.UnresolvedError
 	if !errors.As(err, &ue) {
 		t.Fatalf("expected *lock.UnresolvedError, got %v", err)
@@ -456,7 +456,7 @@ func TestBuildLockSecondEntryDigestError(t *testing.T) {
 			{Name: "b", Ref: "oci://ghcr.io/acme/b:1.0.0", Compatibility: "^1.0.0", Required: true},
 		},
 	}}
-	_, err := s.buildLock(context.Background(), "testdata/root", root)
+	_, err := s.buildLock(context.Background(), "testdata/root", root, nil)
 	var ue *lock.UnresolvedError
 	if !errors.As(err, &ue) {
 		t.Fatalf("expected *lock.UnresolvedError, got %v", err)
@@ -474,7 +474,7 @@ func TestBuildLockLocalReferenceLoadError(t *testing.T) {
 			{Name: "badcfg", Ref: "/nonexistent/ref/path"},
 		},
 	}}
-	_, err := s.buildLock(context.Background(), ".", root)
+	_, err := s.buildLock(context.Background(), ".", root, nil)
 	var ue *lock.UnresolvedError
 	if !errors.As(err, &ue) {
 		t.Fatalf("expected *lock.UnresolvedError, got %v", err)
@@ -502,7 +502,7 @@ func TestBuildLockLocalReferenceHashError(t *testing.T) {
 			{Name: "localcfg", Ref: dir},
 		},
 	}}
-	_, err := s.buildLock(context.Background(), ".", root)
+	_, err := s.buildLock(context.Background(), ".", root, nil)
 	var ue *lock.UnresolvedError
 	if !errors.As(err, &ue) {
 		t.Fatalf("expected *lock.UnresolvedError, got %v", err)
@@ -672,7 +672,7 @@ func TestBuildLockOCIRootReferenceBaseDir(t *testing.T) {
 			{Name: "sec", Ref: "oci://ghcr.io/acme/sec:2.0.0"},
 		},
 	}}
-	l, err := s.buildLock(context.Background(), "oci://ghcr.io/acme/root:1.0.0", root)
+	l, err := s.buildLock(context.Background(), "oci://ghcr.io/acme/root:1.0.0", root, nil)
 	if err != nil {
 		t.Fatalf("buildLock: %v", err)
 	}

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -271,6 +271,38 @@ func TestGraphCommand_Error(t *testing.T) {
 	}
 }
 
+// TestGraphCommand_ResolvesDependency exercises the per-dependency progress
+// callback (OnDepResolved -> count.Add) by resolving a real OCI dependency.
+func TestGraphCommand_ResolvesDependency(t *testing.T) {
+	dir := t.TempDir()
+	yaml := "pactoVersion: \"1.0\"\nservice:\n  name: root\n  version: \"2.1.0\"\ndependencies:\n  - name: auth\n    ref: oci://ghcr.io/acme/auth\n    compatibility: ^1.0.0\n"
+	if err := os.WriteFile(filepath.Join(dir, "pacto.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	auth := &contract.Contract{
+		PactoVersion: "1.0",
+		Service:      contract.ServiceIdentity{Name: "auth", Version: "1.2.0"},
+	}
+	store := &testutil.MockBundleStore{
+		ListTagsFn: func(_ context.Context, _ string) ([]string, error) { return []string{"1.2.0"}, nil },
+		ResolveFn:  func(_ context.Context, _ string) (string, error) { return "sha256:v1", nil },
+		PullFn: func(_ context.Context, _ string) (*contract.Bundle, error) {
+			return &contract.Bundle{Contract: auth}, nil
+		},
+	}
+	svc := app.NewService(store, nil)
+	root := cli.NewRootCommand(svc, cli.VersionInfo{Version: "test"})
+	root.SetArgs([]string{"graph", dir})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("graph failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "auth@1.2.0") {
+		t.Errorf("expected resolved dependency in output, got %q", out.String())
+	}
+}
+
 func TestExplainCommand(t *testing.T) {
 	bundleDir := testutil.WriteTestBundle(t)
 	svc := app.NewService(nil, nil)

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -21,17 +21,20 @@ func newDiffCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oldOverrides, newOverrides := getDiffOverrides(cmd)
+			format := v.GetString(outputFormatKey)
+
+			sp := startSpinner(cmd, format, "Resolving diff")
 			result, err := svc.Diff(cmd.Context(), app.DiffOptions{
 				OldPath:      args[0],
 				NewPath:      args[1],
 				OldOverrides: oldOverrides,
 				NewOverrides: newOverrides,
 			})
+			sp.Stop()
 			if err != nil {
 				return err
 			}
 
-			format := v.GetString(outputFormatKey)
 			if err := printDiffResult(cmd, result, format); err != nil {
 				return err
 			}

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -23,6 +24,7 @@ func newDiffCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 			oldOverrides, newOverrides := getDiffOverrides(cmd)
 			format := v.GetString(outputFormatKey)
 
+			start := time.Now()
 			sp := startSpinner(cmd, format, "Resolving diff")
 			result, err := svc.Diff(cmd.Context(), app.DiffOptions{
 				OldPath:      args[0],
@@ -30,10 +32,11 @@ func newDiffCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 				OldOverrides: oldOverrides,
 				NewOverrides: newOverrides,
 			})
-			sp.Stop()
 			if err != nil {
+				sp.Stop()
 				return err
 			}
+			sp.StopOK("Diffed", start)
 
 			if err := printDiffResult(cmd, result, format); err != nil {
 				return err

--- a/internal/cli/graph.go
+++ b/internal/cli/graph.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/trianalab/pacto/v2/internal/app"
@@ -20,17 +22,20 @@ func newGraphCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 			onlyRefs, _ := cmd.Flags().GetBool("only-references")
 			format := v.GetString(outputFormatKey)
 
-			sp := startSpinner(cmd, format, "Resolving graph")
+			start := time.Now()
+			sp, count := startSpinnerCounted(cmd, format, "Resolving graph")
 			result, err := svc.Graph(cmd.Context(), app.GraphOptions{
 				Path:              path,
 				Overrides:         getOverrides(cmd),
 				IncludeReferences: withRefs || onlyRefs,
 				OnlyReferences:    onlyRefs,
+				OnDepResolved:     func() { count.Add(1) },
 			})
-			sp.Stop()
 			if err != nil {
+				sp.Stop()
 				return err
 			}
+			sp.StopOK("Resolved graph", start)
 
 			return printGraphResult(cmd, result, format)
 		},

--- a/internal/cli/graph.go
+++ b/internal/cli/graph.go
@@ -18,18 +18,20 @@ func newGraphCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 
 			withRefs, _ := cmd.Flags().GetBool("with-references")
 			onlyRefs, _ := cmd.Flags().GetBool("only-references")
+			format := v.GetString(outputFormatKey)
 
+			sp := startSpinner(cmd, format, "Resolving graph")
 			result, err := svc.Graph(cmd.Context(), app.GraphOptions{
 				Path:              path,
 				Overrides:         getOverrides(cmd),
 				IncludeReferences: withRefs || onlyRefs,
 				OnlyReferences:    onlyRefs,
 			})
+			sp.Stop()
 			if err != nil {
 				return err
 			}
 
-			format := v.GetString(outputFormatKey)
 			return printGraphResult(cmd, result, format)
 		},
 	}

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -28,11 +28,15 @@ func newLockCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 			start := time.Now()
 			sp, count := startSpinnerCounted(cmd, format, "Resolving lock")
 			result, err := svc.Lock(cmd.Context(), app.LockOptions{
-				Path:          optionalArg(args),
-				Update:        update || len(names) > 0,
-				UpdateNames:   names,
-				Check:         check,
-				Overrides:     getOverrides(cmd),
+				Path:        optionalArg(args),
+				Update:      update || len(names) > 0,
+				UpdateNames: names,
+				Check:       check,
+				Overrides:   getOverrides(cmd),
+				// Counts dependency-node fetches only; reference closure is pinned
+				// separately and intentionally not counted here. Do not wire refs
+				// into this callback — the verify-path resolve already passes nil to
+				// avoid double-counting.
 				OnDepResolved: func() { count.Add(1) },
 			})
 			if err != nil {

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -23,18 +25,21 @@ func newLockCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 			names, _ := cmd.Flags().GetStringArray("update-name")
 			format := v.GetString(outputFormatKey)
 
-			sp := startSpinner(cmd, format, "Resolving lock")
+			start := time.Now()
+			sp, count := startSpinnerCounted(cmd, format, "Resolving lock")
 			result, err := svc.Lock(cmd.Context(), app.LockOptions{
-				Path:        optionalArg(args),
-				Update:      update || len(names) > 0,
-				UpdateNames: names,
-				Check:       check,
-				Overrides:   getOverrides(cmd),
+				Path:          optionalArg(args),
+				Update:        update || len(names) > 0,
+				UpdateNames:   names,
+				Check:         check,
+				Overrides:     getOverrides(cmd),
+				OnDepResolved: func() { count.Add(1) },
 			})
-			sp.Stop()
 			if err != nil {
+				sp.Stop()
 				return err
 			}
+			sp.StopOK("Locked", start)
 			return printLockResult(cmd, result, format)
 		},
 	}

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -21,7 +21,9 @@ func newLockCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 			update, _ := cmd.Flags().GetBool("update")
 			check, _ := cmd.Flags().GetBool("check")
 			names, _ := cmd.Flags().GetStringArray("update-name")
+			format := v.GetString(outputFormatKey)
 
+			sp := startSpinner(cmd, format, "Resolving lock")
 			result, err := svc.Lock(cmd.Context(), app.LockOptions{
 				Path:        optionalArg(args),
 				Update:      update || len(names) > 0,
@@ -29,10 +31,11 @@ func newLockCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 				Check:       check,
 				Overrides:   getOverrides(cmd),
 			})
+			sp.Stop()
 			if err != nil {
 				return err
 			}
-			return printLockResult(cmd, result, v.GetString(outputFormatKey))
+			return printLockResult(cmd, result, format)
 		},
 	}
 	cmd.Flags().Bool("update", false, "re-resolve dependencies to the newest version within their constraint")

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -30,10 +30,7 @@ func formatResult(cmd *cobra.Command, format string, result any, textFn, markdow
 
 func printInitResult(cmd *cobra.Command, result *app.InitResult, format string) error {
 	return formatResult(cmd, format, result, func() error {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Created %s/\n", result.Dir)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", result.Path)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s/interfaces/\n", result.Dir)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s/configuration/\n", result.Dir)
+		revealInit(cmd.OutOrStdout(), initLines(result))
 		return nil
 	}, nil)
 }

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -40,10 +40,19 @@ func printInitResult(cmd *cobra.Command, result *app.InitResult, format string) 
 
 func printValidateResult(cmd *cobra.Command, result *app.ValidateResult, format string) error {
 	return formatResult(cmd, format, result, func() error {
+		w := cmd.OutOrStdout()
 		if result.Valid {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s is valid\n", result.Path)
+			if useColor(w) {
+				_, _ = fmt.Fprintf(w, "%s %s is valid\n", checkGlyph(true), result.Path)
+			} else {
+				_, _ = fmt.Fprintf(w, "%s is valid\n", result.Path)
+			}
 		} else {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s is invalid\n", result.Path)
+			if useColor(w) {
+				_, _ = fmt.Fprintf(w, "%s %s is invalid\n", crossGlyph(true), result.Path)
+			} else {
+				_, _ = fmt.Fprintf(w, "%s is invalid\n", result.Path)
+			}
 		}
 
 		for _, e := range result.Errors {
@@ -60,22 +69,25 @@ func printValidateResult(cmd *cobra.Command, result *app.ValidateResult, format 
 
 func printPackResult(cmd *cobra.Command, result *app.PackResult, format string) error {
 	return formatResult(cmd, format, result, func() error {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Packed %s@%s -> %s\n", result.Name, result.Version, result.Output)
+		w := cmd.OutOrStdout()
+		_, _ = fmt.Fprintf(w, "%sPacked %s@%s -> %s\n", okGlyph(w), result.Name, result.Version, result.Output)
 		return nil
 	}, nil)
 }
 
 func printPushResult(cmd *cobra.Command, result *app.PushResult, format string) error {
 	return formatResult(cmd, format, result, func() error {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Pushed %s@%s -> %s\n", result.Name, result.Version, result.Ref)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Digest: %s\n", result.Digest)
+		w := cmd.OutOrStdout()
+		_, _ = fmt.Fprintf(w, "%sPushed %s@%s -> %s\n", okGlyph(w), result.Name, result.Version, result.Ref)
+		_, _ = fmt.Fprintf(w, "Digest: %s\n", result.Digest)
 		return nil
 	}, nil)
 }
 
 func printPullResult(cmd *cobra.Command, result *app.PullResult, format string) error {
 	return formatResult(cmd, format, result, func() error {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Pulled %s@%s -> %s/\n", result.Name, result.Version, result.Output)
+		w := cmd.OutOrStdout()
+		_, _ = fmt.Fprintf(w, "%sPulled %s@%s -> %s/\n", okGlyph(w), result.Name, result.Version, result.Output)
 		return nil
 	}, nil)
 }
@@ -83,11 +95,11 @@ func printPullResult(cmd *cobra.Command, result *app.PullResult, format string) 
 func printDiffResult(cmd *cobra.Command, result *app.DiffResult, format string) error {
 	return formatResult(cmd, format, result, func() error {
 		w := cmd.OutOrStdout()
-		rendered := graph.RenderDiffTree(result.GraphDiff)
+		rendered := graph.RenderDiffTreeColored(result.GraphDiff, diffColors(w))
 		hasSBOM := result.SBOMDiff != nil && len(result.SBOMDiff.Changes) > 0
 		hasDepSBOM := hasAnyDepSBOM(result.DependencyDiffs)
 
-		_, _ = fmt.Fprintf(w, "Classification: %s\n", result.Classification)
+		_, _ = fmt.Fprintf(w, "Classification: %s\n", colorClassification(w, result.Classification))
 
 		if len(result.Changes) == 0 && len(result.DependencyDiffs) == 0 && rendered == "" && !hasSBOM && !hasDepSBOM {
 			_, _ = fmt.Fprintln(w, "No changes detected.")
@@ -190,6 +202,34 @@ func treeColors(w io.Writer) graph.TreeColors {
 		Marker:  ansi("2"),  // dim
 		Error:   ansi("31"), // red
 		Warn:    ansi("33"), // yellow
+	}
+}
+
+// diffColors returns ANSI colorizers for diff trees when color is enabled for w.
+func diffColors(w io.Writer) graph.DiffColors {
+	if !useColor(w) {
+		return graph.DiffColors{}
+	}
+	ansi := func(code string) func(string) string {
+		return func(s string) string { return "\033[" + code + "m" + s + "\033[0m" }
+	}
+	return graph.DiffColors{Added: ansi("32"), Removed: ansi("31"), Changed: ansi("33")}
+}
+
+// colorClassification colors the diff classification string; passthrough off-TTY.
+func colorClassification(w io.Writer, s string) string {
+	if !useColor(w) {
+		return s
+	}
+	switch s {
+	case "BREAKING":
+		return crossGlyph(true) + " \033[31m" + s + "\033[0m"
+	case "NON_BREAKING":
+		return checkGlyph(true) + " \033[32m" + s + "\033[0m"
+	case "POTENTIAL_BREAKING":
+		return "\033[33m" + s + "\033[0m"
+	default:
+		return s
 	}
 }
 
@@ -406,11 +446,12 @@ func printSBOMChangeRows(w io.Writer, changes []sbom.Change) {
 
 func printLockResult(cmd *cobra.Command, r *app.LockResult, format string) error {
 	return formatResult(cmd, format, r, func() error {
+		w := cmd.OutOrStdout()
 		if r.UpToDate {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "pacto.lock is up to date (%d dependencies, %d references)\n", r.Dependencies, r.References)
+			_, _ = fmt.Fprintf(w, "%spacto.lock is up to date (%d dependencies, %d references)\n", okGlyph(w), r.Dependencies, r.References)
 			return nil
 		}
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "wrote %s (%d dependencies, %d references)\n", r.Path, r.Dependencies, r.References)
+		_, _ = fmt.Fprintf(w, "%swrote %s (%d dependencies, %d references)\n", okGlyph(w), r.Path, r.Dependencies, r.References)
 		return nil
 	}, nil)
 }

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -169,9 +169,28 @@ func printDiffMarkdown(cmd *cobra.Command, result *app.DiffResult) error {
 
 func printGraphResult(cmd *cobra.Command, result *app.GraphResult, format string) error {
 	return formatResult(cmd, format, result, func() error {
-		_, _ = fmt.Fprint(cmd.OutOrStdout(), graph.RenderTree(result))
+		w := cmd.OutOrStdout()
+		_, _ = fmt.Fprint(w, graph.RenderTreeColored(result, treeColors(w)))
 		return nil
 	}, nil)
+}
+
+// treeColors returns ANSI colorizers when color is enabled for w, else the
+// zero value (plain output).
+func treeColors(w io.Writer) graph.TreeColors {
+	if !useColor(w) {
+		return graph.TreeColors{}
+	}
+	ansi := func(code string) func(string) string {
+		return func(s string) string { return "\033[" + code + "m" + s + "\033[0m" }
+	}
+	return graph.TreeColors{
+		Name:    ansi("1"),  // bold
+		Version: ansi("36"), // cyan
+		Marker:  ansi("2"),  // dim
+		Error:   ansi("31"), // red
+		Warn:    ansi("33"), // yellow
+	}
 }
 
 func printExplainResult(cmd *cobra.Command, result *app.ExplainResult, format string) error {

--- a/internal/cli/output_internal_test.go
+++ b/internal/cli/output_internal_test.go
@@ -1195,3 +1195,70 @@ func TestPrintGraphResultPlainWhenNotTTY(t *testing.T) {
 		t.Fatalf("expected no ANSI without TTY, got %q", buf.String())
 	}
 }
+
+func TestColorClassification(t *testing.T) {
+	withTTY(t, true)
+	t.Setenv("NO_COLOR", "")
+	w := &bytes.Buffer{}
+	if !strings.Contains(colorClassification(w, "BREAKING"), "\033[31m") {
+		t.Fatal("BREAKING should be red")
+	}
+	if !strings.Contains(colorClassification(w, "NON_BREAKING"), "\033[32m") {
+		t.Fatal("NON_BREAKING should be green")
+	}
+	if !strings.Contains(colorClassification(w, "POTENTIAL_BREAKING"), "\033[33m") {
+		t.Fatal("POTENTIAL_BREAKING should be yellow")
+	}
+	if colorClassification(w, "WEIRD") != "WEIRD" {
+		t.Fatal("unknown classification should pass through")
+	}
+	withTTY(t, false)
+	if colorClassification(&bytes.Buffer{}, "BREAKING") != "BREAKING" {
+		t.Fatal("off-TTY should be plain")
+	}
+}
+
+func TestPrintValidateResultColored(t *testing.T) {
+	withTTY(t, true)
+	t.Setenv("NO_COLOR", "")
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	_ = printValidateResult(cmd, &app.ValidateResult{Valid: true, Path: "svc"}, "text")
+	if !strings.Contains(buf.String(), "✓") {
+		t.Fatal("valid should show ✓")
+	}
+	buf.Reset()
+	_ = printValidateResult(cmd, &app.ValidateResult{Valid: false, Path: "svc"}, "text")
+	if !strings.Contains(buf.String(), "✗") {
+		t.Fatal("invalid should show ✗")
+	}
+}
+
+func TestPrintPushResultGlyphOffTTY(t *testing.T) {
+	withTTY(t, false)
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	_ = printPushResult(cmd, &app.PushResult{Name: "n", Version: "1.0.0", Ref: "r", Digest: "d"}, "text")
+	if buf.String() != "Pushed n@1.0.0 -> r\nDigest: d\n" {
+		t.Fatalf("off-TTY must be byte-identical: %q", buf.String())
+	}
+}
+
+func TestDiffColors(t *testing.T) {
+	withTTY(t, true)
+	t.Setenv("NO_COLOR", "")
+	col := diffColors(&bytes.Buffer{})
+	if col.Added == nil {
+		t.Fatal("TTY diffColors should populate")
+	}
+	// Actually exercise the closures
+	if !strings.Contains(col.Added("test"), "\033[32m") {
+		t.Fatal("Added should apply green")
+	}
+	withTTY(t, false)
+	if diffColors(&bytes.Buffer{}).Added != nil {
+		t.Fatal("off-TTY diffColors must be zero")
+	}
+}

--- a/internal/cli/output_internal_test.go
+++ b/internal/cli/output_internal_test.go
@@ -1166,3 +1166,32 @@ func TestNonEmpty(t *testing.T) {
 		t.Errorf("expected 'hello', got %v", got)
 	}
 }
+
+func TestPrintGraphResultColored(t *testing.T) {
+	withTTY(t, true)
+	t.Setenv("NO_COLOR", "")
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	result := &graph.Result{Root: &graph.Node{Name: "svc", Version: "1.0.0"}}
+	if err := printGraphResult(cmd, result, "text"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "\033[") {
+		t.Fatalf("expected ANSI color in TTY output, got %q", buf.String())
+	}
+}
+
+func TestPrintGraphResultPlainWhenNotTTY(t *testing.T) {
+	withTTY(t, false)
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	result := &graph.Result{Root: &graph.Node{Name: "svc", Version: "1.0.0"}}
+	if err := printGraphResult(cmd, result, "text"); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "\033[") {
+		t.Fatalf("expected no ANSI without TTY, got %q", buf.String())
+	}
+}

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// progressLabel renders the live count line, e.g. "Resolving deps… 7". Pure.
+func progressLabel(base string, done int64) string {
+	return fmt.Sprintf("%s %d", base, done)
+}
+
+// startSpinnerCounted is like startSpinner but renders a live "<base> <n>" count
+// that the caller bumps via the returned counter. The counter is safe to call
+// from multiple goroutines (the resolver fires OnResolved concurrently). The
+// spinner reads it atomically each tick. Same no-op contract as startSpinner:
+// off-TTY / non-text returns a no-op spinner and a usable (but unread) counter.
+func startSpinnerCounted(cmd *cobra.Command, format, base string) (*spinner, *atomic.Int64) {
+	var n atomic.Int64
+	w := cmd.ErrOrStderr()
+	if format != "text" || !isTerminal(w) {
+		return &spinner{}, &n
+	}
+	s := &spinner{
+		w:     w,
+		color: useColor(w),
+		stop:  make(chan struct{}),
+		done:  make(chan struct{}),
+	}
+	writeFrame(w, frameGlyph(0, s.color), progressLabel(base, n.Load())) // first frame
+	go s.runCounted(base, &n)
+	return s, &n
+}
+
+// runCounted ticks the spinner, re-rendering progressLabel(base, n.Load()) each
+// tick so the live count tracks the counter. Shares stop/done with Stop/StopOK.
+func (s *spinner) runCounted(base string, n *atomic.Int64) {
+	defer close(s.done)
+	t := time.NewTicker(spinnerInterval)
+	defer t.Stop()
+	i := 0
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-t.C:
+			i = (i + 1) % len(spinnerFrames)
+			writeFrame(s.w, frameGlyph(i, s.color), progressLabel(base, n.Load()))
+		}
+	}
+}

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -8,8 +8,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// progressLabel renders the live count line, e.g. "Resolving deps… 7". Pure.
+// progressLabel renders the live count line, e.g. "Resolving deps 7". Before any
+// dependency has resolved (done == 0) it returns just the base, so a fast/cached
+// resolve that finishes between ticks never flashes a misleading "0". Pure.
 func progressLabel(base string, done int64) string {
+	if done == 0 {
+		return base
+	}
 	return fmt.Sprintf("%s %d", base, done)
 }
 
@@ -21,7 +26,7 @@ func progressLabel(base string, done int64) string {
 func startSpinnerCounted(cmd *cobra.Command, format, base string) (*spinner, *atomic.Int64) {
 	var n atomic.Int64
 	w := cmd.ErrOrStderr()
-	if format != "text" || !isTerminal(w) {
+	if format != "text" || !isTerminal(w) || !animationsEnabled() {
 		return &spinner{}, &n
 	}
 	s := &spinner{

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -13,8 +13,8 @@ func TestProgressLabel(t *testing.T) {
 	if got := progressLabel("Resolving deps…", 7); got != "Resolving deps… 7" {
 		t.Fatalf("got %q", got)
 	}
-	if got := progressLabel("X", 0); got != "X 0" {
-		t.Fatalf("zero count: got %q", got)
+	if got := progressLabel("X", 0); got != "X" {
+		t.Fatalf("zero count should omit the number: got %q", got)
 	}
 }
 
@@ -28,6 +28,20 @@ func TestStartSpinnerCountedNoopWhenNotText(t *testing.T) {
 	sp.Stop()
 	if buf.Len() != 0 {
 		t.Fatalf("expected no output for json, got %q", buf.String())
+	}
+}
+
+func TestStartSpinnerCountedNoopWhenAnimDisabled(t *testing.T) {
+	withTTY(t, true)
+	t.Setenv("PACTO_NO_ANIM", "1")
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&buf)
+	sp, count := startSpinnerCounted(cmd, "text", "Resolving")
+	count.Add(1) // counter still usable even when suppressed
+	sp.Stop()
+	if buf.Len() != 0 {
+		t.Fatalf("PACTO_NO_ANIM should suppress the counted spinner, got %q", buf.String())
 	}
 }
 

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func TestProgressLabel(t *testing.T) {
+	if got := progressLabel("Resolving deps…", 7); got != "Resolving deps… 7" {
+		t.Fatalf("got %q", got)
+	}
+	if got := progressLabel("X", 0); got != "X 0" {
+		t.Fatalf("zero count: got %q", got)
+	}
+}
+
+func TestStartSpinnerCountedNoopWhenNotText(t *testing.T) {
+	withTTY(t, true)
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&buf)
+	sp, count := startSpinnerCounted(cmd, "json", "Resolving")
+	count.Add(1) // counter still usable
+	sp.Stop()
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output for json, got %q", buf.String())
+	}
+}
+
+func TestStartSpinnerCountedAnimatesLiveCount(t *testing.T) {
+	withTTY(t, true)
+	t.Setenv("NO_COLOR", "")
+	orig := spinnerInterval
+	spinnerInterval = time.Millisecond
+	t.Cleanup(func() { spinnerInterval = orig })
+
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&buf)
+	sp, count := startSpinnerCounted(cmd, "text", "Resolving deps")
+	count.Add(3)
+	time.Sleep(10 * time.Millisecond) // let ticks render the bumped count
+	sp.Stop()
+
+	out := buf.String()
+	if !strings.Contains(out, "Resolving deps") {
+		t.Fatalf("expected base label, got %q", out)
+	}
+	if !strings.Contains(out, "Resolving deps 3") {
+		t.Fatalf("expected live count 3 in output, got %q", out)
+	}
+	if !strings.Contains(out, "\r\033[K") {
+		t.Fatalf("expected line-clear on stop, got %q", out)
+	}
+}

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -20,16 +20,18 @@ func newPullCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ref := args[0]
 			output, _ := cmd.Flags().GetString("output")
+			format := v.GetString(outputFormatKey)
 
+			sp := startSpinner(cmd, format, "Pulling "+ref)
 			result, err := svc.Pull(cmd.Context(), app.PullOptions{
 				Ref:    ref,
 				Output: output,
 			})
+			sp.Stop()
 			if err != nil {
 				return err
 			}
 
-			format := v.GetString(outputFormatKey)
 			return printPullResult(cmd, result, format)
 		},
 	}

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/trianalab/pacto/v2/internal/app"
@@ -22,15 +24,17 @@ func newPullCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 			output, _ := cmd.Flags().GetString("output")
 			format := v.GetString(outputFormatKey)
 
+			start := time.Now()
 			sp := startSpinner(cmd, format, "Pulling "+ref)
 			result, err := svc.Pull(cmd.Context(), app.PullOptions{
 				Ref:    ref,
 				Output: output,
 			})
-			sp.Stop()
 			if err != nil {
+				sp.Stop()
 				return err
 			}
+			sp.StopOK("Pulled", start)
 
 			return printPullResult(cmd, result, format)
 		},

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -27,13 +27,16 @@ func newPushCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 			ref := args[0]
 			path, _ := cmd.Flags().GetString("path")
 			force, _ := cmd.Flags().GetBool("force")
+			format := v.GetString(outputFormatKey)
 
+			sp := startSpinner(cmd, format, "Pushing "+ref)
 			result, err := svc.Push(cmd.Context(), app.PushOptions{
 				Ref:       ref,
 				Path:      path,
 				Force:     force,
 				Overrides: getOverrides(cmd),
 			})
+			sp.Stop()
 			if err != nil {
 				if errors.Is(err, app.ErrArtifactAlreadyExists) {
 					_, _ = fmt.Fprintf(cmd.OutOrStderr(), "Warning: %s\n", err)
@@ -42,7 +45,6 @@ func newPushCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 				return err
 			}
 
-			format := v.GetString(outputFormatKey)
 			return printPushResult(cmd, result, format)
 		},
 	}

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -29,6 +30,7 @@ func newPushCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 			force, _ := cmd.Flags().GetBool("force")
 			format := v.GetString(outputFormatKey)
 
+			start := time.Now()
 			sp := startSpinner(cmd, format, "Pushing "+ref)
 			result, err := svc.Push(cmd.Context(), app.PushOptions{
 				Ref:       ref,
@@ -36,14 +38,15 @@ func newPushCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 				Force:     force,
 				Overrides: getOverrides(cmd),
 			})
-			sp.Stop()
 			if err != nil {
+				sp.Stop()
 				if errors.Is(err, app.ErrArtifactAlreadyExists) {
 					_, _ = fmt.Fprintf(cmd.OutOrStderr(), "Warning: %s\n", err)
 					return nil
 				}
 				return err
 			}
+			sp.StopOK("Pushed", start)
 
 			return printPushResult(cmd, result, format)
 		},

--- a/internal/cli/reveal.go
+++ b/internal/cli/reveal.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/trianalab/pacto/v2/internal/app"
+)
+
+// revealStagger is a var so tests shrink it to ~1ms. ~300ms total / lines.
+var revealStagger = 60 * time.Millisecond
+
+// bannerLines returns the ANSI Shadow PACTO block + tagline, colored when color.
+// Colored rows are wrapped in "\033[36m"…"\033[0m" (cyan, matching the old banner
+// so the existing banner tests pass). Pure. The static banner is bannerFrame at
+// the final step.
+func bannerLines(color bool) []string {
+	rows := []string{
+		"██████╗  █████╗  ██████╗████████╗ ██████╗",
+		"██╔══██╗██╔══██╗██╔════╝╚══██╔══╝██╔═══██╗",
+		"██████╔╝███████║██║        ██║   ██║   ██║",
+		"██╔═══╝ ██╔══██║██║        ██║   ██║   ██║",
+		"██║     ██║  ██║╚██████╗   ██║   ╚██████╔╝",
+		"╚═╝     ╚═╝  ╚═╝ ╚═════╝   ╚═╝    ╚═════╝",
+	}
+	if color {
+		for i, row := range rows {
+			rows[i] = "\033[36m" + row + "\033[0m"
+		}
+	}
+	return append(rows, "  service contracts for cloud-native")
+}
+
+// bannerFrame returns the banner revealed up to `step` lines (color-swept/cascade).
+// step >= len → full static banner. Pure.
+func bannerFrame(step int, color bool) string {
+	lines := bannerLines(color)
+	if step >= len(lines) {
+		return strings.Join(lines, "\n") + "\n"
+	}
+	return strings.Join(lines[:step], "\n") + "\n"
+}
+
+// reveal prints frames[0..n] with revealStagger between them, synchronously.
+// First and last frame always emitted so a no-sleep test covers the render path.
+func reveal(w io.Writer, frame func(step int, color bool) string, steps int, color bool) {
+	// Emit first frame
+	_, _ = fmt.Fprint(w, frame(0, color))
+
+	// Emit intermediate frames
+	for i := 1; i < steps; i++ {
+		time.Sleep(revealStagger)
+		_, _ = fmt.Fprint(w, frame(i, color))
+	}
+
+	// Always emit final frame
+	_, _ = fmt.Fprint(w, frame(steps, color))
+}
+
+// initLines returns the exact 4 current strings, in order. Pure.
+func initLines(r *app.InitResult) []string {
+	return []string{
+		"Created " + r.Dir + "/",
+		"  " + r.Path,
+		"  " + r.Dir + "/interfaces/",
+		"  " + r.Dir + "/configuration/",
+	}
+}
+
+// revealInit prints lines[0] as-is (header), then lines[1:] each as scaffolded
+// items. animate(w) → staggered "  ✓ <path>"; else verbatim (byte-identical).
+func revealInit(w io.Writer, lines []string) {
+	if len(lines) == 0 {
+		return
+	}
+
+	// Print header
+	_, _ = fmt.Fprintln(w, lines[0])
+
+	if animate(w) {
+		// Animated path: stagger items with checkmarks
+		for _, item := range lines[1:] {
+			time.Sleep(revealStagger)
+			trimmed := strings.TrimLeft(item, " ")
+			_, _ = fmt.Fprintf(w, "  %s %s\n", checkGlyph(useColor(w)), trimmed)
+		}
+	} else {
+		// Off-gate path: verbatim output
+		for _, item := range lines[1:] {
+			_, _ = fmt.Fprintln(w, item)
+		}
+	}
+}

--- a/internal/cli/reveal.go
+++ b/internal/cli/reveal.go
@@ -33,21 +33,10 @@ func bannerLines(color bool) []string {
 }
 
 // bannerStatic returns the full banner, all rows printed at once. Pure.
+// The help banner is intentionally static (no animation); the cascade reveal is
+// reserved for `pacto init` (revealInit).
 func bannerStatic(color bool) string {
 	return strings.Join(bannerLines(color), "\n") + "\n"
-}
-
-// revealBanner prints the banner one row at a time with revealStagger between
-// rows — a top-to-bottom cascade. Each row is printed exactly once (no cumulative
-// reprinting), so it draws in cleanly and the final result equals bannerStatic.
-// Synchronous: finishes before the help text follows.
-func revealBanner(w io.Writer, color bool) {
-	for i, line := range bannerLines(color) {
-		if i > 0 {
-			time.Sleep(revealStagger)
-		}
-		_, _ = fmt.Fprintln(w, line)
-	}
 }
 
 // initLines returns the exact 4 current strings, in order. Pure.

--- a/internal/cli/reveal.go
+++ b/internal/cli/reveal.go
@@ -14,8 +14,7 @@ var revealStagger = 60 * time.Millisecond
 
 // bannerLines returns the ANSI Shadow PACTO block + tagline, colored when color.
 // Colored rows are wrapped in "\033[36m"…"\033[0m" (cyan, matching the old banner
-// so the existing banner tests pass). Pure. The static banner is bannerFrame at
-// the final step.
+// so the existing banner tests pass). Pure.
 func bannerLines(color bool) []string {
 	rows := []string{
 		"██████╗  █████╗  ██████╗████████╗ ██████╗",
@@ -33,30 +32,22 @@ func bannerLines(color bool) []string {
 	return append(rows, "  service contracts for cloud-native")
 }
 
-// bannerFrame returns the banner revealed up to `step` lines (color-swept/cascade).
-// step >= len → full static banner. Pure.
-func bannerFrame(step int, color bool) string {
-	lines := bannerLines(color)
-	if step >= len(lines) {
-		return strings.Join(lines, "\n") + "\n"
-	}
-	return strings.Join(lines[:step], "\n") + "\n"
+// bannerStatic returns the full banner, all rows printed at once. Pure.
+func bannerStatic(color bool) string {
+	return strings.Join(bannerLines(color), "\n") + "\n"
 }
 
-// reveal prints frames[0..n] with revealStagger between them, synchronously.
-// First and last frame always emitted so a no-sleep test covers the render path.
-func reveal(w io.Writer, frame func(step int, color bool) string, steps int, color bool) {
-	// Emit first frame
-	_, _ = fmt.Fprint(w, frame(0, color))
-
-	// Emit intermediate frames
-	for i := 1; i < steps; i++ {
-		time.Sleep(revealStagger)
-		_, _ = fmt.Fprint(w, frame(i, color))
+// revealBanner prints the banner one row at a time with revealStagger between
+// rows — a top-to-bottom cascade. Each row is printed exactly once (no cumulative
+// reprinting), so it draws in cleanly and the final result equals bannerStatic.
+// Synchronous: finishes before the help text follows.
+func revealBanner(w io.Writer, color bool) {
+	for i, line := range bannerLines(color) {
+		if i > 0 {
+			time.Sleep(revealStagger)
+		}
+		_, _ = fmt.Fprintln(w, line)
 	}
-
-	// Always emit final frame
-	_, _ = fmt.Fprint(w, frame(steps, color))
 }
 
 // initLines returns the exact 4 current strings, in order. Pure.

--- a/internal/cli/reveal_test.go
+++ b/internal/cli/reveal_test.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/trianalab/pacto/v2/internal/app"
+)
+
+func TestBannerFrameStatic(t *testing.T) {
+	full := bannerFrame(1<<30, true)
+	if !strings.Contains(full, "\033[36m") || !strings.Contains(full, "service contracts") {
+		t.Fatal("full banner missing parts")
+	}
+	if bannerFrame(0, true) == full {
+		t.Fatal("step 0 should be partial")
+	}
+}
+
+func TestRevealEmitsFirstAndLast(t *testing.T) {
+	orig := revealStagger
+	revealStagger = time.Millisecond
+	t.Cleanup(func() { revealStagger = orig })
+	var buf bytes.Buffer
+	reveal(&buf, bannerFrame, len(bannerLines(true)), true)
+	if !strings.Contains(buf.String(), "service contracts") {
+		t.Fatal("reveal must end on full frame")
+	}
+}
+
+func TestInitLines(t *testing.T) {
+	got := initLines(&app.InitResult{Dir: "svc", Path: "svc/pacto.yaml"})
+	want := []string{"Created svc/", "  svc/pacto.yaml", "  svc/interfaces/", "  svc/configuration/"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestRevealInitOffTTY(t *testing.T) {
+	withTTY(t, false)
+	var buf bytes.Buffer
+	revealInit(&buf, initLines(&app.InitResult{Dir: "svc", Path: "svc/pacto.yaml"}))
+	if buf.String() != "Created svc/\n  svc/pacto.yaml\n  svc/interfaces/\n  svc/configuration/\n" {
+		t.Fatalf("off-TTY init must be byte-identical: %q", buf.String())
+	}
+}
+
+func TestRevealInitTTY(t *testing.T) {
+	withTTY(t, true)
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("PACTO_NO_ANIM", "")
+	animDisabled = false
+	t.Cleanup(func() { animDisabled = false })
+	orig := revealStagger
+	revealStagger = time.Millisecond
+	t.Cleanup(func() { revealStagger = orig })
+	var buf bytes.Buffer
+	revealInit(&buf, initLines(&app.InitResult{Dir: "svc", Path: "svc/pacto.yaml"}))
+	if !strings.Contains(buf.String(), "✓") || !strings.Contains(buf.String(), "\033[32m") {
+		t.Fatal("TTY init should show green ✓")
+	}
+}
+
+func TestRevealInitEmptyLines(t *testing.T) {
+	var buf bytes.Buffer
+	revealInit(&buf, []string{})
+	if buf.Len() != 0 {
+		t.Fatal("empty lines should produce no output")
+	}
+}

--- a/internal/cli/reveal_test.go
+++ b/internal/cli/reveal_test.go
@@ -20,20 +20,15 @@ func TestBannerStatic(t *testing.T) {
 	}
 }
 
-func TestRevealBannerCascadeNoDuplication(t *testing.T) {
-	orig := revealStagger
-	revealStagger = time.Millisecond
-	t.Cleanup(func() { revealStagger = orig })
-	var buf bytes.Buffer
-	revealBanner(&buf, true)
-	// Cascade prints each row exactly once -> output must equal the static banner,
-	// i.e. no cumulative-frame stacking (the bug this guards against).
-	if got := buf.String(); got != bannerStatic(true) {
-		t.Fatalf("revealBanner output must equal bannerStatic (no duplication):\n%q", got)
-	}
-	// And the top row must appear exactly once.
-	if n := strings.Count(buf.String(), "██████╗  █████╗"); n != 1 {
+func TestBannerStaticNoDuplication(t *testing.T) {
+	// The help banner is static: each row appears exactly once (guards against the
+	// old cumulative-frame stacking bug).
+	out := bannerStatic(true)
+	if n := strings.Count(out, "██████╗  █████╗"); n != 1 {
 		t.Fatalf("top banner row should appear once, got %d", n)
+	}
+	if !strings.Contains(out, "service contracts") {
+		t.Fatal("banner missing tagline")
 	}
 }
 

--- a/internal/cli/reveal_test.go
+++ b/internal/cli/reveal_test.go
@@ -10,24 +10,30 @@ import (
 	"github.com/trianalab/pacto/v2/internal/app"
 )
 
-func TestBannerFrameStatic(t *testing.T) {
-	full := bannerFrame(1<<30, true)
+func TestBannerStatic(t *testing.T) {
+	full := bannerStatic(true)
 	if !strings.Contains(full, "\033[36m") || !strings.Contains(full, "service contracts") {
-		t.Fatal("full banner missing parts")
+		t.Fatal("colored full banner missing parts")
 	}
-	if bannerFrame(0, true) == full {
-		t.Fatal("step 0 should be partial")
+	if strings.Contains(bannerStatic(false), "\033[36m") {
+		t.Fatal("plain banner must not contain color codes")
 	}
 }
 
-func TestRevealEmitsFirstAndLast(t *testing.T) {
+func TestRevealBannerCascadeNoDuplication(t *testing.T) {
 	orig := revealStagger
 	revealStagger = time.Millisecond
 	t.Cleanup(func() { revealStagger = orig })
 	var buf bytes.Buffer
-	reveal(&buf, bannerFrame, len(bannerLines(true)), true)
-	if !strings.Contains(buf.String(), "service contracts") {
-		t.Fatal("reveal must end on full frame")
+	revealBanner(&buf, true)
+	// Cascade prints each row exactly once -> output must equal the static banner,
+	// i.e. no cumulative-frame stacking (the bug this guards against).
+	if got := buf.String(); got != bannerStatic(true) {
+		t.Fatalf("revealBanner output must equal bannerStatic (no duplication):\n%q", got)
+	}
+	// And the top row must appear exactly once.
+	if n := strings.Count(buf.String(), "██████╗  █████╗"); n != 1 {
+		t.Fatalf("top banner row should appear once, got %d", n)
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -140,9 +140,9 @@ func attachBanner(root *cobra.Command) {
 		if !cmd.HasParent() && useColor(out) {
 			na, _ := cmd.Flags().GetBool("no-anim") // PreRun didn't run on --help
 			if !na && os.Getenv("PACTO_NO_ANIM") == "" && isTerminal(out) {
-				reveal(out, bannerFrame, len(bannerLines(true)), true)
+				revealBanner(out, true)
 			} else {
-				_, _ = fmt.Fprint(out, bannerFrame(1<<30, true)) // full static
+				_, _ = fmt.Fprint(out, bannerStatic(true)) // full static
 			}
 		}
 		def(cmd, args)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -138,12 +138,7 @@ func attachBanner(root *cobra.Command) {
 	root.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		out := cmd.OutOrStdout()
 		if !cmd.HasParent() && useColor(out) {
-			na, _ := cmd.Flags().GetBool("no-anim") // PreRun didn't run on --help
-			if !na && os.Getenv("PACTO_NO_ANIM") == "" && isTerminal(out) {
-				revealBanner(out, true)
-			} else {
-				_, _ = fmt.Fprint(out, bannerStatic(true)) // full static
-			}
+			_, _ = fmt.Fprint(out, bannerStatic(true)) // static colored banner, no animation
 		}
 		def(cmd, args)
 	})

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -36,12 +36,14 @@ func NewRootCommand(svc *app.Service, info VersionInfo) *cobra.Command {
 	root.PersistentFlags().String("config", "", "config file path")
 	root.PersistentFlags().String(outputFormatKey, "text", "output format (text, json, markdown)")
 	root.PersistentFlags().Bool("no-cache", false, "disable OCI bundle cache")
+	root.PersistentFlags().Bool("no-anim", false, "disable animations")
 	root.PersistentFlags().BoolP("verbose", "v", false, "enable verbose output")
 
 	// Bind to Viper
 	_ = v.BindPFlag("config", root.PersistentFlags().Lookup("config"))
 	_ = v.BindPFlag(outputFormatKey, root.PersistentFlags().Lookup(outputFormatKey))
 	_ = v.BindPFlag("no-cache", root.PersistentFlags().Lookup("no-cache"))
+	_ = v.BindPFlag("no-anim", root.PersistentFlags().Lookup("no-anim"))
 	_ = v.BindPFlag("verbose", root.PersistentFlags().Lookup("verbose"))
 
 	// Env prefix
@@ -73,6 +75,8 @@ func NewRootCommand(svc *app.Service, info VersionInfo) *cobra.Command {
 				toggler.DisableCache()
 			}
 		}
+
+		animDisabled = v.GetBool("no-anim")
 
 		// Start async update check
 		if info.Version != "dev" && os.Getenv("PACTO_NO_UPDATE_CHECK") != "1" {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,7 +16,6 @@ import (
 
 const outputFormatKey = "output-format"
 
-
 // checkForUpdateFn is the function used to check for updates, overridable in tests.
 var checkForUpdateFn = update.CheckForUpdate
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,6 +16,14 @@ import (
 
 const outputFormatKey = "output-format"
 
+const banner = "\033[36m" +
+	"  ____           _        \n" +
+	" |  _ \\ __ _  __| |_ ___  \n" +
+	" | |_) / _` |/ _| __/ _ \\ \n" +
+	" |  __/ (_| | (_| || (_) |\n" +
+	" |_|   \\__,_|\\__|\\__\\___/ \n" +
+	"\033[0m\n"
+
 // checkForUpdateFn is the function used to check for updates, overridable in tests.
 var checkForUpdateFn = update.CheckForUpdate
 
@@ -124,5 +132,17 @@ func NewRootCommand(svc *app.Service, info VersionInfo) *cobra.Command {
 	root.AddCommand(newMCPCommand(svc, info.Version))
 	root.AddCommand(newDashboardCommand(svc, v, info.Version))
 
+	attachBanner(root)
 	return root
+}
+
+// attachBanner prints the colored logo above the root command's help on a TTY.
+func attachBanner(root *cobra.Command) {
+	def := root.HelpFunc()
+	root.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		if !cmd.HasParent() && useColor(cmd.OutOrStdout()) {
+			_, _ = fmt.Fprint(cmd.OutOrStdout(), banner)
+		}
+		def(cmd, args)
+	})
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,13 +16,6 @@ import (
 
 const outputFormatKey = "output-format"
 
-const banner = "\033[36m" +
-	"  ____           _        \n" +
-	" |  _ \\ __ _  __| |_ ___  \n" +
-	" | |_) / _` |/ _| __/ _ \\ \n" +
-	" |  __/ (_| | (_| || (_) |\n" +
-	" |_|   \\__,_|\\__|\\__\\___/ \n" +
-	"\033[0m\n"
 
 // checkForUpdateFn is the function used to check for updates, overridable in tests.
 var checkForUpdateFn = update.CheckForUpdate
@@ -140,8 +133,14 @@ func NewRootCommand(svc *app.Service, info VersionInfo) *cobra.Command {
 func attachBanner(root *cobra.Command) {
 	def := root.HelpFunc()
 	root.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		if !cmd.HasParent() && useColor(cmd.OutOrStdout()) {
-			_, _ = fmt.Fprint(cmd.OutOrStdout(), banner)
+		out := cmd.OutOrStdout()
+		if !cmd.HasParent() && useColor(out) {
+			na, _ := cmd.Flags().GetBool("no-anim") // PreRun didn't run on --help
+			if !na && os.Getenv("PACTO_NO_ANIM") == "" && isTerminal(out) {
+				reveal(out, bannerFrame, len(bannerLines(true)), true)
+			} else {
+				_, _ = fmt.Fprint(out, bannerFrame(1<<30, true)) // full static
+			}
 		}
 		def(cmd, args)
 	})

--- a/internal/cli/root_internal_test.go
+++ b/internal/cli/root_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/trianalab/pacto/v2/internal/app"
 	"github.com/trianalab/pacto/v2/internal/update"
@@ -32,6 +33,10 @@ func TestNewRootCommand_PanicRecovery(t *testing.T) {
 func TestBannerOnRootHelpTTY(t *testing.T) {
 	withTTY(t, true)
 	t.Setenv("NO_COLOR", "")
+	t.Setenv("PACTO_NO_ANIM", "")
+	orig := revealStagger
+	revealStagger = 1 * time.Millisecond
+	t.Cleanup(func() { revealStagger = orig })
 	root := NewRootCommand(nil, VersionInfo{Version: "dev"})
 	var buf bytes.Buffer
 	root.SetOut(&buf)
@@ -64,5 +69,22 @@ func TestNoBannerOnSubcommandHelp(t *testing.T) {
 	_ = root.Execute()
 	if strings.Contains(buf.String(), "\033[36m") {
 		t.Fatalf("banner should only show on root help, got %q", buf.String())
+	}
+}
+
+func TestBannerStaticWhenAnimDisabled(t *testing.T) {
+	withTTY(t, true)
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("PACTO_NO_ANIM", "1")
+	root := NewRootCommand(nil, VersionInfo{Version: "dev"})
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetArgs([]string{"--help"})
+	_ = root.Execute()
+	if !strings.Contains(buf.String(), "\033[36m") {
+		t.Fatalf("expected colored banner on root help, got %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "service contracts") {
+		t.Fatalf("expected full banner, got %q", buf.String())
 	}
 }

--- a/internal/cli/root_internal_test.go
+++ b/internal/cli/root_internal_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/trianalab/pacto/v2/internal/app"
@@ -25,5 +26,43 @@ func TestNewRootCommand_PanicRecovery(t *testing.T) {
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBannerOnRootHelpTTY(t *testing.T) {
+	withTTY(t, true)
+	t.Setenv("NO_COLOR", "")
+	root := NewRootCommand(nil, VersionInfo{Version: "dev"})
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetArgs([]string{"--help"})
+	_ = root.Execute()
+	if !strings.Contains(buf.String(), "\033[36m") {
+		t.Fatalf("expected colored banner on root help, got %q", buf.String())
+	}
+}
+
+func TestNoBannerWhenNotTTY(t *testing.T) {
+	withTTY(t, false)
+	root := NewRootCommand(nil, VersionInfo{Version: "dev"})
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetArgs([]string{"--help"})
+	_ = root.Execute()
+	if strings.Contains(buf.String(), "\033[36m") {
+		t.Fatalf("expected no banner without TTY, got %q", buf.String())
+	}
+}
+
+func TestNoBannerOnSubcommandHelp(t *testing.T) {
+	withTTY(t, true)
+	t.Setenv("NO_COLOR", "")
+	root := NewRootCommand(nil, VersionInfo{Version: "dev"})
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetArgs([]string{"version", "--help"})
+	_ = root.Execute()
+	if strings.Contains(buf.String(), "\033[36m") {
+		t.Fatalf("banner should only show on root help, got %q", buf.String())
 	}
 }

--- a/internal/cli/root_internal_test.go
+++ b/internal/cli/root_internal_test.go
@@ -47,6 +47,33 @@ func TestBannerOnRootHelpTTY(t *testing.T) {
 	}
 }
 
+func TestNoAnimFlagSetsAnimDisabled(t *testing.T) {
+	animDisabled = false
+	t.Cleanup(func() { animDisabled = false })
+	root := NewRootCommand(nil, VersionInfo{Version: "dev"})
+	root.SetArgs([]string{"--no-anim", "version"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !animDisabled {
+		t.Fatal("--no-anim should set animDisabled in PreRun")
+	}
+}
+
+func TestPactoNoAnimEnvSetsAnimDisabled(t *testing.T) {
+	animDisabled = false
+	t.Cleanup(func() { animDisabled = false })
+	t.Setenv("PACTO_NO_ANIM", "1")
+	root := NewRootCommand(nil, VersionInfo{Version: "dev"})
+	root.SetArgs([]string{"version"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !animDisabled {
+		t.Fatal("PACTO_NO_ANIM env should set animDisabled via viper")
+	}
+}
+
 func TestNoBannerWhenNotTTY(t *testing.T) {
 	withTTY(t, false)
 	root := NewRootCommand(nil, VersionInfo{Version: "dev"})

--- a/internal/cli/root_internal_test.go
+++ b/internal/cli/root_internal_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/trianalab/pacto/v2/internal/app"
 	"github.com/trianalab/pacto/v2/internal/update"
@@ -33,10 +32,6 @@ func TestNewRootCommand_PanicRecovery(t *testing.T) {
 func TestBannerOnRootHelpTTY(t *testing.T) {
 	withTTY(t, true)
 	t.Setenv("NO_COLOR", "")
-	t.Setenv("PACTO_NO_ANIM", "")
-	orig := revealStagger
-	revealStagger = 1 * time.Millisecond
-	t.Cleanup(func() { revealStagger = orig })
 	root := NewRootCommand(nil, VersionInfo{Version: "dev"})
 	var buf bytes.Buffer
 	root.SetOut(&buf)

--- a/internal/cli/spinner.go
+++ b/internal/cli/spinner.go
@@ -28,6 +28,47 @@ func useColor(w io.Writer) bool {
 	return os.Getenv("NO_COLOR") == "" && isTerminal(w)
 }
 
+// Animation gate. Set once in PersistentPreRunE; read directly on the help path.
+var animDisabled bool
+
+func animate(w io.Writer) bool {
+	return !animDisabled && os.Getenv("PACTO_NO_ANIM") == "" && useColor(w)
+}
+
+const (
+	glyphCheck = "✓" // U+2713
+	glyphCross = "✗" // U+2717
+)
+
+// checkGlyph returns a green ✓ when color, else a plain ✓. Pure.
+func checkGlyph(color bool) string {
+	if color {
+		return "\033[32m" + glyphCheck + "\033[0m"
+	}
+	return glyphCheck
+}
+
+// crossGlyph returns a red ✗ when color, else a plain ✗. Pure.
+func crossGlyph(color bool) string {
+	if color {
+		return "\033[31m" + glyphCross + "\033[0m"
+	}
+	return glyphCross
+}
+
+// okGlyph returns "✓ " (green when color enabled for w) or "" off-TTY/no-color.
+func okGlyph(w io.Writer) string {
+	if !useColor(w) {
+		return ""
+	}
+	return checkGlyph(true) + " "
+}
+
+// checkLine renders the spinner-success line, e.g. "✓ Pulled in 1.2s". Pure.
+func checkLine(label string, d time.Duration, color bool) string {
+	return fmt.Sprintf("%s %s in %s", checkGlyph(color), label, d.Round(100*time.Millisecond))
+}
+
 type spinner struct {
 	w     io.Writer
 	color bool
@@ -80,6 +121,17 @@ func (s *spinner) Stop() {
 	close(s.stop)
 	<-s.done
 	_, _ = fmt.Fprint(s.w, "\r\033[K")
+}
+
+// StopOK halts the spinner, clears its line, then prints checkLine on success.
+// No-op clear on a no-op spinner; the caller still gets the line printed.
+func (s *spinner) StopOK(label string, start time.Time) {
+	s.Stop() // existing clear of "\r\033[K"
+	w := s.w
+	if w == nil {
+		return
+	}
+	_, _ = fmt.Fprintln(w, checkLine(label, time.Since(start), s.color))
 }
 
 func frameGlyph(i int, color bool) string {

--- a/internal/cli/spinner.go
+++ b/internal/cli/spinner.go
@@ -71,6 +71,8 @@ func (s *spinner) run(label string) {
 }
 
 // Stop halts the spinner and clears its line. No-op on a no-op spinner.
+// Must be called exactly once per startSpinner: a second call on a live
+// spinner closes an already-closed channel and panics.
 func (s *spinner) Stop() {
 	if s.stop == nil {
 		return

--- a/internal/cli/spinner.go
+++ b/internal/cli/spinner.go
@@ -31,8 +31,18 @@ func useColor(w io.Writer) bool {
 // Animation gate. Set once in PersistentPreRunE; read directly on the help path.
 var animDisabled bool
 
+// animationsEnabled reports whether motion is allowed at all (--no-anim flag and
+// PACTO_NO_ANIM env both off). It does NOT consider color or TTY — callers add
+// those. This governs the spinner (motion regardless of color); animate adds
+// color on top for color-only reveals.
+func animationsEnabled() bool {
+	return !animDisabled && os.Getenv("PACTO_NO_ANIM") == ""
+}
+
+// animate reports whether a colored animation should play on w: motion enabled
+// AND color enabled (TTY + NO_COLOR unset).
 func animate(w io.Writer) bool {
-	return !animDisabled && os.Getenv("PACTO_NO_ANIM") == "" && useColor(w)
+	return animationsEnabled() && useColor(w)
 }
 
 const (
@@ -81,7 +91,7 @@ type spinner struct {
 // CI logs stay clean.
 func startSpinner(cmd *cobra.Command, format, label string) *spinner {
 	w := cmd.ErrOrStderr()
-	if format != "text" || !isTerminal(w) {
+	if format != "text" || !isTerminal(w) || !animationsEnabled() {
 		return &spinner{}
 	}
 	s := &spinner{

--- a/internal/cli/spinner.go
+++ b/internal/cli/spinner.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// spinnerInterval is a var (not const) so tests can shrink it for deterministic ticks.
+var spinnerInterval = 100 * time.Millisecond
+
+// isTerminal reports whether w is a terminal. Overridable in tests.
+var isTerminal = defaultIsTerminal
+
+func defaultIsTerminal(w io.Writer) bool {
+	f, ok := w.(interface{ Fd() uintptr })
+	return ok && term.IsTerminal(int(f.Fd()))
+}
+
+// useColor reports whether ANSI color should be emitted to w.
+func useColor(w io.Writer) bool {
+	return os.Getenv("NO_COLOR") == "" && isTerminal(w)
+}
+
+type spinner struct {
+	w     io.Writer
+	color bool
+	stop  chan struct{}
+	done  chan struct{}
+}
+
+// startSpinner animates on stderr until Stop is called. It is a no-op when
+// format is not "text" or stderr is not a terminal, so JSON output, pipes and
+// CI logs stay clean.
+func startSpinner(cmd *cobra.Command, format, label string) *spinner {
+	w := cmd.ErrOrStderr()
+	if format != "text" || !isTerminal(w) {
+		return &spinner{}
+	}
+	s := &spinner{
+		w:     w,
+		color: useColor(w),
+		stop:  make(chan struct{}),
+		done:  make(chan struct{}),
+	}
+	writeFrame(w, frameGlyph(0, s.color), label) // first frame synchronously
+	go s.run(label)
+	return s
+}
+
+func (s *spinner) run(label string) {
+	defer close(s.done)
+	t := time.NewTicker(spinnerInterval)
+	defer t.Stop()
+	i := 0
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-t.C:
+			i = (i + 1) % len(spinnerFrames)
+			writeFrame(s.w, frameGlyph(i, s.color), label)
+		}
+	}
+}
+
+// Stop halts the spinner and clears its line. No-op on a no-op spinner.
+func (s *spinner) Stop() {
+	if s.stop == nil {
+		return
+	}
+	close(s.stop)
+	<-s.done
+	_, _ = fmt.Fprint(s.w, "\r\033[K")
+}
+
+func frameGlyph(i int, color bool) string {
+	g := spinnerFrames[i]
+	if color {
+		return "\033[36m" + g + "\033[0m"
+	}
+	return g
+}
+
+func writeFrame(w io.Writer, glyph, label string) {
+	_, _ = fmt.Fprintf(w, "\r%s %s", glyph, label)
+}

--- a/internal/cli/spinner_test.go
+++ b/internal/cli/spinner_test.go
@@ -53,6 +53,20 @@ func TestStartSpinnerNoopWhenNotTTY(t *testing.T) {
 	}
 }
 
+func TestStartSpinnerNoopWhenAnimDisabled(t *testing.T) {
+	withTTY(t, true)
+	animDisabled = true
+	t.Cleanup(func() { animDisabled = false })
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&buf)
+	sp := startSpinner(cmd, "text", "Pulling")
+	sp.Stop()
+	if buf.Len() != 0 {
+		t.Fatalf("--no-anim should suppress the spinner, got %q", buf.String())
+	}
+}
+
 func TestStartSpinnerAnimatesAndClears(t *testing.T) {
 	withTTY(t, true)
 	t.Setenv("NO_COLOR", "") // ensure color path

--- a/internal/cli/spinner_test.go
+++ b/internal/cli/spinner_test.go
@@ -107,3 +107,68 @@ func TestStartSpinnerNoColorFrame(t *testing.T) {
 		t.Fatalf("expected label, got %q", out)
 	}
 }
+
+func TestGlyphs(t *testing.T) {
+	if checkGlyph(false) != "✓" || crossGlyph(false) != "✗" {
+		t.Fatal("plain glyphs wrong")
+	}
+	if !strings.Contains(checkGlyph(true), "\033[32m") || !strings.Contains(crossGlyph(true), "\033[31m") {
+		t.Fatal("colored glyphs missing ANSI")
+	}
+}
+
+func TestOkGlyph(t *testing.T) {
+	withTTY(t, true)
+	t.Setenv("NO_COLOR", "")
+	if !strings.Contains(okGlyph(&bytes.Buffer{}), "✓") {
+		t.Fatal("TTY okGlyph should have check")
+	}
+	withTTY(t, false)
+	if okGlyph(&bytes.Buffer{}) != "" {
+		t.Fatal("non-TTY okGlyph must be empty")
+	}
+}
+
+func TestCheckLine(t *testing.T) {
+	got := checkLine("Pulled", 1234*time.Millisecond, false)
+	if got != "✓ Pulled in 1.2s" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestAnimate(t *testing.T) {
+	withTTY(t, true)
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("PACTO_NO_ANIM", "")
+	animDisabled = false
+	t.Cleanup(func() { animDisabled = false })
+	if !animate(&bytes.Buffer{}) {
+		t.Fatal("should animate on TTY")
+	}
+	animDisabled = true
+	if animate(&bytes.Buffer{}) {
+		t.Fatal("animDisabled must disable")
+	}
+	animDisabled = false
+	t.Setenv("PACTO_NO_ANIM", "1")
+	if animate(&bytes.Buffer{}) {
+		t.Fatal("PACTO_NO_ANIM must disable")
+	}
+}
+
+func TestStopOK(t *testing.T) {
+	withTTY(t, true)
+	t.Setenv("NO_COLOR", "")
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&buf)
+	sp := startSpinner(cmd, "text", "x")
+	sp.StopOK("Pulled", time.Now().Add(-time.Second))
+	out := buf.String()
+	if !strings.Contains(out, "✓") || !strings.Contains(out, "Pulled in") {
+		t.Fatalf("StopOK line missing: %q", out)
+	}
+	// no-op spinner: no panic, no success line
+	noop := startSpinner(&cobra.Command{}, "json", "x") // non-text -> no-op
+	noop.StopOK("X", time.Now())
+}

--- a/internal/cli/spinner_test.go
+++ b/internal/cli/spinner_test.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// withTTY forces isTerminal to report v and restores it after the test.
+func withTTY(t *testing.T, v bool) {
+	t.Helper()
+	orig := isTerminal
+	isTerminal = func(io.Writer) bool { return v }
+	t.Cleanup(func() { isTerminal = orig })
+}
+
+func TestDefaultIsTerminal(t *testing.T) {
+	// no Fd() -> short-circuits to false
+	if defaultIsTerminal(&bytes.Buffer{}) {
+		t.Fatal("buffer is not a terminal")
+	}
+	// os.Stdout has Fd(); under `go test` it is not a TTY, so this returns
+	// false, but it executes the term.IsTerminal line for coverage.
+	_ = defaultIsTerminal(os.Stdout)
+}
+
+func TestStartSpinnerNoopWhenNotText(t *testing.T) {
+	withTTY(t, true)
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&buf)
+	sp := startSpinner(cmd, "json", "Pulling")
+	sp.Stop()
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output for json format, got %q", buf.String())
+	}
+}
+
+func TestStartSpinnerNoopWhenNotTTY(t *testing.T) {
+	withTTY(t, false)
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&buf)
+	sp := startSpinner(cmd, "text", "Pulling")
+	sp.Stop()
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output without TTY, got %q", buf.String())
+	}
+}
+
+func TestStartSpinnerAnimatesAndClears(t *testing.T) {
+	withTTY(t, true)
+	t.Setenv("NO_COLOR", "") // ensure color path
+	orig := spinnerInterval
+	spinnerInterval = time.Millisecond
+	t.Cleanup(func() { spinnerInterval = orig })
+
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&buf)
+	sp := startSpinner(cmd, "text", "Pulling")
+	time.Sleep(10 * time.Millisecond) // let several ticks fire
+	sp.Stop()
+
+	out := buf.String()
+	if !strings.Contains(out, "Pulling") {
+		t.Fatalf("expected label in output, got %q", out)
+	}
+	if !strings.Contains(out, "\033[36m") {
+		t.Fatalf("expected cyan color in output, got %q", out)
+	}
+	if !strings.Contains(out, "\r\033[K") {
+		t.Fatalf("expected line-clear on stop, got %q", out)
+	}
+}
+
+func TestUseColorRespectsNoColor(t *testing.T) {
+	withTTY(t, true)
+	t.Setenv("NO_COLOR", "1")
+	if useColor(&bytes.Buffer{}) {
+		t.Fatal("NO_COLOR set should disable color")
+	}
+	t.Setenv("NO_COLOR", "")
+	if !useColor(&bytes.Buffer{}) {
+		t.Fatal("TTY + no NO_COLOR should enable color")
+	}
+}
+
+func TestStartSpinnerNoColorFrame(t *testing.T) {
+	withTTY(t, true)
+	t.Setenv("NO_COLOR", "1")
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&buf)
+	sp := startSpinner(cmd, "text", "Pushing")
+	sp.Stop()
+	out := buf.String()
+	if strings.Contains(out, "\033[36m") {
+		t.Fatalf("expected no color with NO_COLOR set, got %q", out)
+	}
+	if !strings.Contains(out, "Pushing") {
+		t.Fatalf("expected label, got %q", out)
+	}
+}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -31,17 +31,19 @@ func newValidateCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := optionalArg(args)
 			checkReadiness, _ := cmd.Flags().GetBool("readiness")
+			format := v.GetString(outputFormatKey)
 
+			sp := startSpinner(cmd, format, "Validating")
 			result, err := svc.Validate(cmd.Context(), app.ValidateOptions{
 				Path:      path,
 				Overrides: getOverrides(cmd),
 				Readiness: checkReadiness,
 			})
+			sp.Stop()
 			if err != nil {
 				return err
 			}
 
-			format := v.GetString(outputFormatKey)
 			if err := printValidateResult(cmd, result, format); err != nil {
 				return err
 			}

--- a/pkg/graph/render.go
+++ b/pkg/graph/render.go
@@ -5,27 +5,49 @@ import (
 	"strings"
 )
 
+// TreeColors holds optional colorizer functions applied to tree tokens.
+// A nil field is treated as identity, so the zero value renders plain text.
+type TreeColors struct {
+	Name    func(string) string // node / ref display name
+	Version func(string) string // @version
+	Marker  func(string) string // [local], [ref], (shared)
+	Error   func(string) string // (error: ...)
+	Warn    func(string) string // cycle / conflict lines
+}
+
+func apply(fn func(string) string, s string) string {
+	if fn == nil {
+		return s
+	}
+	return fn(s)
+}
+
 // RenderTree renders the dependency graph as a tree-style string
 // similar to the Unix tree command.
 func RenderTree(r *Result) string {
+	return RenderTreeColored(r, TreeColors{})
+}
+
+// RenderTreeColored renders the tree applying the given colorizers.
+func RenderTreeColored(r *Result, col TreeColors) string {
 	if r == nil || r.Root == nil {
 		return ""
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s@%s\n", r.Root.Name, r.Root.Version)
-	renderChildren(&b, r.Root.Dependencies, "")
+	fmt.Fprintf(&b, "%s@%s\n", apply(col.Name, r.Root.Name), apply(col.Version, r.Root.Version))
+	renderChildren(&b, r.Root.Dependencies, "", col)
 
 	if len(r.Cycles) > 0 {
 		fmt.Fprintf(&b, "\nCycles (%d):\n", len(r.Cycles))
 		for _, cycle := range r.Cycles {
-			fmt.Fprintf(&b, "  %s\n", strings.Join(cycle, " -> "))
+			fmt.Fprintf(&b, "  %s\n", apply(col.Warn, strings.Join(cycle, " -> ")))
 		}
 	}
 
 	if len(r.Conflicts) > 0 {
 		fmt.Fprintf(&b, "\nConflicts (%d):\n", len(r.Conflicts))
 		for _, c := range r.Conflicts {
-			fmt.Fprintf(&b, "  %s: %v\n", c.Name, c.Versions)
+			fmt.Fprintf(&b, "  %s\n", apply(col.Warn, fmt.Sprintf("%s: %v", c.Name, c.Versions)))
 		}
 	}
 
@@ -57,34 +79,34 @@ func treeConnectors(isLast bool) (connector, childPrefix string) {
 	return "├─ ", "│  "
 }
 
-func renderChildren(b *strings.Builder, edges []Edge, prefix string) {
+func renderChildren(b *strings.Builder, edges []Edge, prefix string, col TreeColors) {
 	for i, edge := range edges {
 		connector, childPrefix := treeConnectors(i == len(edges)-1)
 
 		// Reference edges use a distinct notation
 		if edge.Type == EdgeReference {
-			fmt.Fprintf(b, "%s%s%s [ref]\n", prefix, connector, ShortRef(edge.Ref))
+			fmt.Fprintf(b, "%s%s%s %s\n", prefix, connector, apply(col.Name, ShortRef(edge.Ref)), apply(col.Marker, "[ref]"))
 			continue
 		}
 
 		if edge.Error != "" {
-			fmt.Fprintf(b, "%s%s%s (error: %s)\n", prefix, connector, ShortRef(edge.Ref), edge.Error)
+			fmt.Fprintf(b, "%s%s%s %s\n", prefix, connector, apply(col.Name, ShortRef(edge.Ref)), apply(col.Error, fmt.Sprintf("(error: %s)", edge.Error)))
 			continue
 		}
 
 		if edge.Node != nil {
-			label := edge.Node.Name + "@" + edge.Node.Version
+			label := apply(col.Name, edge.Node.Name) + "@" + apply(col.Version, edge.Node.Version)
 			if edge.Node.Local {
-				label += " [local]"
+				label += " " + apply(col.Marker, "[local]")
 			}
 			if edge.Shared {
-				fmt.Fprintf(b, "%s%s%s (shared)\n", prefix, connector, label)
+				fmt.Fprintf(b, "%s%s%s %s\n", prefix, connector, label, apply(col.Marker, "(shared)"))
 			} else {
 				fmt.Fprintf(b, "%s%s%s\n", prefix, connector, label)
-				renderChildren(b, edge.Node.Dependencies, prefix+childPrefix)
+				renderChildren(b, edge.Node.Dependencies, prefix+childPrefix, col)
 			}
 		} else {
-			fmt.Fprintf(b, "%s%s%s\n", prefix, connector, ShortRef(edge.Ref))
+			fmt.Fprintf(b, "%s%s%s\n", prefix, connector, apply(col.Name, ShortRef(edge.Ref)))
 		}
 	}
 }

--- a/pkg/graph/render_test.go
+++ b/pkg/graph/render_test.go
@@ -220,3 +220,59 @@ func TestShortRef(t *testing.T) {
 		}
 	}
 }
+
+func TestRenderTreeColoredIdentityMatchesPlain(t *testing.T) {
+	r := &Result{
+		Root: &Node{
+			Name:    "svc",
+			Version: "1.0.0",
+			Dependencies: []Edge{
+				{Ref: "reg/dep:1.0.0", Node: &Node{Name: "dep", Version: "1.0.0"}},
+			},
+		},
+	}
+	if RenderTreeColored(r, TreeColors{}) != RenderTree(r) {
+		t.Fatal("zero TreeColors must equal plain RenderTree")
+	}
+}
+
+func TestRenderTreeColoredAppliesColors(t *testing.T) {
+	wrap := func(tag string) func(string) string {
+		return func(s string) string { return "<" + tag + ">" + s + "</" + tag + ">" }
+	}
+	col := TreeColors{
+		Name:    wrap("n"),
+		Version: wrap("v"),
+		Marker:  wrap("m"),
+		Error:   wrap("e"),
+		Warn:    wrap("w"),
+	}
+	// Build a Result exercising: normal dep, local dep, shared dep, ref edge,
+	// error edge, cycles, conflicts.
+	r := &Result{
+		Root: &Node{
+			Name:    "root",
+			Version: "1.0.0",
+			Dependencies: []Edge{
+				{Ref: "reg/a:1.0.0", Node: &Node{Name: "a", Version: "1.0.0"}},
+				{Ref: "../b", Local: true, Node: &Node{Name: "b", Version: "2.0.0", Local: true}},
+				{Ref: "reg/c:3.0.0", Shared: true, Node: &Node{Name: "c", Version: "3.0.0"}},
+				{Ref: "ghcr.io/x/cfg:1.0.0", Type: EdgeReference},
+				{Ref: "ghcr.io/x/broken:1.0.0", Error: "boom"},
+			},
+		},
+		Cycles:    [][]string{{"a", "b", "a"}},
+		Conflicts: []Conflict{{Name: "c", Versions: []string{"c@3.0.0", "c@4.0.0"}}},
+	}
+	out := RenderTreeColored(r, col)
+	for _, want := range []string{
+		"<n>root</n>", "<v>1.0.0</v>", // root name/version
+		"<m>[local]</m>", "<m>[ref]</m>", "<m>(shared)</m>",
+		"<e>(error: boom)</e>",
+		"<w>a -> b -> a</w>",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in:\n%s", want, out)
+		}
+	}
+}

--- a/pkg/graph/renderdiff.go
+++ b/pkg/graph/renderdiff.go
@@ -6,21 +6,36 @@ import (
 	"strings"
 )
 
+// DiffColors holds optional colorizer functions applied to diff tree labels.
+// A nil field is treated as identity, so the zero value renders plain text.
+type DiffColors struct {
+	Name    func(string) string // node name (recommended nil — alignment safety)
+	Added   func(string) string
+	Removed func(string) string
+	Changed func(string) string
+}
+
 // RenderDiffTree renders a graph diff as a tree-style string,
 // showing only nodes that have changes in their subtree.
 // Uses the same tree connectors as RenderTree for consistency.
 func RenderDiffTree(d *GraphDiff) string {
+	return RenderDiffTreeColored(d, DiffColors{})
+}
+
+// RenderDiffTreeColored renders a graph diff as a tree-style string with
+// optional colorizers applied to change labels.
+func RenderDiffTreeColored(d *GraphDiff, col DiffColors) string {
 	if d == nil || len(d.Changes) == 0 {
 		return ""
 	}
 
 	var b strings.Builder
-	fmt.Fprintln(&b, d.Root.Name)
-	renderDiffChildren(&b, d.Root.Children, "")
+	fmt.Fprintln(&b, apply(col.Name, d.Root.Name))
+	renderDiffChildren(&b, d.Root.Children, "", col)
 	return b.String()
 }
 
-func renderDiffChildren(b *strings.Builder, children []DiffNode, prefix string) {
+func renderDiffChildren(b *strings.Builder, children []DiffNode, prefix string, col DiffColors) {
 	// Filter to only children that have changes in their subtree.
 	var relevant []DiffNode
 	for _, child := range children {
@@ -32,10 +47,10 @@ func renderDiffChildren(b *strings.Builder, children []DiffNode, prefix string) 
 	for i, child := range relevant {
 		connector, childPrefix := treeConnectors(i == len(relevant)-1)
 
-		label := formatDiffLabel(child)
+		label := formatDiffLabel(child, col)
 		fmt.Fprintf(b, "%s%s%s\n", prefix, connector, label)
 
-		renderDiffChildren(b, child.Children, prefix+childPrefix)
+		renderDiffChildren(b, child.Children, prefix+childPrefix, col)
 	}
 }
 
@@ -43,20 +58,29 @@ func renderDiffChildren(b *strings.Builder, children []DiffNode, prefix string) 
 // tree, sized so the version transition that follows lines up across rows.
 const diffLabelWidth = 14
 
-func formatDiffLabel(n DiffNode) string {
+func formatDiffLabel(n DiffNode, col DiffColors) string {
+	var label string
+	var picker func(string) string
 	if n.Change == nil {
-		return n.Name
+		label = n.Name
+		picker = col.Name
+	} else {
+		switch n.Change.ChangeType {
+		case VersionChanged:
+			label = fmt.Sprintf("%-*s%s → %s", diffLabelWidth, n.Name, n.Change.OldVersion, n.Change.NewVersion)
+			picker = col.Changed
+		case AddedNode:
+			label = fmt.Sprintf("%-*s+%s", diffLabelWidth, n.Name, n.Change.NewVersion)
+			picker = col.Added
+		case RemovedNode:
+			label = fmt.Sprintf("%-*s-%s", diffLabelWidth, n.Name, n.Change.OldVersion)
+			picker = col.Removed
+		default:
+			label = n.Name
+			picker = col.Name
+		}
 	}
-	switch n.Change.ChangeType {
-	case VersionChanged:
-		return fmt.Sprintf("%-*s%s → %s", diffLabelWidth, n.Name, n.Change.OldVersion, n.Change.NewVersion)
-	case AddedNode:
-		return fmt.Sprintf("%-*s+%s", diffLabelWidth, n.Name, n.Change.NewVersion)
-	case RemovedNode:
-		return fmt.Sprintf("%-*s-%s", diffLabelWidth, n.Name, n.Change.OldVersion)
-	default:
-		return n.Name
-	}
+	return apply(picker, label)
 }
 
 // hasChanges returns true if the node or any of its descendants have a change.

--- a/pkg/graph/renderdiff_test.go
+++ b/pkg/graph/renderdiff_test.go
@@ -237,8 +237,55 @@ func TestHasChanges(t *testing.T) {
 
 func TestFormatDiffLabel_UnknownType(t *testing.T) {
 	n := DiffNode{Name: "x", Change: &GraphChange{ChangeType: "unknown"}}
-	got := formatDiffLabel(n)
+	got := formatDiffLabel(n, DiffColors{})
 	if got != "x" {
 		t.Errorf("expected 'x', got %q", got)
+	}
+}
+
+func TestRenderDiffTreeColoredIdentityMatchesPlain(t *testing.T) {
+	d := &GraphDiff{
+		Root: DiffNode{
+			Name: "root",
+			Children: []DiffNode{
+				{Name: "svc-a", Version: "v1.0.0", Change: &GraphChange{Name: "svc-a", ChangeType: AddedNode, NewVersion: "v1.0.0"}},
+			},
+		},
+		Changes: []GraphChange{{Name: "svc-a", ChangeType: AddedNode, NewVersion: "v1.0.0"}},
+	}
+	if RenderDiffTreeColored(d, DiffColors{}) != RenderDiffTree(d) {
+		t.Fatal("zero DiffColors must equal plain RenderDiffTree")
+	}
+}
+
+func TestRenderDiffTreeColoredAppliesColors(t *testing.T) {
+	wrap := func(tag string) func(string) string {
+		return func(s string) string { return "<" + tag + ">" + s + "</" + tag + ">" }
+	}
+	col := DiffColors{Added: wrap("a"), Removed: wrap("r"), Changed: wrap("c"), Name: wrap("n")}
+	d := &GraphDiff{
+		Root: DiffNode{
+			Name: "root",
+			Children: []DiffNode{
+				{Name: "added", Version: "v1.0.0", Change: &GraphChange{Name: "added", ChangeType: AddedNode, NewVersion: "v1.0.0"}},
+				{Name: "removed", Version: "v1.0.0", Change: &GraphChange{Name: "removed", ChangeType: RemovedNode, OldVersion: "v1.0.0"}},
+				{Name: "changed", Version: "v2.0.0", Change: &GraphChange{Name: "changed", ChangeType: VersionChanged, OldVersion: "v1.0.0", NewVersion: "v2.0.0"}},
+				{Name: "intermediate", Version: "v1.0.0", Children: []DiffNode{
+					{Name: "nested", Version: "v1.0.0", Change: &GraphChange{Name: "nested", ChangeType: AddedNode, NewVersion: "v1.0.0"}},
+				}},
+			},
+		},
+		Changes: []GraphChange{
+			{Name: "added", ChangeType: AddedNode, NewVersion: "v1.0.0"},
+			{Name: "removed", ChangeType: RemovedNode, OldVersion: "v1.0.0"},
+			{Name: "changed", ChangeType: VersionChanged, OldVersion: "v1.0.0", NewVersion: "v2.0.0"},
+			{Name: "nested", ChangeType: AddedNode, NewVersion: "v1.0.0"},
+		},
+	}
+	out := RenderDiffTreeColored(d, col)
+	for _, want := range []string{"<a>", "<r>", "<c>", "<n>"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in:\n%s", want, out)
+		}
 	}
 }

--- a/pkg/graph/resolver.go
+++ b/pkg/graph/resolver.go
@@ -59,6 +59,11 @@ type Result struct {
 type ResolveOptions struct {
 	IncludeReferences bool // include config/policy reference edges
 	OnlyReferences    bool // show only reference edges (no dependencies)
+	// OnResolved is fired exactly once per UNIQUE fetched node (not per edge:
+	// shared edges and cycles re-traverse and must NOT re-fire). nil = no-op.
+	// It is invoked from multiple goroutines (sibling deps resolve concurrently),
+	// so it MUST be goroutine-safe.
+	OnResolved func()
 }
 
 // resolver holds shared state for a single graph resolution pass.
@@ -251,6 +256,12 @@ func (r *resolver) resolveEdge(ctx context.Context, dep contract.Dependency, pat
 	delete(r.pending, dep.Ref)
 	r.mu.Unlock()
 	close(ch)
+
+	// Fire once per unique fetched node (the dedup/commit point above). Shared
+	// edges and cycles return earlier and never reach here, so they never refire.
+	if r.opts.OnResolved != nil {
+		r.opts.OnResolved()
+	}
 
 	childPath := append(append([]string{}, path...), dep.Ref)
 	node.Dependencies = r.resolveChildren(ctx, bundle.Contract.Dependencies, childPath)

--- a/pkg/graph/resolver_test.go
+++ b/pkg/graph/resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/trianalab/pacto/v2/pkg/contract"
@@ -1044,6 +1045,75 @@ func TestResolve_FetchErrorParallel(t *testing.T) {
 	missingEdge := result.Root.Dependencies[1]
 	if missingEdge.Error == "" {
 		t.Error("expected error for missing ref")
+	}
+}
+
+// TestResolveOnResolvedFiresPerUniqueNode asserts OnResolved fires exactly once
+// per UNIQUE fetched node, not per edge: a diamond (root -> b, root -> c, b -> d,
+// c -> d) has 4 edges to d's subtree but only 3 unique fetched nodes (b, c, d).
+func TestResolveOnResolvedFiresPerUniqueNode(t *testing.T) {
+	fetcher := &mockFetcher{
+		contracts: map[string]*contract.Contract{
+			"oci://registry.io/svc-b:1.0.0": {
+				Service: contract.ServiceIdentity{Name: "svc-b", Version: "1.0.0"},
+				Dependencies: []contract.Dependency{
+					{Ref: "oci://registry.io/svc-d:1.0.0", Required: true},
+				},
+			},
+			"oci://registry.io/svc-c:1.0.0": {
+				Service: contract.ServiceIdentity{Name: "svc-c", Version: "1.0.0"},
+				Dependencies: []contract.Dependency{
+					{Ref: "oci://registry.io/svc-d:1.0.0", Required: true},
+				},
+			},
+			"oci://registry.io/svc-d:1.0.0": {
+				Service: contract.ServiceIdentity{Name: "svc-d", Version: "1.0.0"},
+			},
+		},
+	}
+	c := &contract.Contract{
+		Service: contract.ServiceIdentity{Name: "svc-a", Version: "1.0.0"},
+		Dependencies: []contract.Dependency{
+			{Ref: "oci://registry.io/svc-b:1.0.0", Required: true},
+			{Ref: "oci://registry.io/svc-c:1.0.0", Required: true},
+		},
+	}
+
+	var n int64
+	opts := ResolveOptions{OnResolved: func() { atomic.AddInt64(&n, 1) }}
+	ResolveWithOptions(context.Background(), c, fetcher, opts)
+
+	if got := atomic.LoadInt64(&n); got != 3 {
+		t.Fatalf("expected 3 unique-node fires (b, c, d once), got %d", got)
+	}
+}
+
+// TestResolveOnResolvedNilDoesNotPanic asserts a nil OnResolved resolves
+// identically to a no-callback resolve (default Resolve behaviour preserved).
+func TestResolveOnResolvedNilDoesNotPanic(t *testing.T) {
+	fetcher := &mockFetcher{
+		contracts: map[string]*contract.Contract{
+			"oci://registry.io/svc-b:1.0.0": {
+				Service: contract.ServiceIdentity{Name: "svc-b", Version: "1.0.0"},
+			},
+		},
+	}
+	c := &contract.Contract{
+		Service: contract.ServiceIdentity{Name: "svc-a", Version: "1.0.0"},
+		Dependencies: []contract.Dependency{
+			{Ref: "oci://registry.io/svc-b:1.0.0", Required: true},
+		},
+	}
+
+	withNil := ResolveWithOptions(context.Background(), c, fetcher, ResolveOptions{OnResolved: nil})
+	plain := Resolve(context.Background(), c, fetcher)
+
+	if len(withNil.Root.Dependencies) != len(plain.Root.Dependencies) {
+		t.Fatalf("nil OnResolved changed resolution: %d vs %d deps",
+			len(withNil.Root.Dependencies), len(plain.Root.Dependencies))
+	}
+	if withNil.Root.Dependencies[0].Node == nil {
+		t.Fatal("nil OnResolved should still resolve the dependency node")
 	}
 }
 


### PR DESCRIPTION
## What

Brings genuinely enjoyable, **fully TTY-gated** UX to the pacto CLI. Every decoration is inert in non-interactive contexts (pipes, JSON/markdown, CI) — output stays byte-for-byte identical to before.

### Phase 1 — foundation
- **Spinner** on network-bound commands (`pull`, `push`, `lock`, `validate`, `graph`, `diff`), stderr-only, no-op off-TTY/JSON.
- **Colored graph tree** (`RenderTreeColored`, ANSI injected from the CLI; `pkg/graph` stays ANSI-free).
- **Banner** on root `--help`.

### Phase 2 — UX delight
- **Animated ANSI-Shadow `PACTO` banner** + tagline, one-time reveal then static (root help only).
- **Item-based progress** — live count during `lock`/`graph` closure resolution (resolver callback → atomic counter).
- **Spinner → green `✓` + elapsed** on success (`✓ Pulled in 1.2s`).
- **Colored results** — validate `✓`/`✗`, diff `BREAKING`/`NON_BREAKING` classification (display-only — raw value still drives the exit code) + colored diff tree (`RenderDiffTreeColored`).
- **Success glyphs** on push/pull/pack/lock/init result lines.
- **`pacto init` reveal** — scaffolded files appear with green checkmarks.
- **`--no-anim` flag + `PACTO_NO_ANIM`** to disable all animation (color independently governed by `NO_COLOR`).

## Gating model

- `useColor(w)` = `NO_COLOR` unset **and** TTY → governs color.
- `animate(w)` = `!--no-anim` **and** `PACTO_NO_ANIM` unset **and** `useColor(w)` → governs animation.
- Spinner/progress write to **stderr**; result/JSON/markdown payloads on **stdout** are never decorated.

## Out of scope (deliberate)

- Byte-level progress bars (pacto bundles are KB-sized; go-containerregistry has no pull byte-progress) — spinner→✓+elapsed instead.
- Dashboard multi-version fetch progress (no CLI caller; would be uncoverable) — deferred until a `fetch-all` command exists.
- Looping animation; diff-tree N/M bar (closure total is unknown upfront — a live count is honest).

## Verification

- No new dependencies. Module/API unchanged for external consumers (the operator imports only `pkg/{contract,oci,readiness,schemax,validation}` — unaffected).
- **100% coverage** on `internal/cli` + `pkg/graph`; full CI set `-race` clean; gofmt/vet/build clean.
- Pipeline-impact audit (per-command runtime capture): piped stdout/stderr + exit codes byte-identical to base; the TTY gate is the sole differentiator.
- Visual PTY smoke confirms banner, init `✓` reveal, spinner→`✓`, colored results all render.

