### PR TITLE
fix: correct v2 module paths in install docs/badges and add godoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/TrianaLab/pacto/actions/workflows/ci.yml/badge.svg)](https://github.com/TrianaLab/pacto/actions/workflows/ci.yml)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/trianalab/pacto)](https://pkg.go.dev/github.com/trianalab/pacto)
-[![Go Report Card](https://goreportcard.com/badge/github.com/trianalab/pacto)](https://goreportcard.com/report/github.com/trianalab/pacto)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/trianalab/pacto/v2)](https://pkg.go.dev/github.com/trianalab/pacto/v2)
+[![Go Report Card](https://goreportcard.com/badge/github.com/trianalab/pacto/v2)](https://goreportcard.com/report/github.com/trianalab/pacto/v2)
 [![codecov](https://codecov.io/github/TrianaLab/pacto/graph/badge.svg?token=p3AJpP3BbO)](https://codecov.io/github/TrianaLab/pacto)
 [![GitHub Release](https://img.shields.io/github/v/release/TrianaLab/pacto)](https://github.com/TrianaLab/pacto/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -212,7 +212,7 @@ See [MANIFEST.md](MANIFEST.md) for the full rationale.
 curl -fsSL https://raw.githubusercontent.com/TrianaLab/pacto/main/scripts/get-pacto.sh | bash
 
 # Go
-go install github.com/trianalab/pacto/cmd/pacto@latest
+go install github.com/trianalab/pacto/v2/cmd/pacto@latest
 
 # From source
 git clone https://github.com/TrianaLab/pacto.git && cd pacto && make build

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ pacto version
 
 ## Via Go
 
-Requires [Go 1.25](https://go.dev/dl/) or later.
+Requires [Go 1.26](https://go.dev/dl/) or later.
 
 ```bash
 go install github.com/trianalab/pacto/v2/cmd/pacto@latest

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ pacto version
 Requires [Go 1.25](https://go.dev/dl/) or later.
 
 ```bash
-go install github.com/trianalab/pacto/cmd/pacto@latest
+go install github.com/trianalab/pacto/v2/cmd/pacto@latest
 ```
 
 ## From source (manual build)
@@ -51,7 +51,7 @@ pacto update v1.2.0
 This downloads the new binary, **verifies its SHA-256 against the `checksums.txt` published with the release**, and only then replaces the current one. If the download is corrupted, truncated, or tampered with, the update is aborted and the existing binary is left untouched. No additional tools required.
 
 !!! note
-    If you installed via `go install`, use `go install github.com/trianalab/pacto/cmd/pacto@latest` to update instead.
+    If you installed via `go install`, use `go install github.com/trianalab/pacto/v2/cmd/pacto@latest` to update instead.
 
 Pacto also checks for updates automatically and shows a notification when a newer version is available. To disable this, set `PACTO_NO_UPDATE_CHECK=1` in your environment.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,7 +11,7 @@ curl -fsSL https://raw.githubusercontent.com/TrianaLab/pacto/main/scripts/get-pa
 Or via Go:
 
 ```bash
-go install github.com/trianalab/pacto/cmd/pacto@latest
+go install github.com/trianalab/pacto/v2/cmd/pacto@latest
 ```
 
 See [Installation](installation.md) for more options.

--- a/internal/app/explain.go
+++ b/internal/app/explain.go
@@ -22,16 +22,16 @@ type ExplainOptions struct {
 
 // ExplainResult holds the result of the explain command.
 type ExplainResult struct {
-	Name         string                 `json:"name"`
-	Version      string                 `json:"version"`
-	Owner        contract.Owner         `json:"owner,omitempty"`
-	PactoVersion string                 `json:"pactoVersion"`
-	Runtime      ExplainRuntime         `json:"runtime"`
-	Interfaces   []ExplainInterface     `json:"interfaces,omitempty"`
-	Dependencies []ExplainDependency    `json:"dependencies,omitempty"`
-	Scaling      *contract.Scaling      `json:"scaling,omitempty"`
-	Readiness    *ExplainReadiness      `json:"readiness,omitempty"`
-	Metadata     map[string]interface{} `json:"metadata,omitempty"`
+	Name         string              `json:"name"`
+	Version      string              `json:"version"`
+	Owner        contract.Owner      `json:"owner,omitempty"`
+	PactoVersion string              `json:"pactoVersion"`
+	Runtime      ExplainRuntime      `json:"runtime"`
+	Interfaces   []ExplainInterface  `json:"interfaces,omitempty"`
+	Dependencies []ExplainDependency `json:"dependencies,omitempty"`
+	Scaling      *contract.Scaling   `json:"scaling,omitempty"`
+	Readiness    *ExplainReadiness   `json:"readiness,omitempty"`
+	Metadata     map[string]any      `json:"metadata,omitempty"`
 }
 
 // ExplainReadiness is a derived readiness summary for the explain output.

--- a/internal/mcp/create.go
+++ b/internal/mcp/create.go
@@ -52,7 +52,7 @@ type CreateInput struct {
 	Replicas         *int
 	MinReplicas      *int
 	MaxReplicas      *int
-	Metadata         map[string]interface{}
+	Metadata         map[string]any
 
 	DryRun bool
 }
@@ -111,7 +111,7 @@ type EditInput struct {
 	Replicas            *int
 	MinReplicas         *int
 	MaxReplicas         *int
-	SetMetadata         map[string]interface{}
+	SetMetadata         map[string]any
 	RemoveMetadata      []string
 
 	DryRun bool
@@ -211,8 +211,8 @@ type runtimeIntent struct {
 	dataLossImpact            string
 }
 
-func deriveRuntimeMap(intent runtimeIntent) map[string]interface{} {
-	rt := make(map[string]interface{})
+func deriveRuntimeMap(intent runtimeIntent) map[string]any {
+	rt := make(map[string]any)
 
 	workload := intent.workload
 	if workload == "" {
@@ -240,9 +240,9 @@ func deriveRuntimeMap(intent runtimeIntent) map[string]interface{} {
 		dataCrit = intent.dataLossImpact
 	}
 
-	rt["state"] = map[string]interface{}{
+	rt["state"] = map[string]any{
 		"type": stateType,
-		"persistence": map[string]interface{}{
+		"persistence": map[string]any{
 			"scope":      scope,
 			"durability": durability,
 		},
@@ -348,18 +348,18 @@ func applyHintsToCreate(input *CreateInput, h descriptionHints) {
 	}
 }
 
-func buildCreateMap(input CreateInput) map[string]interface{} {
-	m := map[string]interface{}{
+func buildCreateMap(input CreateInput) map[string]any {
+	m := map[string]any{
 		"pactoVersion": "1.0",
-		"service": map[string]interface{}{
+		"service": map[string]any{
 			"name":    input.Name,
 			"version": defaultVersion(input.Version),
 		},
 	}
 
-	svc := m["service"].(map[string]interface{})
+	svc := m["service"].(map[string]any)
 	if input.Owner != "" {
-		svc["owner"] = map[string]interface{}{"team": input.Owner}
+		svc["owner"] = map[string]any{"team": input.Owner}
 	}
 
 	if len(input.Interfaces) > 0 {
@@ -389,8 +389,8 @@ func buildCreateMap(input CreateInput) map[string]interface{} {
 	}
 
 	if len(input.ConfigProperties) > 0 {
-		m["configurations"] = []interface{}{
-			map[string]interface{}{
+		m["configurations"] = []any{
+			map[string]any{
 				"name":   "default",
 				"schema": "configuration/schema.json",
 			},
@@ -404,10 +404,10 @@ func buildCreateMap(input CreateInput) map[string]interface{} {
 	return m
 }
 
-func buildInterfacesList(inputs []InterfaceInput) []interface{} {
-	var result []interface{}
+func buildInterfacesList(inputs []InterfaceInput) []any {
+	var result []any
 	for _, iface := range inputs {
-		entry := map[string]interface{}{
+		entry := map[string]any{
 			"name":     iface.Name,
 			"type":     iface.Type,
 			"contract": interfaceContractPath(iface),
@@ -446,10 +446,10 @@ func dependencyName(dep DependencyInput) string {
 	return ref[strings.LastIndex(ref, "/")+1:]
 }
 
-func buildDependenciesList(inputs []DependencyInput) []interface{} {
-	var result []interface{}
+func buildDependenciesList(inputs []DependencyInput) []any {
+	var result []any
 	for _, dep := range inputs {
-		entry := map[string]interface{}{
+		entry := map[string]any{
 			"name":          dependencyName(dep),
 			"ref":           dep.Ref,
 			"compatibility": defaultCompatibility(dep.Compatibility),
@@ -462,7 +462,7 @@ func buildDependenciesList(inputs []DependencyInput) []interface{} {
 	return result
 }
 
-func wireHealthMetrics(rt map[string]interface{}, interfaces []InterfaceInput) {
+func wireHealthMetrics(rt map[string]any, interfaces []InterfaceInput) {
 	var httpIface string
 	for _, iface := range interfaces {
 		if iface.Type == contract.InterfaceTypeHTTP {
@@ -473,21 +473,21 @@ func wireHealthMetrics(rt map[string]interface{}, interfaces []InterfaceInput) {
 	if httpIface == "" {
 		return
 	}
-	rt["health"] = map[string]interface{}{
+	rt["health"] = map[string]any{
 		"interface": httpIface,
 		"path":      "/health",
 	}
-	rt["metrics"] = map[string]interface{}{
+	rt["metrics"] = map[string]any{
 		"interface": httpIface,
 		"path":      "/metrics",
 	}
 }
 
-func buildScalingMap(replicas, min, max *int) map[string]interface{} {
+func buildScalingMap(replicas, min, max *int) map[string]any {
 	if replicas != nil {
-		return map[string]interface{}{"replicas": *replicas}
+		return map[string]any{"replicas": *replicas}
 	}
-	s := map[string]interface{}{}
+	s := map[string]any{}
 	if min != nil {
 		s["min"] = *min
 	}
@@ -512,7 +512,7 @@ func Edit(input EditInput) (*EditResult, error) {
 		return nil, fmt.Errorf("failed to read %s: %w", pactoPath, err)
 	}
 
-	var m map[string]interface{}
+	var m map[string]any
 	if err := yaml.Unmarshal(rawYAML, &m); err != nil {
 		return nil, fmt.Errorf("failed to parse %s: %w", pactoPath, err)
 	}
@@ -564,12 +564,12 @@ func Edit(input EditInput) (*EditResult, error) {
 	}, nil
 }
 
-func applyEdits(m map[string]interface{}, input EditInput) []string {
+func applyEdits(m map[string]any, input EditInput) []string {
 	var changes []string
 
-	svc, _ := m["service"].(map[string]interface{})
+	svc, _ := m["service"].(map[string]any)
 	if svc == nil {
-		svc = map[string]interface{}{}
+		svc = map[string]any{}
 		m["service"] = svc
 	}
 
@@ -582,7 +582,7 @@ func applyEdits(m map[string]interface{}, input EditInput) []string {
 		changes = append(changes, fmt.Sprintf("set version to %s", *input.Version))
 	}
 	if input.Owner != nil {
-		svc["owner"] = map[string]interface{}{"team": *input.Owner}
+		svc["owner"] = map[string]any{"team": *input.Owner}
 		changes = append(changes, fmt.Sprintf("set owner to %q", *input.Owner))
 	}
 
@@ -631,9 +631,9 @@ func hasScalingEdits(input EditInput) bool {
 	return input.Replicas != nil || input.MinReplicas != nil || input.MaxReplicas != nil
 }
 
-func removeInterfaces(m map[string]interface{}, names []string) []string {
+func removeInterfaces(m map[string]any, names []string) []string {
 	var changes []string
-	ifaces, ok := m["interfaces"].([]interface{})
+	ifaces, ok := m["interfaces"].([]any)
 	if !ok {
 		return nil
 	}
@@ -641,9 +641,9 @@ func removeInterfaces(m map[string]interface{}, names []string) []string {
 	for _, n := range names {
 		removeSet[n] = true
 	}
-	var kept []interface{}
+	var kept []any
 	for _, iface := range ifaces {
-		if ifaceMap, ok := iface.(map[string]interface{}); ok {
+		if ifaceMap, ok := iface.(map[string]any); ok {
 			if name, ok := ifaceMap["name"].(string); ok && removeSet[name] {
 				changes = append(changes, fmt.Sprintf("removed interface %q", name))
 				continue
@@ -659,11 +659,11 @@ func removeInterfaces(m map[string]interface{}, names []string) []string {
 	return changes
 }
 
-func addInterfaces(m map[string]interface{}, inputs []InterfaceInput) []string {
+func addInterfaces(m map[string]any, inputs []InterfaceInput) []string {
 	var changes []string
-	ifaces, _ := m["interfaces"].([]interface{})
+	ifaces, _ := m["interfaces"].([]any)
 	for _, iface := range inputs {
-		entry := map[string]interface{}{
+		entry := map[string]any{
 			"name":     iface.Name,
 			"type":     iface.Type,
 			"contract": interfaceContractPath(iface),
@@ -681,9 +681,9 @@ func addInterfaces(m map[string]interface{}, inputs []InterfaceInput) []string {
 	return changes
 }
 
-func removeDependencies(m map[string]interface{}, refs []string) []string {
+func removeDependencies(m map[string]any, refs []string) []string {
 	var changes []string
-	deps, ok := m["dependencies"].([]interface{})
+	deps, ok := m["dependencies"].([]any)
 	if !ok {
 		return nil
 	}
@@ -691,9 +691,9 @@ func removeDependencies(m map[string]interface{}, refs []string) []string {
 	for _, r := range refs {
 		removeSet[r] = true
 	}
-	var kept []interface{}
+	var kept []any
 	for _, dep := range deps {
-		if depMap, ok := dep.(map[string]interface{}); ok {
+		if depMap, ok := dep.(map[string]any); ok {
 			if ref, ok := depMap["ref"].(string); ok && removeSet[ref] {
 				changes = append(changes, fmt.Sprintf("removed dependency %q", ref))
 				continue
@@ -709,11 +709,11 @@ func removeDependencies(m map[string]interface{}, refs []string) []string {
 	return changes
 }
 
-func addDependencies(m map[string]interface{}, inputs []DependencyInput) []string {
+func addDependencies(m map[string]any, inputs []DependencyInput) []string {
 	var changes []string
-	deps, _ := m["dependencies"].([]interface{})
+	deps, _ := m["dependencies"].([]any)
 	for _, dep := range inputs {
-		entry := map[string]interface{}{
+		entry := map[string]any{
 			"name":          dependencyName(dep),
 			"ref":           dep.Ref,
 			"compatibility": defaultCompatibility(dep.Compatibility),
@@ -734,12 +734,12 @@ func hasRuntimeEdits(input EditInput) bool {
 		input.DataLossImpact != nil
 }
 
-func applyRuntimeEdits(m map[string]interface{}, input EditInput) []string {
+func applyRuntimeEdits(m map[string]any, input EditInput) []string {
 	var changes []string
 
-	rt, ok := m["runtime"].(map[string]interface{})
+	rt, ok := m["runtime"].(map[string]any)
 	if !ok {
-		rt = map[string]interface{}{"workload": contract.WorkloadTypeService}
+		rt = map[string]any{"workload": contract.WorkloadTypeService}
 	}
 
 	if input.Workload != nil {
@@ -766,7 +766,7 @@ func hasStateEdits(input EditInput) bool {
 		input.DataSharedAcrossInstances != nil || input.DataLossImpact != nil
 }
 
-func buildStateIntent(rt map[string]interface{}, input EditInput) runtimeIntent {
+func buildStateIntent(rt map[string]any, input EditInput) runtimeIntent {
 	storesData, dataSurvives, dataShared, dataLossImpact := readCurrentState(rt)
 
 	if input.StoresData != nil {
@@ -790,15 +790,15 @@ func buildStateIntent(rt map[string]interface{}, input EditInput) runtimeIntent 
 	}
 }
 
-func readCurrentState(rt map[string]interface{}) (storesData, dataSurvives, dataShared bool, dataLossImpact string) {
-	state, ok := rt["state"].(map[string]interface{})
+func readCurrentState(rt map[string]any) (storesData, dataSurvives, dataShared bool, dataLossImpact string) {
+	state, ok := rt["state"].(map[string]any)
 	if !ok {
 		return
 	}
 	if t, ok := state["type"].(string); ok && t != contract.StateStateless {
 		storesData = true
 	}
-	if p, ok := state["persistence"].(map[string]interface{}); ok {
+	if p, ok := state["persistence"].(map[string]any); ok {
 		if d, ok := p["durability"].(string); ok && d == contract.DurabilityPersistent {
 			dataSurvives = true
 		}
@@ -812,17 +812,17 @@ func readCurrentState(rt map[string]interface{}) (storesData, dataSurvives, data
 	return
 }
 
-func rewireHealthMetricsIfNeeded(rt, m map[string]interface{}) {
+func rewireHealthMetricsIfNeeded(rt, m map[string]any) {
 	if _, hasHealth := rt["health"]; hasHealth {
 		return
 	}
-	ifaces, ok := m["interfaces"].([]interface{})
+	ifaces, ok := m["interfaces"].([]any)
 	if !ok {
 		return
 	}
 	var ifaceInputs []InterfaceInput
 	for _, iface := range ifaces {
-		if ifaceMap, ok := iface.(map[string]interface{}); ok {
+		if ifaceMap, ok := iface.(map[string]any); ok {
 			// Use safe assertions: a parseable-but-malformed interface (missing
 			// or non-string name/type) must not panic — skip it instead.
 			name, _ := ifaceMap["name"].(string)
@@ -836,23 +836,23 @@ func rewireHealthMetricsIfNeeded(rt, m map[string]interface{}) {
 	wireHealthMetrics(rt, ifaceInputs)
 }
 
-func ensureConfigSection(m map[string]interface{}) {
+func ensureConfigSection(m map[string]any) {
 	if _, ok := m["configurations"]; ok {
 		return
 	}
-	m["configurations"] = []interface{}{
-		map[string]interface{}{
+	m["configurations"] = []any{
+		map[string]any{
 			"name":   "default",
 			"schema": "configuration/schema.json",
 		},
 	}
 }
 
-func applyMetadataEdits(m map[string]interface{}, set map[string]interface{}, remove []string) []string {
+func applyMetadataEdits(m map[string]any, set map[string]any, remove []string) []string {
 	var changes []string
-	meta, ok := m["metadata"].(map[string]interface{})
+	meta, ok := m["metadata"].(map[string]any)
 	if !ok {
-		meta = make(map[string]interface{})
+		meta = make(map[string]any)
 	}
 
 	for k, v := range set {
@@ -937,7 +937,7 @@ var topLevelKeyOrder = []string{
 	"policies", "dependencies", "runtime", "scaling", "metadata",
 }
 
-func marshalContract(m map[string]interface{}) ([]byte, error) {
+func marshalContract(m map[string]any) ([]byte, error) {
 	doc := &yaml.Node{Kind: yaml.DocumentNode}
 	mapping := &yaml.Node{Kind: yaml.MappingNode}
 
@@ -974,7 +974,7 @@ func marshalContract(m map[string]interface{}) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func valueToNode(v interface{}) (*yaml.Node, error) {
+func valueToNode(v any) (*yaml.Node, error) {
 	data, err := yamlMarshalFn(v)
 	if err != nil {
 		return nil, err
@@ -1174,7 +1174,7 @@ paths:
 }
 
 func generateConfigSchema(props []ConfigProperty) []byte {
-	properties := make(map[string]interface{})
+	properties := make(map[string]any)
 	var required []string
 
 	for _, p := range props {
@@ -1182,7 +1182,7 @@ func generateConfigSchema(props []ConfigProperty) []byte {
 		if propType == "" {
 			propType = "string"
 		}
-		properties[p.Name] = map[string]interface{}{
+		properties[p.Name] = map[string]any{
 			"type": propType,
 		}
 		if p.Required {
@@ -1190,7 +1190,7 @@ func generateConfigSchema(props []ConfigProperty) []byte {
 		}
 	}
 
-	schema := map[string]interface{}{
+	schema := map[string]any{
 		"$schema":              "https://json-schema.org/draft/2020-12/schema",
 		"type":                 "object",
 		"properties":           properties,
@@ -1240,7 +1240,7 @@ func summarizeContract(c *contract.Contract) ContractSummary {
 	return s
 }
 
-func summarizeFromMap(m map[string]interface{}) ContractSummary {
+func summarizeFromMap(m map[string]any) ContractSummary {
 	s := ContractSummary{Sections: make(map[string]string)}
 	summarizeService(&s, m)
 	summarizeRuntime(&s, m)
@@ -1250,8 +1250,8 @@ func summarizeFromMap(m map[string]interface{}) ContractSummary {
 	return s
 }
 
-func summarizeService(s *ContractSummary, m map[string]interface{}) {
-	svc, ok := m["service"].(map[string]interface{})
+func summarizeService(s *ContractSummary, m map[string]any) {
+	svc, ok := m["service"].(map[string]any)
 	if !ok {
 		return
 	}
@@ -1259,7 +1259,7 @@ func summarizeService(s *ContractSummary, m map[string]interface{}) {
 	s.Version, _ = svc["version"].(string)
 	if str, ok := svc["owner"].(string); ok {
 		s.Owner = str
-	} else if obj, ok := svc["owner"].(map[string]interface{}); ok {
+	} else if obj, ok := svc["owner"].(map[string]any); ok {
 		if team, _ := obj["team"].(string); team != "" {
 			s.Owner = team
 		} else if dri, _ := obj["dri"].(string); dri != "" {
@@ -1268,24 +1268,24 @@ func summarizeService(s *ContractSummary, m map[string]interface{}) {
 	}
 }
 
-func summarizeRuntime(s *ContractSummary, m map[string]interface{}) {
-	rt, ok := m["runtime"].(map[string]interface{})
+func summarizeRuntime(s *ContractSummary, m map[string]any) {
+	rt, ok := m["runtime"].(map[string]any)
 	if !ok {
 		return
 	}
 	s.Workload, _ = rt["workload"].(string)
-	if state, ok := rt["state"].(map[string]interface{}); ok {
+	if state, ok := rt["state"].(map[string]any); ok {
 		s.StateType, _ = state["type"].(string)
 	}
 }
 
-func summarizeInterfacesFromMap(s *ContractSummary, m map[string]interface{}) {
-	ifaces, ok := m["interfaces"].([]interface{})
+func summarizeInterfacesFromMap(s *ContractSummary, m map[string]any) {
+	ifaces, ok := m["interfaces"].([]any)
 	if !ok {
 		return
 	}
 	for _, iface := range ifaces {
-		if ifaceMap, ok := iface.(map[string]interface{}); ok {
+		if ifaceMap, ok := iface.(map[string]any); ok {
 			name, _ := ifaceMap["name"].(string)
 			typ, _ := ifaceMap["type"].(string)
 			s.Interfaces = append(s.Interfaces, fmt.Sprintf("%s (%s)", name, typ))
@@ -1293,13 +1293,13 @@ func summarizeInterfacesFromMap(s *ContractSummary, m map[string]interface{}) {
 	}
 }
 
-func summarizeDepsFromMap(s *ContractSummary, m map[string]interface{}) {
-	deps, ok := m["dependencies"].([]interface{})
+func summarizeDepsFromMap(s *ContractSummary, m map[string]any) {
+	deps, ok := m["dependencies"].([]any)
 	if !ok {
 		return
 	}
 	for _, dep := range deps {
-		if depMap, ok := dep.(map[string]interface{}); ok {
+		if depMap, ok := dep.(map[string]any); ok {
 			if ref, ok := depMap["ref"].(string); ok {
 				s.Dependencies = append(s.Dependencies, ref)
 			}
@@ -1307,7 +1307,7 @@ func summarizeDepsFromMap(s *ContractSummary, m map[string]interface{}) {
 	}
 }
 
-func summarizeSectionsFromMap(s *ContractSummary, m map[string]interface{}) {
+func summarizeSectionsFromMap(s *ContractSummary, m map[string]any) {
 	for _, key := range []string{"service", "interfaces", "runtime"} {
 		if _, ok := m[key]; ok {
 			s.Sections[key] = "present"

--- a/internal/mcp/create_test.go
+++ b/internal/mcp/create_test.go
@@ -232,7 +232,7 @@ func TestCreate_WithConfig(t *testing.T) {
 func TestCreate_WithMetadata(t *testing.T) {
 	result, err := Create(CreateInput{
 		Name:     "meta-svc",
-		Metadata: map[string]interface{}{"team": "platform", "tier": "critical"},
+		Metadata: map[string]any{"team": "platform", "tier": "critical"},
 		DryRun:   true,
 	})
 	if err != nil {
@@ -357,11 +357,11 @@ func TestCreate_ScheduledInference(t *testing.T) {
 func TestDeriveRuntimeMap(t *testing.T) {
 	t.Run("stateless default", func(t *testing.T) {
 		rt := deriveRuntimeMap(runtimeIntent{})
-		state := rt["state"].(map[string]interface{})
+		state := rt["state"].(map[string]any)
 		if state["type"] != "stateless" {
 			t.Errorf("expected stateless, got %v", state["type"])
 		}
-		p := state["persistence"].(map[string]interface{})
+		p := state["persistence"].(map[string]any)
 		if p["scope"] != "local" {
 			t.Errorf("expected local scope, got %v", p["scope"])
 		}
@@ -377,11 +377,11 @@ func TestDeriveRuntimeMap(t *testing.T) {
 			dataSharedAcrossInstances: true,
 			dataLossImpact:            "high",
 		})
-		state := rt["state"].(map[string]interface{})
+		state := rt["state"].(map[string]any)
 		if state["type"] != "stateful" {
 			t.Errorf("expected stateful, got %v", state["type"])
 		}
-		p := state["persistence"].(map[string]interface{})
+		p := state["persistence"].(map[string]any)
 		if p["scope"] != "shared" {
 			t.Errorf("expected shared, got %v", p["scope"])
 		}
@@ -395,11 +395,11 @@ func TestDeriveRuntimeMap(t *testing.T) {
 
 	t.Run("stores data ephemeral", func(t *testing.T) {
 		rt := deriveRuntimeMap(runtimeIntent{storesData: true})
-		state := rt["state"].(map[string]interface{})
+		state := rt["state"].(map[string]any)
 		if state["type"] != "stateful" {
 			t.Errorf("expected stateful, got %v", state["type"])
 		}
-		p := state["persistence"].(map[string]interface{})
+		p := state["persistence"].(map[string]any)
 		if p["durability"] != "ephemeral" {
 			t.Errorf("expected ephemeral for non-persistent data, got %v", p["durability"])
 		}
@@ -608,7 +608,7 @@ func TestEdit_Metadata(t *testing.T) {
 	dir := testutil.WriteTestBundle(t)
 	result, err := Edit(EditInput{
 		Path:        dir,
-		SetMetadata: map[string]interface{}{"team": "platform"},
+		SetMetadata: map[string]any{"team": "platform"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -623,7 +623,7 @@ func TestEdit_RemoveMetadata(t *testing.T) {
 	// Add then remove
 	_, _ = Edit(EditInput{
 		Path:        dir,
-		SetMetadata: map[string]interface{}{"team": "x"},
+		SetMetadata: map[string]any{"team": "x"},
 	})
 	result, err := Edit(EditInput{
 		Path:           dir,
@@ -760,15 +760,15 @@ runtime:
 // --- YAML marshaling tests ---
 
 func TestMarshalContract_KeyOrder(t *testing.T) {
-	m := map[string]interface{}{
-		"metadata":     map[string]interface{}{"team": "x"},
+	m := map[string]any{
+		"metadata":     map[string]any{"team": "x"},
 		"pactoVersion": "1.0",
-		"service":      map[string]interface{}{"name": "test", "version": "1.0.0"},
-		"runtime": map[string]interface{}{
+		"service":      map[string]any{"name": "test", "version": "1.0.0"},
+		"runtime": map[string]any{
 			"workload": "service",
-			"state": map[string]interface{}{
+			"state": map[string]any{
 				"type":            "stateless",
-				"persistence":     map[string]interface{}{"scope": "local", "durability": "ephemeral"},
+				"persistence":     map[string]any{"scope": "local", "durability": "ephemeral"},
 				"dataCriticality": "low",
 			},
 		},
@@ -963,7 +963,7 @@ func TestCollectDerived(t *testing.T) {
 
 func TestWireHealthMetrics(t *testing.T) {
 	t.Run("with http", func(t *testing.T) {
-		rt := map[string]interface{}{}
+		rt := map[string]any{}
 		wireHealthMetrics(rt, []InterfaceInput{{Name: "api", Type: "http"}})
 		if _, ok := rt["health"]; !ok {
 			t.Error("expected health to be wired")
@@ -974,7 +974,7 @@ func TestWireHealthMetrics(t *testing.T) {
 	})
 
 	t.Run("no http", func(t *testing.T) {
-		rt := map[string]interface{}{}
+		rt := map[string]any{}
 		wireHealthMetrics(rt, []InterfaceInput{{Name: "events", Type: "event"}})
 		if _, ok := rt["health"]; ok {
 			t.Error("expected no health without HTTP")
@@ -982,7 +982,7 @@ func TestWireHealthMetrics(t *testing.T) {
 	})
 
 	t.Run("empty interfaces", func(t *testing.T) {
-		rt := map[string]interface{}{}
+		rt := map[string]any{}
 		wireHealthMetrics(rt, nil)
 		if _, ok := rt["health"]; ok {
 			t.Error("expected no health without interfaces")
@@ -991,26 +991,26 @@ func TestWireHealthMetrics(t *testing.T) {
 }
 
 func TestRemoveInterfaces(t *testing.T) {
-	m := map[string]interface{}{
-		"interfaces": []interface{}{
-			map[string]interface{}{"name": "api", "type": "http"},
-			map[string]interface{}{"name": "events", "type": "event"},
+	m := map[string]any{
+		"interfaces": []any{
+			map[string]any{"name": "api", "type": "http"},
+			map[string]any{"name": "events", "type": "event"},
 		},
 	}
 	changes := removeInterfaces(m, []string{"api"})
 	if len(changes) != 1 {
 		t.Errorf("expected 1 change, got %d", len(changes))
 	}
-	ifaces := m["interfaces"].([]interface{})
+	ifaces := m["interfaces"].([]any)
 	if len(ifaces) != 1 {
 		t.Errorf("expected 1 remaining interface, got %d", len(ifaces))
 	}
 }
 
 func TestRemoveInterfaces_All(t *testing.T) {
-	m := map[string]interface{}{
-		"interfaces": []interface{}{
-			map[string]interface{}{"name": "api", "type": "http"},
+	m := map[string]any{
+		"interfaces": []any{
+			map[string]any{"name": "api", "type": "http"},
 		},
 	}
 	removeInterfaces(m, []string{"api"})
@@ -1020,7 +1020,7 @@ func TestRemoveInterfaces_All(t *testing.T) {
 }
 
 func TestRemoveInterfaces_NoInterfaces(t *testing.T) {
-	m := map[string]interface{}{}
+	m := map[string]any{}
 	changes := removeInterfaces(m, []string{"api"})
 	if len(changes) != 0 {
 		t.Error("expected no changes when no interfaces exist")
@@ -1028,10 +1028,10 @@ func TestRemoveInterfaces_NoInterfaces(t *testing.T) {
 }
 
 func TestRemoveDependencies(t *testing.T) {
-	m := map[string]interface{}{
-		"dependencies": []interface{}{
-			map[string]interface{}{"ref": "postgres"},
-			map[string]interface{}{"ref": "redis"},
+	m := map[string]any{
+		"dependencies": []any{
+			map[string]any{"ref": "postgres"},
+			map[string]any{"ref": "redis"},
 		},
 	}
 	changes := removeDependencies(m, []string{"redis"})
@@ -1041,9 +1041,9 @@ func TestRemoveDependencies(t *testing.T) {
 }
 
 func TestRemoveDependencies_All(t *testing.T) {
-	m := map[string]interface{}{
-		"dependencies": []interface{}{
-			map[string]interface{}{"ref": "postgres"},
+	m := map[string]any{
+		"dependencies": []any{
+			map[string]any{"ref": "postgres"},
 		},
 	}
 	removeDependencies(m, []string{"postgres"})
@@ -1053,7 +1053,7 @@ func TestRemoveDependencies_All(t *testing.T) {
 }
 
 func TestRemoveDependencies_NoDeps(t *testing.T) {
-	m := map[string]interface{}{}
+	m := map[string]any{}
 	changes := removeDependencies(m, []string{"pg"})
 	if len(changes) != 0 {
 		t.Error("expected no changes when no deps exist")
@@ -1062,18 +1062,18 @@ func TestRemoveDependencies_NoDeps(t *testing.T) {
 
 func TestApplyMetadataEdits(t *testing.T) {
 	t.Run("set and remove", func(t *testing.T) {
-		m := map[string]interface{}{
-			"metadata": map[string]interface{}{"old": "value"},
+		m := map[string]any{
+			"metadata": map[string]any{"old": "value"},
 		}
-		changes := applyMetadataEdits(m, map[string]interface{}{"new": "val"}, []string{"old"})
+		changes := applyMetadataEdits(m, map[string]any{"new": "val"}, []string{"old"})
 		if len(changes) != 2 {
 			t.Errorf("expected 2 changes, got %d", len(changes))
 		}
 	})
 
 	t.Run("remove all deletes key", func(t *testing.T) {
-		m := map[string]interface{}{
-			"metadata": map[string]interface{}{"only": "value"},
+		m := map[string]any{
+			"metadata": map[string]any{"only": "value"},
 		}
 		applyMetadataEdits(m, nil, []string{"only"})
 		if _, ok := m["metadata"]; ok {
@@ -1082,8 +1082,8 @@ func TestApplyMetadataEdits(t *testing.T) {
 	})
 
 	t.Run("no existing metadata", func(t *testing.T) {
-		m := map[string]interface{}{}
-		changes := applyMetadataEdits(m, map[string]interface{}{"key": "val"}, nil)
+		m := map[string]any{}
+		changes := applyMetadataEdits(m, map[string]any{"key": "val"}, nil)
 		if len(changes) != 1 {
 			t.Errorf("expected 1 change, got %d", len(changes))
 		}
@@ -1110,7 +1110,7 @@ func TestBuildScalingMap(t *testing.T) {
 
 func TestEnsureConfigSection(t *testing.T) {
 	t.Run("adds when missing", func(t *testing.T) {
-		m := map[string]interface{}{}
+		m := map[string]any{}
 		ensureConfigSection(m)
 		if _, ok := m["configurations"]; !ok {
 			t.Error("expected configurations added")
@@ -1118,12 +1118,12 @@ func TestEnsureConfigSection(t *testing.T) {
 	})
 
 	t.Run("no-op when present", func(t *testing.T) {
-		m := map[string]interface{}{
-			"configurations": []interface{}{map[string]interface{}{"name": "default", "schema": "custom.json"}},
+		m := map[string]any{
+			"configurations": []any{map[string]any{"name": "default", "schema": "custom.json"}},
 		}
 		ensureConfigSection(m)
-		cfgs := m["configurations"].([]interface{})
-		cfg := cfgs[0].(map[string]interface{})
+		cfgs := m["configurations"].([]any)
+		cfg := cfgs[0].(map[string]any)
 		if cfg["schema"] != "custom.json" {
 			t.Error("should not overwrite existing config")
 		}
@@ -1131,16 +1131,16 @@ func TestEnsureConfigSection(t *testing.T) {
 }
 
 func TestSummarizeFromMap(t *testing.T) {
-	m := map[string]interface{}{
+	m := map[string]any{
 		"pactoVersion": "1.0",
-		"service":      map[string]interface{}{"name": "test", "version": "1.0.0", "owner": "team/x"},
-		"interfaces":   []interface{}{map[string]interface{}{"name": "api", "type": "http"}},
-		"dependencies": []interface{}{map[string]interface{}{"ref": "postgres"}},
-		"runtime": map[string]interface{}{
+		"service":      map[string]any{"name": "test", "version": "1.0.0", "owner": "team/x"},
+		"interfaces":   []any{map[string]any{"name": "api", "type": "http"}},
+		"dependencies": []any{map[string]any{"ref": "postgres"}},
+		"runtime": map[string]any{
 			"workload": "service",
-			"state":    map[string]interface{}{"type": "stateless"},
+			"state":    map[string]any{"type": "stateless"},
 		},
-		"metadata": map[string]interface{}{"team": "x"},
+		"metadata": map[string]any{"team": "x"},
 	}
 	s := summarizeFromMap(m)
 	if s.Name != "test" {
@@ -1161,9 +1161,9 @@ func TestSummarizeFromMap(t *testing.T) {
 }
 
 func TestSummarizeFromMapMinimal(t *testing.T) {
-	m := map[string]interface{}{
+	m := map[string]any{
 		"pactoVersion": "1.0",
-		"service":      map[string]interface{}{"name": "test", "version": "1.0.0"},
+		"service":      map[string]any{"name": "test", "version": "1.0.0"},
 	}
 	s := summarizeFromMap(m)
 	if s.Sections["metadata"] != "absent" {
@@ -1177,7 +1177,7 @@ func TestValueToNode(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	_, err = valueToNode(map[string]interface{}{"key": "value"})
+	_, err = valueToNode(map[string]any{"key": "value"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1468,9 +1468,9 @@ func TestValidateYAML_ParseError(t *testing.T) {
 // --- marshalContract error ---
 
 func TestMarshalContract_Valid(t *testing.T) {
-	m := map[string]interface{}{
+	m := map[string]any{
 		"pactoVersion": "1.0",
-		"service":      map[string]interface{}{"name": "test", "version": "1.0.0"},
+		"service":      map[string]any{"name": "test", "version": "1.0.0"},
 	}
 	data, err := marshalContract(m)
 	if err != nil {
@@ -1723,7 +1723,7 @@ func TestEdit_AddInterfaceWithPortAndVisibility(t *testing.T) {
 
 func TestEdit_NilServiceMap(t *testing.T) {
 	// Exercise the svc == nil branch in applyEdits
-	m := map[string]interface{}{
+	m := map[string]any{
 		"pactoVersion": "1.0",
 	}
 	changes := applyEdits(m, EditInput{Name: strPtr("new")})
@@ -1934,7 +1934,7 @@ func TestAssessSections_Full(t *testing.T) {
 		Configurations: []contract.ConfigurationSource{{Name: "default", Schema: "schema.json"}},
 		Dependencies:   []contract.Dependency{{Name: "pg", Ref: "pg", Compatibility: "^1.0.0"}},
 		Scaling:        &contract.Scaling{Min: 1, Max: 3},
-		Metadata:       map[string]interface{}{"team": "x"},
+		Metadata:       map[string]any{"team": "x"},
 		Policies:       []contract.PolicySource{{Name: "local", Schema: "policy/schema.json"}},
 	}
 	s := assessSections(c)
@@ -2041,7 +2041,7 @@ func TestWriteBundle_ConfigError(t *testing.T) {
 }
 
 func TestSummarizeFromMap_Empty(t *testing.T) {
-	s := summarizeFromMap(map[string]interface{}{})
+	s := summarizeFromMap(map[string]any{})
 	if s.Name != "" {
 		t.Error("expected empty name")
 	}
@@ -2049,11 +2049,11 @@ func TestSummarizeFromMap_Empty(t *testing.T) {
 
 func TestSummarizeFromMap_StructuredOwner(t *testing.T) {
 	t.Run("team and dri", func(t *testing.T) {
-		m := map[string]interface{}{
-			"service": map[string]interface{}{
+		m := map[string]any{
+			"service": map[string]any{
 				"name":    "svc",
 				"version": "1.0.0",
-				"owner":   map[string]interface{}{"team": "foundations", "dri": "alice"},
+				"owner":   map[string]any{"team": "foundations", "dri": "alice"},
 			},
 		}
 		s := summarizeFromMap(m)
@@ -2062,11 +2062,11 @@ func TestSummarizeFromMap_StructuredOwner(t *testing.T) {
 		}
 	})
 	t.Run("dri only", func(t *testing.T) {
-		m := map[string]interface{}{
-			"service": map[string]interface{}{
+		m := map[string]any{
+			"service": map[string]any{
 				"name":    "svc",
 				"version": "1.0.0",
-				"owner":   map[string]interface{}{"dri": "bob"},
+				"owner":   map[string]any{"dri": "bob"},
 			},
 		}
 		s := summarizeFromMap(m)
@@ -2075,11 +2075,11 @@ func TestSummarizeFromMap_StructuredOwner(t *testing.T) {
 		}
 	})
 	t.Run("empty structured", func(t *testing.T) {
-		m := map[string]interface{}{
-			"service": map[string]interface{}{
+		m := map[string]any{
+			"service": map[string]any{
 				"name":    "svc",
 				"version": "1.0.0",
-				"owner":   map[string]interface{}{},
+				"owner":   map[string]any{},
 			},
 		}
 		s := summarizeFromMap(m)
@@ -2388,7 +2388,7 @@ func TestCreateHandler_AllPaths(t *testing.T) {
 func TestValueToNode_MarshalError(t *testing.T) {
 	orig := yamlMarshalFn
 	defer func() { yamlMarshalFn = orig }()
-	yamlMarshalFn = func(v interface{}) ([]byte, error) {
+	yamlMarshalFn = func(v any) ([]byte, error) {
 		return nil, fmt.Errorf("marshal boom")
 	}
 	_, err := valueToNode("hello")
@@ -2400,7 +2400,7 @@ func TestValueToNode_MarshalError(t *testing.T) {
 func TestValueToNode_UnmarshalError(t *testing.T) {
 	orig := yamlUnmarshalFn
 	defer func() { yamlUnmarshalFn = orig }()
-	yamlUnmarshalFn = func(data []byte, v interface{}) error {
+	yamlUnmarshalFn = func(data []byte, v any) error {
 		return fmt.Errorf("unmarshal boom")
 	}
 	_, err := valueToNode("hello")
@@ -2413,7 +2413,7 @@ func TestValueToNode_EmptyContent(t *testing.T) {
 	orig := yamlUnmarshalFn
 	defer func() { yamlUnmarshalFn = orig }()
 	// Simulate empty/whitespace input yielding a document with no content.
-	yamlUnmarshalFn = func(data []byte, v interface{}) error { return nil }
+	yamlUnmarshalFn = func(data []byte, v any) error { return nil }
 	_, err := valueToNode("hello")
 	if err == nil || !strings.Contains(err.Error(), "no content") {
 		t.Errorf("expected 'no content' error (not a panic), got: %v", err)
@@ -2421,14 +2421,14 @@ func TestValueToNode_EmptyContent(t *testing.T) {
 }
 
 func TestRewireHealthMetricsIfNeeded_MalformedInterface(t *testing.T) {
-	rt := map[string]interface{}{}
+	rt := map[string]any{}
 	// Interfaces with missing/non-string name or type must be skipped, not panic.
-	m := map[string]interface{}{
-		"runtime": map[string]interface{}{},
-		"interfaces": []interface{}{
-			map[string]interface{}{"type": "http"},              // missing name
-			map[string]interface{}{"name": 123, "type": "http"}, // non-string name
-			map[string]interface{}{"name": "ok"},                // missing type
+	m := map[string]any{
+		"runtime": map[string]any{},
+		"interfaces": []any{
+			map[string]any{"type": "http"},              // missing name
+			map[string]any{"name": 123, "type": "http"}, // non-string name
+			map[string]any{"name": "ok"},                // missing type
 		},
 	}
 	// Must not panic.
@@ -2438,10 +2438,10 @@ func TestRewireHealthMetricsIfNeeded_MalformedInterface(t *testing.T) {
 func TestMarshalContract_ValueToNodeError(t *testing.T) {
 	orig := yamlMarshalFn
 	defer func() { yamlMarshalFn = orig }()
-	yamlMarshalFn = func(v interface{}) ([]byte, error) {
+	yamlMarshalFn = func(v any) ([]byte, error) {
 		return nil, fmt.Errorf("node error")
 	}
-	m := map[string]interface{}{
+	m := map[string]any{
 		"pactoVersion": "v1",
 	}
 	_, err := marshalContract(m)
@@ -2515,7 +2515,7 @@ runtime:
 func TestCreate_YAMLMarshalError(t *testing.T) {
 	orig := yamlMarshalFn
 	defer func() { yamlMarshalFn = orig }()
-	yamlMarshalFn = func(v interface{}) ([]byte, error) {
+	yamlMarshalFn = func(v any) ([]byte, error) {
 		return nil, fmt.Errorf("create marshal fail")
 	}
 	_, err := Create(CreateInput{Name: "test"})
@@ -2528,7 +2528,7 @@ func TestEdit_YAMLMarshalError(t *testing.T) {
 	dir := testutil.WriteTestBundle(t)
 	orig := yamlMarshalFn
 	defer func() { yamlMarshalFn = orig }()
-	yamlMarshalFn = func(v interface{}) ([]byte, error) {
+	yamlMarshalFn = func(v any) ([]byte, error) {
 		return nil, fmt.Errorf("edit marshal fail")
 	}
 	_, err := Edit(EditInput{Path: dir, Version: strPtr("2.0.0")})
@@ -2541,11 +2541,11 @@ func TestEdit_YAMLMarshalError(t *testing.T) {
 
 // brokenFS is a filesystem that returns errors for all operations.
 func TestRewireHealthMetricsIfNeeded_NonMapInterface(t *testing.T) {
-	rt := map[string]interface{}{}
-	m := map[string]interface{}{
-		"interfaces": []interface{}{
+	rt := map[string]any{}
+	m := map[string]any{
+		"interfaces": []any{
 			"not-a-map", // triggers the non-map branch in the loop
-			map[string]interface{}{"name": "api", "type": "http"},
+			map[string]any{"name": "api", "type": "http"},
 		},
 	}
 	rewireHealthMetricsIfNeeded(rt, m)
@@ -2555,8 +2555,8 @@ func TestRewireHealthMetricsIfNeeded_NonMapInterface(t *testing.T) {
 }
 
 func TestRewireHealthMetricsIfNeeded_InterfacesNotSlice(t *testing.T) {
-	rt := map[string]interface{}{}
-	m := map[string]interface{}{
+	rt := map[string]any{}
+	m := map[string]any{
 		"interfaces": "not-a-slice", // triggers the !ok return on type assertion
 	}
 	rewireHealthMetricsIfNeeded(rt, m)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -166,7 +166,7 @@ func parseEditScalars(req *mcpsdk.CallToolRequest, input *EditInput) {
 func parseEditJSONFields(req *mcpsdk.CallToolRequest, input *EditInput) error {
 	type jsonField struct {
 		name string
-		dst  interface{}
+		dst  any
 	}
 	fields := []jsonField{
 		{"add_interfaces", &input.AddInterfaces},

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -194,7 +194,7 @@ func TestCreateToolErrors(t *testing.T) {
 	t.Run("create internal error", func(t *testing.T) {
 		orig := yamlMarshalFn
 		defer func() { yamlMarshalFn = orig }()
-		yamlMarshalFn = func(v interface{}) ([]byte, error) {
+		yamlMarshalFn = func(v any) ([]byte, error) {
 			return nil, fmt.Errorf("injected marshal error")
 		}
 		result := callTool(t, svc, "pacto_create", map[string]any{

--- a/pkg/contract/contract.go
+++ b/pkg/contract/contract.go
@@ -1,3 +1,8 @@
+// Package contract defines the core data model for Pacto service contracts: the
+// in-memory representation of a pacto.yaml and the types for service identity,
+// interfaces, dependencies, configurations, policies, runtime semantics,
+// scaling, and readiness. It also provides YAML parsing along with OCI-reference
+// and semver-range helpers shared by the CLI, dashboard, and operator.
 package contract
 
 // Contract is the root aggregate — the parsed in-memory representation of a pacto.yaml.

--- a/pkg/contract/contract.go
+++ b/pkg/contract/contract.go
@@ -7,16 +7,16 @@ package contract
 
 // Contract is the root aggregate — the parsed in-memory representation of a pacto.yaml.
 type Contract struct {
-	PactoVersion   string                 `yaml:"pactoVersion" json:"pactoVersion"`
-	Service        ServiceIdentity        `yaml:"service" json:"service"`
-	Interfaces     []Interface            `yaml:"interfaces,omitempty" json:"interfaces,omitempty"`
-	Configurations []ConfigurationSource  `yaml:"configurations,omitempty" json:"configurations,omitempty"`
-	Policies       []PolicySource         `yaml:"policies,omitempty" json:"policies,omitempty"`
-	Dependencies   []Dependency           `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
-	Runtime        *Runtime               `yaml:"runtime,omitempty" json:"runtime,omitempty"`
-	Scaling        *Scaling               `yaml:"scaling,omitempty" json:"scaling,omitempty"`
-	Readiness      *Readiness             `yaml:"readiness,omitempty" json:"readiness,omitempty"`
-	Metadata       map[string]interface{} `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+	PactoVersion   string                `yaml:"pactoVersion" json:"pactoVersion"`
+	Service        ServiceIdentity       `yaml:"service" json:"service"`
+	Interfaces     []Interface           `yaml:"interfaces,omitempty" json:"interfaces,omitempty"`
+	Configurations []ConfigurationSource `yaml:"configurations,omitempty" json:"configurations,omitempty"`
+	Policies       []PolicySource        `yaml:"policies,omitempty" json:"policies,omitempty"`
+	Dependencies   []Dependency          `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
+	Runtime        *Runtime              `yaml:"runtime,omitempty" json:"runtime,omitempty"`
+	Scaling        *Scaling              `yaml:"scaling,omitempty" json:"scaling,omitempty"`
+	Readiness      *Readiness            `yaml:"readiness,omitempty" json:"readiness,omitempty"`
+	Metadata       map[string]any        `yaml:"metadata,omitempty" json:"metadata,omitempty"`
 }
 
 // Readiness declares operational readiness evidence for the service.
@@ -155,10 +155,10 @@ const (
 // Name is required and must be unique within the configurations array.
 // Exactly one of Schema or Ref must be set. Values is only allowed with Schema.
 type ConfigurationSource struct {
-	Name   string                 `yaml:"name" json:"name"`
-	Schema string                 `yaml:"schema,omitempty" json:"schema,omitempty"`
-	Ref    string                 `yaml:"ref,omitempty" json:"ref,omitempty"`
-	Values map[string]interface{} `yaml:"values,omitempty" json:"values,omitempty"`
+	Name   string         `yaml:"name" json:"name"`
+	Schema string         `yaml:"schema,omitempty" json:"schema,omitempty"`
+	Ref    string         `yaml:"ref,omitempty" json:"ref,omitempty"`
+	Values map[string]any `yaml:"values,omitempty" json:"values,omitempty"`
 }
 
 // PolicySource declares a named policy constraint source.

--- a/pkg/contract/contract_test.go
+++ b/pkg/contract/contract_test.go
@@ -10,7 +10,7 @@ func TestConfigurationSource_Fields(t *testing.T) {
 	cs := ConfigurationSource{
 		Name:   "app",
 		Schema: "config/schema.json",
-		Values: map[string]interface{}{"KEY": "val"},
+		Values: map[string]any{"KEY": "val"},
 	}
 	if cs.Name != "app" {
 		t.Errorf("expected name app, got %s", cs.Name)
@@ -37,7 +37,7 @@ func TestContract_Configurations(t *testing.T) {
 	c := &Contract{
 		Configurations: []ConfigurationSource{
 			{Name: "app", Schema: "config/app.json"},
-			{Name: "db", Ref: "oci://example.com/db-config:1.0", Values: map[string]interface{}{"HOST": "localhost"}},
+			{Name: "db", Ref: "oci://example.com/db-config:1.0", Values: map[string]any{"HOST": "localhost"}},
 		},
 	}
 	if len(c.Configurations) != 2 {

--- a/pkg/contract/errors.go
+++ b/pkg/contract/errors.go
@@ -9,6 +9,7 @@ type ParseError struct {
 	Err     error // underlying cause, if any
 }
 
+// Error returns a "parse error" message, including the path when set.
 func (e *ParseError) Error() string {
 	if e.Path != "" {
 		return fmt.Sprintf("parse error at %s: %s", e.Path, e.Message)
@@ -16,6 +17,7 @@ func (e *ParseError) Error() string {
 	return fmt.Sprintf("parse error: %s", e.Message)
 }
 
+// Unwrap returns the underlying cause, enabling errors.Is and errors.As.
 func (e *ParseError) Unwrap() error {
 	return e.Err
 }
@@ -27,6 +29,7 @@ type ValidationError struct {
 	Message string
 }
 
+// Error formats the failure as "[CODE] path: message".
 func (e *ValidationError) Error() string {
 	return fmt.Sprintf("[%s] %s: %s", e.Code, e.Path, e.Message)
 }
@@ -38,6 +41,7 @@ type ValidationWarning struct {
 	Message string
 }
 
+// String formats the warning as "[CODE] path: message".
 func (w *ValidationWarning) String() string {
 	return fmt.Sprintf("[%s] %s: %s", w.Code, w.Path, w.Message)
 }

--- a/pkg/dashboard/cache.go
+++ b/pkg/dashboard/cache.go
@@ -78,6 +78,8 @@ func NewCachedDataSource(source DataSource, cache Cache, ttl time.Duration, pref
 	return &CachedDataSource{source: source, cache: cache, ttl: ttl, prefix: prefix}
 }
 
+// ListServices returns the wrapped source's service list, served from cache
+// within the TTL and otherwise fetched and cached.
 func (c *CachedDataSource) ListServices(ctx context.Context) ([]Service, error) {
 	key := c.prefix + "services:list"
 	if v, ok := c.cache.Get(key); ok {
@@ -93,6 +95,8 @@ func (c *CachedDataSource) ListServices(ctx context.Context) ([]Service, error) 
 	return result, nil
 }
 
+// GetService returns the wrapped source's details for name, served from cache
+// within the TTL and otherwise fetched and cached.
 func (c *CachedDataSource) GetService(ctx context.Context, name string) (*ServiceDetails, error) {
 	key := c.prefix + "service:" + name
 	if v, ok := c.cache.Get(key); ok {
@@ -108,6 +112,8 @@ func (c *CachedDataSource) GetService(ctx context.Context, name string) (*Servic
 	return result, nil
 }
 
+// GetVersions returns the wrapped source's version history for name, served
+// from cache within the TTL and otherwise fetched and cached.
 func (c *CachedDataSource) GetVersions(ctx context.Context, name string) ([]Version, error) {
 	key := c.prefix + "versions:" + name
 	if v, ok := c.cache.Get(key); ok {
@@ -123,6 +129,8 @@ func (c *CachedDataSource) GetVersions(ctx context.Context, name string) ([]Vers
 	return result, nil
 }
 
+// GetDiff returns the wrapped source's diff between a and b, served from cache
+// within the TTL and otherwise computed and cached.
 func (c *CachedDataSource) GetDiff(ctx context.Context, a, b Ref) (*DiffResult, error) {
 	key := c.prefix + "diff:" + a.Name + "@" + a.Version + ".." + b.Name + "@" + b.Version
 	if v, ok := c.cache.Get(key); ok {
@@ -138,6 +146,8 @@ func (c *CachedDataSource) GetDiff(ctx context.Context, a, b Ref) (*DiffResult, 
 	return result, nil
 }
 
+// GetServiceVersion returns the wrapped source's details for a specific ref,
+// served from cache within the TTL and otherwise fetched and cached.
 func (c *CachedDataSource) GetServiceVersion(ctx context.Context, ref Ref) (*ServiceDetails, error) {
 	key := c.prefix + "serviceversion:" + ref.Name + "@" + ref.Version
 	if v, ok := c.cache.Get(key); ok {

--- a/pkg/dashboard/mapping_test.go
+++ b/pkg/dashboard/mapping_test.go
@@ -170,7 +170,7 @@ func TestServiceDetailsFromBundle_Configuration(t *testing.T) {
 				Name:   "default",
 				Schema: "config.schema.json",
 				Ref:    "shared-config",
-				Values: map[string]interface{}{
+				Values: map[string]any{
 					"port":    float64(8080),
 					"enabled": true,
 				},
@@ -247,7 +247,7 @@ func TestServiceDetailsFromBundle_Policy(t *testing.T) {
 func TestServiceDetailsFromBundle_Metadata(t *testing.T) {
 	c := &contract.Contract{
 		Service: contract.ServiceIdentity{Name: "svc", Version: "1.0.0"},
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"team": "platform",
 			"tier": "backend",
 		},
@@ -267,7 +267,7 @@ func TestServiceDetailsFromBundle_Metadata(t *testing.T) {
 func TestServiceDetailsFromBundle_Metadata_NonStringSkipped(t *testing.T) {
 	c := &contract.Contract{
 		Service: contract.ServiceIdentity{Name: "svc", Version: "1.0.0"},
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"team":  "platform",
 			"count": 42, // non-string, should be skipped
 		},
@@ -784,7 +784,7 @@ func TestServiceDetailsFromBundle_ConfigurationValuesWithKeys(t *testing.T) {
 		Configurations: []contract.ConfigurationSource{
 			{
 				Name: "default",
-				Values: map[string]interface{}{
+				Values: map[string]any{
 					"port": float64(8080),
 				},
 			},
@@ -962,7 +962,7 @@ func TestServiceDetailsFromBundle_MultiConfig(t *testing.T) {
 	c := &contract.Contract{
 		Service: contract.ServiceIdentity{Name: "svc", Version: "1.0.0"},
 		Configurations: []contract.ConfigurationSource{
-			{Name: "app", Schema: "config/app.json", Values: map[string]interface{}{"PORT": float64(8080)}},
+			{Name: "app", Schema: "config/app.json", Values: map[string]any{"PORT": float64(8080)}},
 			{Name: "db", Ref: "oci://ghcr.io/acme/db-config:1.0.0"},
 		},
 	}

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -1,3 +1,8 @@
+// Package dashboard serves the Pacto dashboard: a REST API and web UI that
+// aggregates contract and runtime data from multiple sources — Kubernetes (via
+// the operator), OCI registries, local directories, and on-disk cache — into a
+// single view of a service fleet. It computes compliance and readiness, builds
+// dependency graphs, and diffs contract versions.
 package dashboard
 
 import (

--- a/pkg/dashboard/source_cache.go
+++ b/pkg/dashboard/source_cache.go
@@ -155,6 +155,8 @@ func (s *CacheSource) VersionCount() int {
 	return total
 }
 
+// ListServices returns one entry per service found in the on-disk OCI cache,
+// using each service's latest cached version, sorted by name.
 func (s *CacheSource) ListServices(_ context.Context) ([]Service, error) {
 	var services []Service
 	for _, svc := range s.snapshot() {
@@ -173,6 +175,8 @@ func (s *CacheSource) ListServices(_ context.Context) ([]Service, error) {
 	return services, nil
 }
 
+// GetService returns details for the latest cached version of name from the
+// on-disk OCI cache, or an error if it is not cached.
 func (s *CacheSource) GetService(_ context.Context, name string) (*ServiceDetails, error) {
 	svc, ok := s.snapshot()[name]
 	if !ok {
@@ -185,6 +189,8 @@ func (s *CacheSource) GetService(_ context.Context, name string) (*ServiceDetail
 	return ServiceDetailsFromBundle(latest.bundle, "oci"), nil
 }
 
+// GetVersions returns all cached versions of name (latest first) with contract
+// hash, classification, and the on-disk materialization time as createdAt.
 func (s *CacheSource) GetVersions(_ context.Context, name string) ([]Version, error) {
 	svc, ok := s.snapshot()[name]
 	if !ok {
@@ -222,6 +228,8 @@ func (s *CacheSource) GetVersions(_ context.Context, name string) ([]Version, er
 	return versions, nil
 }
 
+// GetDiff compares two versions read from the on-disk OCI cache, erroring if
+// either version is not cached.
 func (s *CacheSource) GetDiff(_ context.Context, a, b Ref) (*DiffResult, error) {
 	idx := s.snapshot()
 	svcA, ok := idx[a.Name]
@@ -245,6 +253,8 @@ func (s *CacheSource) GetDiff(_ context.Context, a, b Ref) (*DiffResult, error) 
 	return ComputeDiff(a, b, bundleA.bundle, bundleB.bundle), nil
 }
 
+// GetServiceVersion returns details for a specific cached version from the
+// on-disk OCI cache, or an error if that version is not cached.
 func (s *CacheSource) GetServiceVersion(_ context.Context, ref Ref) (*ServiceDetails, error) {
 	svc, ok := s.snapshot()[ref.Name]
 	if !ok {

--- a/pkg/dashboard/source_k8s.go
+++ b/pkg/dashboard/source_k8s.go
@@ -334,6 +334,8 @@ type k8sInsight struct {
 	Description string `json:"description,omitempty"`
 }
 
+// ListServices returns one entry per Pacto CRD found in the cluster, built from
+// each resource's status, sorted by name.
 func (s *K8sSource) ListServices(ctx context.Context) ([]Service, error) {
 	resources, err := s.listPactos(ctx)
 	if err != nil {
@@ -353,6 +355,8 @@ func (s *K8sSource) ListServices(ctx context.Context) ([]Service, error) {
 	return services, nil
 }
 
+// GetService returns details built from the named Pacto CRD's status in the
+// cluster, or an error if no such resource exists.
 func (s *K8sSource) GetService(ctx context.Context, name string) (*ServiceDetails, error) {
 	r, err := s.getPacto(ctx, name)
 	if err != nil {
@@ -361,6 +365,8 @@ func (s *K8sSource) GetService(ctx context.Context, name string) (*ServiceDetail
 	return serviceDetailsFromK8sStatus(r), nil
 }
 
+// GetVersions returns the version history for name from PactoRevision CRDs in
+// the cluster, sorted descending by semver.
 func (s *K8sSource) GetVersions(ctx context.Context, name string) ([]Version, error) {
 	revisions, err := s.listRevisions(ctx)
 	if err != nil {

--- a/pkg/dashboard/source_local.go
+++ b/pkg/dashboard/source_local.go
@@ -74,6 +74,8 @@ func NewLocalSource(root string) *LocalSource {
 	return &LocalSource{root: root}
 }
 
+// ListServices returns one entry per service discovered by scanning the root
+// directory for pacto.yaml bundles (first match per name wins), sorted by name.
 func (s *LocalSource) ListServices(_ context.Context) ([]Service, error) {
 	if _, err := os.ReadDir(s.root); err != nil {
 		return nil, fmt.Errorf("reading directory %s: %w", s.root, err)
@@ -103,6 +105,8 @@ func (s *LocalSource) ListServices(_ context.Context) ([]Service, error) {
 	return services, nil
 }
 
+// GetService returns details for the named bundle found under the root
+// directory, or an error if no bundle with that service name exists.
 func (s *LocalSource) GetService(_ context.Context, name string) (*ServiceDetails, error) {
 	bundle, err := s.findBundle(name)
 	if err != nil {
@@ -113,6 +117,8 @@ func (s *LocalSource) GetService(_ context.Context, name string) (*ServiceDetail
 	return ServiceDetailsFromBundle(bundle, "local"), nil
 }
 
+// GetVersions returns the single on-disk version of name, since the local
+// source only knows the bundle currently present in the directory.
 func (s *LocalSource) GetVersions(_ context.Context, name string) ([]Version, error) {
 	bundle, err := s.findBundle(name)
 	if err != nil {
@@ -127,6 +133,8 @@ func (s *LocalSource) GetVersions(_ context.Context, name string) ([]Version, er
 	return []Version{v}, nil
 }
 
+// GetDiff compares the on-disk bundles for a and b found under the root
+// directory, erroring if either service is not present locally.
 func (s *LocalSource) GetDiff(_ context.Context, a, b Ref) (*DiffResult, error) {
 	bundleA, err := s.findBundle(a.Name)
 	if err != nil {
@@ -139,6 +147,8 @@ func (s *LocalSource) GetDiff(_ context.Context, a, b Ref) (*DiffResult, error) 
 	return ComputeDiff(a, b, bundleA, bundleB), nil
 }
 
+// GetServiceVersion returns details for the local bundle only when its on-disk
+// version matches ref.Version; otherwise it returns an error.
 func (s *LocalSource) GetServiceVersion(_ context.Context, ref Ref) (*ServiceDetails, error) {
 	bundle, err := s.findBundle(ref.Name)
 	if err != nil {

--- a/pkg/dashboard/source_oci.go
+++ b/pkg/dashboard/source_oci.go
@@ -103,6 +103,9 @@ func (s *OCISource) Discovering() bool {
 	}
 }
 
+// ListServices returns the services discovered so far from the OCI registry,
+// kicking off background discovery on first call and returning immediately
+// (initially empty) while it proceeds; results are sorted by name.
 func (s *OCISource) ListServices(ctx context.Context) ([]Service, error) {
 	s.mu.Lock()
 	if !s.started {
@@ -346,6 +349,8 @@ func collectOCIRepos(refs []string) []string {
 	return repos
 }
 
+// GetService returns details for name by pulling its latest-tagged bundle from
+// the OCI registry, or an error if the service repo cannot be resolved.
 func (s *OCISource) GetService(ctx context.Context, name string) (*ServiceDetails, error) {
 	bundle, err := s.findLatestBundle(ctx, name)
 	if err != nil {
@@ -354,6 +359,9 @@ func (s *OCISource) GetService(ctx context.Context, name string) (*ServiceDetail
 	return ServiceDetailsFromBundle(bundle, "oci"), nil
 }
 
+// GetVersions returns the semver tags for name from the OCI registry (latest
+// first), enriched with hash, createdAt, and classification from the internal
+// disk cache when available.
 func (s *OCISource) GetVersions(ctx context.Context, name string) ([]Version, error) {
 	repo, err := s.findRepo(ctx, name)
 	if err != nil {
@@ -400,6 +408,8 @@ func (s *OCISource) GetVersions(ctx context.Context, name string) ([]Version, er
 	return versions, nil
 }
 
+// GetDiff compares two versions by pulling each from the OCI registry, erroring
+// if either ref cannot be pulled.
 func (s *OCISource) GetDiff(ctx context.Context, a, b Ref) (*DiffResult, error) {
 	bundleA, err := s.pullRef(ctx, a)
 	if err != nil {
@@ -412,6 +422,8 @@ func (s *OCISource) GetDiff(ctx context.Context, a, b Ref) (*DiffResult, error) 
 	return ComputeDiff(a, b, bundleA, bundleB), nil
 }
 
+// GetServiceVersion returns details for a specific ref by pulling that exact
+// version's bundle from the OCI registry.
 func (s *OCISource) GetServiceVersion(ctx context.Context, ref Ref) (*ServiceDetails, error) {
 	bundle, err := s.pullRef(ctx, ref)
 	if err != nil {

--- a/pkg/dashboard/source_resolver.go
+++ b/pkg/dashboard/source_resolver.go
@@ -201,6 +201,8 @@ func mergeServiceEntry(name string, entry *serviceEntry) Service {
 	return merged
 }
 
+// ListServices queries every registered source concurrently and returns one
+// merged entry per service name (k8s runtime over contract sources), sorted by name.
 func (r *ResolvedSource) ListServices(ctx context.Context) ([]Service, error) {
 	_, _, all := r.sources()
 
@@ -250,6 +252,9 @@ func (r *ResolvedSource) ListServices(ctx context.Context) ([]Service, error) {
 	return services, nil
 }
 
+// GetService resolves the single authoritative contract snapshot (highest-priority
+// contract source) and enriches it with k8s runtime data, erroring if name is
+// found in no source.
 func (r *ResolvedSource) GetService(ctx context.Context, name string) (*ServiceDetails, error) {
 	contract, runtime, _ := r.sources()
 
@@ -419,6 +424,8 @@ func enrichRuntimeMetadata(contract *ServiceDetails, runtime *ServiceDetails) {
 // Cache enrichment (hash, classification) is internal to OCISource.
 var resolverVersionSources = []string{"k8s", "oci", "local", "cache"}
 
+// GetVersions merges version history for name across all sources (k8s, oci,
+// local, cache), enriching duplicates by version, sorted descending by semver.
 func (r *ResolvedSource) GetVersions(ctx context.Context, name string) ([]Version, error) {
 	_, _, all := r.sources()
 
@@ -475,6 +482,8 @@ func enrichVersion(dst, src *Version) {
 	}
 }
 
+// GetDiff delegates to the contract bundle sources (the from.Source hint if
+// given, else oci/local/cache in order); k8s is excluded as it has no history.
 func (r *ResolvedSource) GetDiff(ctx context.Context, from, to Ref) (*DiffResult, error) {
 	_, _, all := r.sources()
 
@@ -501,6 +510,8 @@ func (r *ResolvedSource) GetDiff(ctx context.Context, from, to Ref) (*DiffResult
 	return nil, fmt.Errorf("diff requires contract bundle data (not available for %q)", from.Name)
 }
 
+// GetServiceVersion delegates to the contract bundle sources (the ref.Source
+// hint if given, else oci/local/cache in order) for the requested version.
 func (r *ResolvedSource) GetServiceVersion(ctx context.Context, ref Ref) (*ServiceDetails, error) {
 	_, _, all := r.sources()
 

--- a/pkg/diff/engine.go
+++ b/pkg/diff/engine.go
@@ -1,3 +1,8 @@
+// Package diff compares two versioned contracts and classifies each change as
+// non-breaking, potentially breaking, or breaking to downstream consumers. A
+// deterministic rule table drives classification across service identity,
+// interfaces, configuration, policies, dependencies, runtime, and embedded
+// OpenAPI and SBOM artifacts, so the same change always classifies the same way.
 package diff
 
 import (

--- a/pkg/diff/engine.go
+++ b/pkg/diff/engine.go
@@ -23,10 +23,12 @@ const (
 	Breaking                                // Consumers are definitely affected.
 )
 
+// MarshalJSON serializes the Classification as its String form (e.g. "BREAKING").
 func (c Classification) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.String())
 }
 
+// String returns the upper-snake-case name: "NON_BREAKING", "POTENTIAL_BREAKING", "BREAKING", or "UNKNOWN".
 func (c Classification) String() string {
 	switch c {
 	case NonBreaking:
@@ -49,10 +51,12 @@ const (
 	Modified
 )
 
+// MarshalJSON serializes the ChangeType as its lowercase String form (e.g. "added").
 func (t ChangeType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.String())
 }
 
+// String returns the lowercase name: "added", "removed", "modified", or "unknown".
 func (t ChangeType) String() string {
 	switch t {
 	case Added:
@@ -70,8 +74,8 @@ func (t ChangeType) String() string {
 type Change struct {
 	Path           string         `json:"path"`
 	Type           ChangeType     `json:"type"`
-	OldValue       interface{}    `json:"oldValue,omitempty"`
-	NewValue       interface{}    `json:"newValue,omitempty"`
+	OldValue       any            `json:"oldValue,omitempty"`
+	NewValue       any            `json:"newValue,omitempty"`
 	Classification Classification `json:"classification"`
 	Reason         string         `json:"reason"`
 }

--- a/pkg/doc/generate.go
+++ b/pkg/doc/generate.go
@@ -1,3 +1,8 @@
+// Package doc generates Markdown documentation from a Pacto contract and serves
+// it as rendered HTML. The generated docs include a Mermaid architecture
+// diagram, interface and endpoint tables, configuration and policy schemas, the
+// dependency graph, and a readiness summary; the package also parses OpenAPI
+// specs and can serve Swagger UI.
 package doc
 
 import (

--- a/pkg/doc/generate.go
+++ b/pkg/doc/generate.go
@@ -50,20 +50,20 @@ func init() {
 
 func loadSchemaDescriptions(data []byte) map[string]string {
 	dst := make(map[string]string)
-	var root map[string]interface{}
+	var root map[string]any
 	if err := json.Unmarshal(data, &root); err != nil {
 		return dst
 	}
-	props, _ := root["properties"].(map[string]interface{})
+	props, _ := root["properties"].(map[string]any)
 	extractEnumDescriptions(props, "", dst)
 	return dst
 }
 
 // extractEnumDescriptions recursively walks schema properties and collects
 // x-enum-descriptions into the dst map keyed as "path.value".
-func extractEnumDescriptions(props map[string]interface{}, prefix string, dst map[string]string) {
+func extractEnumDescriptions(props map[string]any, prefix string, dst map[string]string) {
 	for key, val := range props {
-		obj, ok := val.(map[string]interface{})
+		obj, ok := val.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -78,7 +78,7 @@ func extractEnumDescriptions(props map[string]interface{}, prefix string, dst ma
 		}
 
 		// Collect x-enum-descriptions
-		if xDescs, ok := obj["x-enum-descriptions"].(map[string]interface{}); ok {
+		if xDescs, ok := obj["x-enum-descriptions"].(map[string]any); ok {
 			for enumVal, enumDesc := range xDescs {
 				if s, ok := enumDesc.(string); ok {
 					dst[path+"."+enumVal] = s
@@ -87,7 +87,7 @@ func extractEnumDescriptions(props map[string]interface{}, prefix string, dst ma
 		}
 
 		// Recurse into nested properties
-		if nested, ok := obj["properties"].(map[string]interface{}); ok {
+		if nested, ok := obj["properties"].(map[string]any); ok {
 			extractEnumDescriptions(nested, path, dst)
 		}
 	}

--- a/pkg/doc/generate_test.go
+++ b/pkg/doc/generate_test.go
@@ -85,7 +85,7 @@ func fullContract() *contract.Contract {
 			},
 		},
 		Scaling: &contract.Scaling{Min: 2, Max: 10},
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"team": "payments",
 			"tier": "critical",
 		},
@@ -543,7 +543,7 @@ info:
 }
 
 func TestExtractEnumDescriptions_NonObjectValue(t *testing.T) {
-	props := map[string]interface{}{
+	props := map[string]any{
 		"name":    "not an object",
 		"version": 42,
 	}
@@ -1221,7 +1221,7 @@ func TestGenerate_EmptyConfiguration(t *testing.T) {
 	}{
 		{"nil", nil},
 		{"empty slice", []contract.ConfigurationSource{}},
-		{"values only", []contract.ConfigurationSource{{Name: "default", Values: map[string]interface{}{"KEY": "val"}}}},
+		{"values only", []contract.ConfigurationSource{{Name: "default", Values: map[string]any{"KEY": "val"}}}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/graph/resolver.go
+++ b/pkg/graph/resolver.go
@@ -1,3 +1,6 @@
+// Package graph builds and traverses a service's dependency graph. It resolves
+// dependencies recursively through a pluggable fetcher (siblings in parallel),
+// detects cycles and version conflicts, and renders or diffs the resolved graph.
 package graph
 
 import (

--- a/pkg/graph/resolver.go
+++ b/pkg/graph/resolver.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"slices"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
@@ -196,7 +197,7 @@ func (r *resolver) resolveEdge(ctx context.Context, dep contract.Dependency, pat
 	}
 
 	r.mu.Lock()
-	if inPath(dep.Ref, path) {
+	if slices.Contains(path, dep.Ref) {
 		cyclePath := append(append([]string{}, path...), dep.Ref)
 		r.cycles = append(r.cycles, cyclePath)
 		r.mu.Unlock()
@@ -280,13 +281,4 @@ func (r *resolver) failEdge(ref string, ch chan struct{}, errMsg string) {
 	delete(r.pending, ref)
 	r.mu.Unlock()
 	close(ch)
-}
-
-func inPath(ref string, path []string) bool {
-	for _, p := range path {
-		if p == ref {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/lock/errors.go
+++ b/pkg/lock/errors.go
@@ -5,6 +5,7 @@ import "fmt"
 // DriftError: a locked OCI digest no longer matches the current resolution.
 type DriftError struct{ Name, Locked, Current string }
 
+// Error formats a LOCK_DIGEST_MISMATCH message naming the locked and current digests.
 func (e *DriftError) Error() string {
 	return fmt.Sprintf("LOCK_DIGEST_MISMATCH: %s locked at %s but resolves to %s; run `pacto lock --update` to re-pin", e.Name, e.Locked, e.Current)
 }
@@ -12,6 +13,7 @@ func (e *DriftError) Error() string {
 // LocalDriftError: a local dependency's content hash changed.
 type LocalDriftError struct{ Name, Locked, Current string }
 
+// Error formats a LOCK_LOCAL_DRIFT message for the changed local dependency.
 func (e *LocalDriftError) Error() string {
 	return fmt.Sprintf("LOCK_LOCAL_DRIFT: local dependency %s content changed since lock; run `pacto lock --update`", e.Name)
 }
@@ -19,11 +21,13 @@ func (e *LocalDriftError) Error() string {
 // StaleError: pacto.yaml and pacto.lock disagree on which deps/refs exist.
 type StaleError struct{ Detail string }
 
+// Error formats a LOCK_STALE message describing the pacto.yaml/pacto.lock mismatch.
 func (e *StaleError) Error() string { return fmt.Sprintf("LOCK_STALE: %s; run `pacto lock`", e.Detail) }
 
 // ConflictError: the closure requires a service at two incompatible versions.
 type ConflictError struct{ Service string }
 
+// Error formats a LOCK_CONFLICT message naming the service required at conflicting versions.
 func (e *ConflictError) Error() string {
 	return fmt.Sprintf("LOCK_CONFLICT: %s required at conflicting versions", e.Service)
 }
@@ -34,6 +38,7 @@ type UnresolvedError struct {
 	Reason string
 }
 
+// Error formats a LOCK_UNRESOLVED message with the ref and the reason it failed.
 func (e *UnresolvedError) Error() string {
 	return fmt.Sprintf("LOCK_UNRESOLVED: cannot resolve %s: %s", e.Ref, e.Reason)
 }
@@ -41,6 +46,7 @@ func (e *UnresolvedError) Error() string {
 // MissingError: a lock was required (e.g. --check) but none exists.
 type MissingError struct{ Path string }
 
+// Error formats a LOCK_MISSING message naming the lock path that was not found.
 func (e *MissingError) Error() string {
 	return fmt.Sprintf("LOCK_MISSING: no %s found", e.Path)
 }

--- a/pkg/oci/bundle.go
+++ b/pkg/oci/bundle.go
@@ -1,3 +1,8 @@
+// Package oci stores and retrieves Pacto contract bundles in OCI registries. It
+// packs a bundle into an OCI artifact and pushes or pulls it through any
+// registry (GHCR, ECR, ACR, Docker Hub, Harbor), with authentication, on-disk
+// caching, and resolution of untagged or constrained references to a concrete
+// semver version. No custom registry is required.
 package oci
 
 import (

--- a/pkg/oci/cache.go
+++ b/pkg/oci/cache.go
@@ -87,14 +87,21 @@ func CacheDirFor(home string) string {
 	return filepath.Join(home, ".cache", "pacto", "oci")
 }
 
+// Push uploads the bundle to the registry via the wrapped store. It does not
+// populate the cache; pushed bundles are only cached when later pulled.
 func (c *CachedStore) Push(ctx context.Context, ref string, bundle *contract.Bundle) (string, error) {
 	return c.inner.Push(ctx, ref, bundle)
 }
 
+// Resolve delegates to the wrapped store to resolve a ref to a digest; it is
+// not cached and always contacts the underlying store.
 func (c *CachedStore) Resolve(ctx context.Context, ref string) (string, error) {
 	return c.inner.Resolve(ctx, ref)
 }
 
+// ListTags returns the tags for repo, serving from the in-memory tags cache on
+// a hit and otherwise querying the wrapped store and caching the result for the
+// process lifetime.
 func (c *CachedStore) ListTags(ctx context.Context, repo string) ([]string, error) {
 	c.tagsMu.Lock()
 	if cached, ok := c.tagsCache[repo]; ok {
@@ -116,6 +123,9 @@ func (c *CachedStore) ListTags(ctx context.Context, repo string) ([]string, erro
 	return tags, nil
 }
 
+// Pull returns the bundle for ref, checking the in-memory cache, then the disk
+// cache (skipped when DisableCache is active), then the wrapped store. Registry
+// pulls are stored in memory and persisted to disk for future lookups.
 func (c *CachedStore) Pull(ctx context.Context, ref string) (*contract.Bundle, error) {
 	// 1. In-memory cache (fastest).
 	c.pullMu.Lock()

--- a/pkg/oci/errors.go
+++ b/pkg/oci/errors.go
@@ -15,10 +15,13 @@ type RegistryUnreachableError struct {
 	Err error
 }
 
+// Error reports the unreachable registry, prefixing the message with
+// "registry unreachable for <ref>".
 func (e *RegistryUnreachableError) Error() string {
 	return fmt.Sprintf("registry unreachable for %s: %v", e.Ref, e.Err)
 }
 
+// Unwrap returns the underlying network error so errors.Is/As works.
 func (e *RegistryUnreachableError) Unwrap() error { return e.Err }
 
 // AuthenticationError indicates credential rejection (401/403).
@@ -29,6 +32,8 @@ type AuthenticationError struct {
 	Rejected []string
 }
 
+// Error reports the auth failure, prefixed with "authentication failed for
+// <ref>", listing rejected/tried credentials and remediation hints.
 func (e *AuthenticationError) Error() string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "authentication failed for %s", e.Ref)
@@ -42,6 +47,7 @@ func (e *AuthenticationError) Error() string {
 	return b.String()
 }
 
+// Unwrap returns the underlying transport error so errors.Is/As works.
 func (e *AuthenticationError) Unwrap() error { return e.Err }
 
 // isAuthError reports whether err is a transport error with a 401 or 403 status.
@@ -59,10 +65,12 @@ type ArtifactNotFoundError struct {
 	Err error
 }
 
+// Error reports the missing artifact, prefixed with "artifact not found:".
 func (e *ArtifactNotFoundError) Error() string {
 	return fmt.Sprintf("artifact not found: %s", e.Ref)
 }
 
+// Unwrap returns the underlying transport error so errors.Is/As works.
 func (e *ArtifactNotFoundError) Unwrap() error { return e.Err }
 
 // wrapRemoteError translates go-containerregistry errors into domain error types.

--- a/pkg/oci/resolver.go
+++ b/pkg/oci/resolver.go
@@ -27,10 +27,12 @@ type InvalidRefError struct {
 	Err error
 }
 
+// Error reports the unparseable reference, prefixed with "invalid OCI reference".
 func (e *InvalidRefError) Error() string {
 	return fmt.Sprintf("invalid OCI reference %q: %v", e.Ref, e.Err)
 }
 
+// Unwrap returns the underlying parse error so errors.Is/As works.
 func (e *InvalidRefError) Unwrap() error { return e.Err }
 
 // InvalidBundleError indicates the pulled artifact is not a valid Pacto bundle.
@@ -39,10 +41,12 @@ type InvalidBundleError struct {
 	Err error
 }
 
+// Error reports that the artifact at the ref is not a valid Pacto bundle.
 func (e *InvalidBundleError) Error() string {
 	return fmt.Sprintf("artifact at %s is not a valid Pacto bundle: %v", e.Ref, e.Err)
 }
 
+// Unwrap returns the underlying validation error so errors.Is/As works.
 func (e *InvalidBundleError) Unwrap() error { return e.Err }
 
 // NoMatchingVersionError indicates no tags satisfy the compatibility constraint.
@@ -52,10 +56,12 @@ type NoMatchingVersionError struct {
 	Err        error
 }
 
+// Error reports that no tags satisfy the constraint, naming the ref and constraint.
 func (e *NoMatchingVersionError) Error() string {
 	return fmt.Sprintf("no versions of %s match constraint %q: %v", e.Ref, e.Constraint, e.Err)
 }
 
+// Unwrap returns the underlying error so errors.Is/As works.
 func (e *NoMatchingVersionError) Unwrap() error { return e.Err }
 
 // Resolver provides lazy, on-demand resolution of Pacto bundles from OCI

--- a/pkg/override/override.go
+++ b/pkg/override/override.go
@@ -1,3 +1,7 @@
+// Package override merges values into a contract's YAML from CLI flags. It
+// applies value files and --set key=value pairs with strict precedence
+// (base < files < --set), supporting nested and array-indexed paths while
+// preserving the original YAML formatting.
 package override
 
 import (

--- a/pkg/override/override.go
+++ b/pkg/override/override.go
@@ -32,12 +32,12 @@ func Apply(base []byte, overrides Overrides) ([]byte, error) {
 		return base, nil
 	}
 
-	var baseMap map[string]interface{}
+	var baseMap map[string]any
 	if err := yaml.Unmarshal(base, &baseMap); err != nil {
 		return nil, fmt.Errorf("failed to parse base YAML: %w", err)
 	}
 	if baseMap == nil {
-		baseMap = make(map[string]interface{})
+		baseMap = make(map[string]any)
 	}
 
 	// Apply value files in order.
@@ -46,7 +46,7 @@ func Apply(base []byte, overrides Overrides) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read values file %q: %w", f, err)
 		}
-		var vals map[string]interface{}
+		var vals map[string]any
 		if err := yaml.Unmarshal(data, &vals); err != nil {
 			return nil, fmt.Errorf("failed to parse values file %q: %w", f, err)
 		}
@@ -74,7 +74,7 @@ func Apply(base []byte, overrides Overrides) ([]byte, error) {
 }
 
 // deepMerge recursively merges src into dst. Values in src take precedence.
-func deepMerge(dst, src map[string]interface{}) {
+func deepMerge(dst, src map[string]any) {
 	for k, srcVal := range src {
 		dstVal, exists := dst[k]
 		if !exists {
@@ -82,8 +82,8 @@ func deepMerge(dst, src map[string]interface{}) {
 			continue
 		}
 
-		dstMap, dstIsMap := dstVal.(map[string]interface{})
-		srcMap, srcIsMap := srcVal.(map[string]interface{})
+		dstMap, dstIsMap := dstVal.(map[string]any)
+		srcMap, srcIsMap := srcVal.(map[string]any)
 		if dstIsMap && srcIsMap {
 			deepMerge(dstMap, srcMap)
 		} else {
@@ -94,9 +94,9 @@ func deepMerge(dst, src map[string]interface{}) {
 
 // setNestedValue sets a value at a dot-separated key path in a nested map.
 // Supports array indexing with bracket notation (e.g. "interfaces[0].port").
-func setNestedValue(m map[string]interface{}, keyPath string, value interface{}) error {
+func setNestedValue(m map[string]any, keyPath string, value any) error {
 	parts := splitKeyPath(keyPath)
-	current := interface{}(m)
+	current := any(m)
 	for i, part := range parts[:len(parts)-1] {
 		next, err := traversePart(current, part, parts[:i+1])
 		if err != nil {
@@ -110,15 +110,15 @@ func setNestedValue(m map[string]interface{}, keyPath string, value interface{})
 
 // traversePart resolves a single path segment, returning the next node.
 // Creates intermediate maps for non-array key parts that don't exist yet.
-func traversePart(current interface{}, part string, contextPath []string) (interface{}, error) {
-	obj, ok := current.(map[string]interface{})
+func traversePart(current any, part string, contextPath []string) (any, error) {
+	obj, ok := current.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("cannot traverse into non-object at %q", strings.Join(contextPath[:len(contextPath)-1], "."))
 	}
 
 	name, idx, isArray := parseArrayIndex(part)
 	if isArray {
-		arr, ok := obj[name].([]interface{})
+		arr, ok := obj[name].([]any)
 		if !ok {
 			return nil, fmt.Errorf("expected array at %q", strings.Join(contextPath, "."))
 		}
@@ -130,7 +130,7 @@ func traversePart(current interface{}, part string, contextPath []string) (inter
 
 	next, exists := obj[name]
 	if !exists {
-		newMap := make(map[string]interface{})
+		newMap := make(map[string]any)
 		obj[name] = newMap
 		return newMap, nil
 	}
@@ -138,8 +138,8 @@ func traversePart(current interface{}, part string, contextPath []string) (inter
 }
 
 // setAtPart sets a value at the final path segment within the current node.
-func setAtPart(current interface{}, part string, value interface{}) error {
-	obj, ok := current.(map[string]interface{})
+func setAtPart(current any, part string, value any) error {
+	obj, ok := current.(map[string]any)
 	if !ok {
 		return fmt.Errorf("cannot set key in non-object")
 	}
@@ -150,7 +150,7 @@ func setAtPart(current interface{}, part string, value interface{}) error {
 		return nil
 	}
 
-	arr, ok := obj[name].([]interface{})
+	arr, ok := obj[name].([]any)
 	if !ok {
 		return fmt.Errorf("expected array at %q", name)
 	}
@@ -185,7 +185,7 @@ func parseArrayIndex(part string) (name string, index int, isArray bool) {
 
 // parseValue attempts to parse a string value into its most specific type.
 // Order: integer → float → boolean → string.
-func parseValue(s string) interface{} {
+func parseValue(s string) any {
 	if i, err := strconv.ParseInt(s, 10, 64); err == nil {
 		return i
 	}
@@ -202,7 +202,7 @@ func parseValue(s string) interface{} {
 // values to date strings (YYYY-MM-DD) if they represent a bare date (midnight UTC
 // with zero sub-second), or to RFC3339 strings otherwise.
 // This prevents yaml.Marshal from formatting bare dates as RFC3339 timestamps.
-func normalizeTimestamps(v interface{}) interface{} {
+func normalizeTimestamps(v any) any {
 	switch val := v.(type) {
 	case time.Time:
 		// Check if this is a bare date (midnight UTC, no sub-second precision).
@@ -210,12 +210,12 @@ func normalizeTimestamps(v interface{}) interface{} {
 			return val.Format("2006-01-02")
 		}
 		return val.Format(time.RFC3339)
-	case map[string]interface{}:
+	case map[string]any:
 		for k, mv := range val {
 			val[k] = normalizeTimestamps(mv)
 		}
 		return val
-	case []interface{}:
+	case []any:
 		for i, elem := range val {
 			val[i] = normalizeTimestamps(elem)
 		}

--- a/pkg/override/override_test.go
+++ b/pkg/override/override_test.go
@@ -33,9 +33,9 @@ func TestApply_Empty(t *testing.T) {
 	}
 }
 
-func mustParseYAML(t *testing.T, data []byte) map[string]interface{} {
+func mustParseYAML(t *testing.T, data []byte) map[string]any {
 	t.Helper()
-	var m map[string]interface{}
+	var m map[string]any
 	if err := yaml.Unmarshal(data, &m); err != nil {
 		t.Fatalf("failed to parse YAML: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestApply_SetValue(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	m := mustParseYAML(t, out)
-	svc := m["service"].(map[string]interface{})
+	svc := m["service"].(map[string]any)
 	if svc["version"] != "2.0.0" {
 		t.Errorf("expected version 2.0.0, got %v", svc["version"])
 	}
@@ -62,7 +62,7 @@ func TestApply_SetNewNestedKey(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	m := mustParseYAML(t, out)
-	svc := m["service"].(map[string]interface{})
+	svc := m["service"].(map[string]any)
 	if svc["owner"] != "team-a" {
 		t.Errorf("expected owner team-a, got %v", svc["owner"])
 	}
@@ -81,7 +81,7 @@ func TestApply_ValueFile(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	m := mustParseYAML(t, out)
-	svc := m["service"].(map[string]interface{})
+	svc := m["service"].(map[string]any)
 	if svc["version"] != "3.0.0" {
 		t.Errorf("expected version 3.0.0, got %v", svc["version"])
 	}
@@ -110,7 +110,7 @@ func TestApply_Precedence(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	m := mustParseYAML(t, out)
-	svc := m["service"].(map[string]interface{})
+	svc := m["service"].(map[string]any)
 	if svc["version"] != "3.0.0" {
 		t.Errorf("--set should take precedence, got %v", svc["version"])
 	}
@@ -135,7 +135,7 @@ func TestApply_MultipleValueFiles(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	m := mustParseYAML(t, out)
-	svc := m["service"].(map[string]interface{})
+	svc := m["service"].(map[string]any)
 	if svc["version"] != "3.0.0" {
 		t.Errorf("last file should win, got %v", svc["version"])
 	}
@@ -172,7 +172,7 @@ func TestApply_InvalidValueFile(t *testing.T) {
 func TestParseValue(t *testing.T) {
 	tests := []struct {
 		input    string
-		expected interface{}
+		expected any
 	}{
 		{"42", int64(42)},
 		{"3.14", 3.14},
@@ -190,21 +190,21 @@ func TestParseValue(t *testing.T) {
 }
 
 func TestSetNestedValue_ArrayIndex(t *testing.T) {
-	m := map[string]interface{}{
-		"items": []interface{}{"a", "b", "c"},
+	m := map[string]any{
+		"items": []any{"a", "b", "c"},
 	}
 	if err := setNestedValue(m, "items[1]", "x"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	arr := m["items"].([]interface{})
+	arr := m["items"].([]any)
 	if arr[1] != "x" {
 		t.Errorf("expected items[1]=x, got %v", arr[1])
 	}
 }
 
 func TestSetNestedValue_OutOfBounds(t *testing.T) {
-	m := map[string]interface{}{
-		"items": []interface{}{"a"},
+	m := map[string]any{
+		"items": []any{"a"},
 	}
 	if err := setNestedValue(m, "items[5]", "x"); err == nil {
 		t.Error("expected error for out-of-bounds index")
@@ -212,7 +212,7 @@ func TestSetNestedValue_OutOfBounds(t *testing.T) {
 }
 
 func TestSetNestedValue_TraverseNonObject(t *testing.T) {
-	m := map[string]interface{}{
+	m := map[string]any{
 		"key": "scalar",
 	}
 	if err := setNestedValue(m, "key.nested", "val"); err == nil {
@@ -221,7 +221,7 @@ func TestSetNestedValue_TraverseNonObject(t *testing.T) {
 }
 
 func TestSetNestedValue_TraverseArrayNotFound(t *testing.T) {
-	m := map[string]interface{}{
+	m := map[string]any{
 		"key": "not-an-array",
 	}
 	if err := setNestedValue(m, "key[0].nested", "val"); err == nil {
@@ -230,8 +230,8 @@ func TestSetNestedValue_TraverseArrayNotFound(t *testing.T) {
 }
 
 func TestSetNestedValue_TraverseArrayOutOfBounds(t *testing.T) {
-	m := map[string]interface{}{
-		"items": []interface{}{"a"},
+	m := map[string]any{
+		"items": []any{"a"},
 	}
 	if err := setNestedValue(m, "items[5].nested", "val"); err == nil {
 		t.Error("expected error for out-of-bounds array traversal")
@@ -239,21 +239,21 @@ func TestSetNestedValue_TraverseArrayOutOfBounds(t *testing.T) {
 }
 
 func TestSetNestedValue_SetKeyInNonObject(t *testing.T) {
-	m := map[string]interface{}{
-		"items": []interface{}{"a", "b"},
+	m := map[string]any{
+		"items": []any{"a", "b"},
 	}
 	if err := setNestedValue(m, "items[0]", "x"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	arr := m["items"].([]interface{})
+	arr := m["items"].([]any)
 	if arr[0] != "x" {
 		t.Errorf("expected items[0]=x, got %v", arr[0])
 	}
 }
 
 func TestSetNestedValue_SetArrayOutOfBounds(t *testing.T) {
-	m := map[string]interface{}{
-		"items": []interface{}{"a"},
+	m := map[string]any{
+		"items": []any{"a"},
 	}
 	if err := setNestedValue(m, "items[5]", "x"); err == nil {
 		t.Error("expected error for out-of-bounds set")
@@ -261,7 +261,7 @@ func TestSetNestedValue_SetArrayOutOfBounds(t *testing.T) {
 }
 
 func TestSetNestedValue_SetArrayNotArray(t *testing.T) {
-	m := map[string]interface{}{
+	m := map[string]any{
 		"key": "scalar",
 	}
 	if err := setNestedValue(m, "key[0]", "x"); err == nil {
@@ -270,7 +270,7 @@ func TestSetNestedValue_SetArrayNotArray(t *testing.T) {
 }
 
 func TestSetNestedValue_SingleKey(t *testing.T) {
-	m := map[string]interface{}{}
+	m := map[string]any{}
 	if err := setNestedValue(m, "key", "val"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -280,17 +280,17 @@ func TestSetNestedValue_SingleKey(t *testing.T) {
 }
 
 func TestSetNestedValue_TraverseArrayThenSet(t *testing.T) {
-	m := map[string]interface{}{
-		"items": []interface{}{
-			map[string]interface{}{"name": "a"},
-			map[string]interface{}{"name": "b"},
+	m := map[string]any{
+		"items": []any{
+			map[string]any{"name": "a"},
+			map[string]any{"name": "b"},
 		},
 	}
 	if err := setNestedValue(m, "items[1].name", "updated"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	arr := m["items"].([]interface{})
-	item := arr[1].(map[string]interface{})
+	arr := m["items"].([]any)
+	item := arr[1].(map[string]any)
 	if item["name"] != "updated" {
 		t.Errorf("expected items[1].name=updated, got %v", item["name"])
 	}
@@ -298,8 +298,8 @@ func TestSetNestedValue_TraverseArrayThenSet(t *testing.T) {
 
 func TestSetNestedValue_TraverseIntoNonObjectViaArray(t *testing.T) {
 	// Array element is a scalar, not a map — further traversal should fail.
-	m := map[string]interface{}{
-		"items": []interface{}{"scalar"},
+	m := map[string]any{
+		"items": []any{"scalar"},
 	}
 	// 3 segments: items[0] -> "scalar" (not a map) -> key.sub fails at traversePart
 	if err := setNestedValue(m, "items[0].key.sub", "val"); err == nil {
@@ -317,12 +317,12 @@ func TestApply_SetNestedValueError(t *testing.T) {
 }
 
 func TestSetNestedValue_CreateIntermediateMaps(t *testing.T) {
-	m := map[string]interface{}{}
+	m := map[string]any{}
 	if err := setNestedValue(m, "a.b.c", "val"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	a := m["a"].(map[string]interface{})
-	b := a["b"].(map[string]interface{})
+	a := m["a"].(map[string]any)
+	b := a["b"].(map[string]any)
 	if b["c"] != "val" {
 		t.Errorf("expected a.b.c=val, got %v", b["c"])
 	}
@@ -352,15 +352,15 @@ func TestSplitKeyPath(t *testing.T) {
 }
 
 func TestDeepMerge(t *testing.T) {
-	dst := map[string]interface{}{
-		"a": map[string]interface{}{
+	dst := map[string]any{
+		"a": map[string]any{
 			"x": 1,
 			"y": 2,
 		},
 		"b": "keep",
 	}
-	src := map[string]interface{}{
-		"a": map[string]interface{}{
+	src := map[string]any{
+		"a": map[string]any{
 			"y": 3,
 			"z": 4,
 		},
@@ -368,7 +368,7 @@ func TestDeepMerge(t *testing.T) {
 	}
 	deepMerge(dst, src)
 
-	a := dst["a"].(map[string]interface{})
+	a := dst["a"].(map[string]any)
 	if a["x"] != 1 {
 		t.Errorf("expected a.x=1, got %v", a["x"])
 	}
@@ -473,7 +473,7 @@ func TestApply_PreserveTimestamps(t *testing.T) {
 	// Midnight UTC timestamps may be formatted as bare dates (desired behavior).
 	// This test ensures we don't break real timestamps.
 	m := mustParseYAML(t, out)
-	event := m["event"].(map[string]interface{})
+	event := m["event"].(map[string]any)
 	// Just verify the key exists and is not corrupted.
 	if event["created"] == nil {
 		t.Errorf("created field missing after override")
@@ -513,41 +513,41 @@ func TestNormalizeTimestamps(t *testing.T) {
 	}
 
 	// Map recursion.
-	m := map[string]interface{}{
+	m := map[string]any{
 		"date":      bareDate,
 		"timestamp": timestamp,
-		"nested": map[string]interface{}{
+		"nested": map[string]any{
 			"expires": bareDate,
 		},
 	}
 	result = normalizeTimestamps(m)
-	rm := result.(map[string]interface{})
+	rm := result.(map[string]any)
 	if rm["date"] != "2099-12-31" {
 		t.Errorf("map recursion: expected date=2099-12-31, got %v", rm["date"])
 	}
 	if rm["timestamp"] != "2099-12-31T14:30:00Z" {
 		t.Errorf("map recursion: expected timestamp=RFC3339, got %v", rm["timestamp"])
 	}
-	nested := rm["nested"].(map[string]interface{})
+	nested := rm["nested"].(map[string]any)
 	if nested["expires"] != "2099-12-31" {
 		t.Errorf("map recursion: expected nested expires=2099-12-31, got %v", nested["expires"])
 	}
 
 	// Slice recursion.
-	slice := []interface{}{
+	slice := []any{
 		bareDate,
 		timestamp,
-		map[string]interface{}{"d": bareDate},
+		map[string]any{"d": bareDate},
 	}
 	result = normalizeTimestamps(slice)
-	rs := result.([]interface{})
+	rs := result.([]any)
 	if rs[0] != "2099-12-31" {
 		t.Errorf("slice recursion: expected rs[0]=2099-12-31, got %v", rs[0])
 	}
 	if rs[1] != "2099-12-31T14:30:00Z" {
 		t.Errorf("slice recursion: expected rs[1]=RFC3339, got %v", rs[1])
 	}
-	sliceMap := rs[2].(map[string]interface{})
+	sliceMap := rs[2].(map[string]any)
 	if sliceMap["d"] != "2099-12-31" {
 		t.Errorf("slice recursion: expected sliceMap[d]=2099-12-31, got %v", sliceMap["d"])
 	}

--- a/pkg/plugin/runner.go
+++ b/pkg/plugin/runner.go
@@ -1,3 +1,8 @@
+// Package plugin discovers and executes out-of-process Pacto plugins. A plugin
+// is a pacto-plugin-<name> binary that reads a GenerateRequest as JSON on stdin
+// and writes a GenerateResponse as JSON on stdout; the runner handles binary
+// discovery, process lifecycle, and timeout enforcement so plugins can produce
+// deployment artifacts from a contract.
 package plugin
 
 import (

--- a/pkg/validation/crossfield.go
+++ b/pkg/validation/crossfield.go
@@ -479,7 +479,7 @@ func validateSingleConfigValues(cfg contract.ConfigurationSource, fieldPath stri
 
 	// Round-trip through JSON to normalize types (e.g. YAML int → JSON float64).
 	valuesJSON, _ := json.Marshal(cfg.Values)
-	var valuesGeneric interface{}
+	var valuesGeneric any
 	json.Unmarshal(valuesJSON, &valuesGeneric) //nolint:errcheck // round-trip of valid data
 
 	if err := schema.Validate(valuesGeneric); err != nil {
@@ -494,7 +494,7 @@ func validateSingleConfigValues(cfg contract.ConfigurationSource, fieldPath stri
 // compileConfigSchema parses and compiles a JSON Schema from raw bytes.
 func compileConfigSchema(data []byte) (*jsonschema.Schema, error) {
 	compiler := jsonschema.NewCompiler()
-	var schemaDoc interface{}
+	var schemaDoc any
 	if err := json.Unmarshal(data, &schemaDoc); err != nil {
 		return nil, fmt.Errorf("failed to parse: %w", err)
 	}
@@ -524,7 +524,7 @@ func validateInterfaceFileContent(c *contract.Contract, bundleFS fs.FS, result *
 		if !isYAMLFile(iface.Contract) {
 			continue
 		}
-		var parsed interface{}
+		var parsed any
 		if err := yaml.Unmarshal(data, &parsed); err != nil {
 			result.AddError(
 				fmt.Sprintf("interfaces[%d].contract", i),

--- a/pkg/validation/crossfield_test.go
+++ b/pkg/validation/crossfield_test.go
@@ -533,7 +533,7 @@ func TestValidateConfigValues_NoValues(t *testing.T) {
 func TestValidateConfigValues_ValuesWithoutSchema(t *testing.T) {
 	c := validContract()
 	c.Configurations = []contract.ConfigurationSource{
-		{Name: "default", Values: map[string]interface{}{"key": "val"}},
+		{Name: "default", Values: map[string]any{"key": "val"}},
 	}
 	var result ValidationResult
 	validateConfigValues(c, nil, &result)
@@ -548,7 +548,7 @@ func TestValidateConfigValues_NilBundleFS(t *testing.T) {
 		{
 			Name:   "default",
 			Schema: "config-schema.json",
-			Values: map[string]interface{}{"key": "val"},
+			Values: map[string]any{"key": "val"},
 		},
 	}
 	var result ValidationResult
@@ -564,7 +564,7 @@ func TestValidateConfigValues_Valid(t *testing.T) {
 		{
 			Name:   "default",
 			Schema: "config-schema.json",
-			Values: map[string]interface{}{"DB_HOST": "localhost"},
+			Values: map[string]any{"DB_HOST": "localhost"},
 		},
 	}
 	bundleFS := fstest.MapFS{
@@ -588,7 +588,7 @@ func TestValidateConfigValues_SchemaFileNotFound(t *testing.T) {
 		{
 			Name:   "default",
 			Schema: "missing-schema.json",
-			Values: map[string]interface{}{"key": "val"},
+			Values: map[string]any{"key": "val"},
 		},
 	}
 	bundleFS := fstest.MapFS{}
@@ -606,7 +606,7 @@ func TestValidateConfigValues_InvalidSchemaJSON(t *testing.T) {
 		{
 			Name:   "default",
 			Schema: "bad-schema.json",
-			Values: map[string]interface{}{"key": "val"},
+			Values: map[string]any{"key": "val"},
 		},
 	}
 	bundleFS := fstest.MapFS{
@@ -627,7 +627,7 @@ func TestValidateConfigValues_InvalidSchemaCompile(t *testing.T) {
 		{
 			Name:   "default",
 			Schema: "bad-compile.json",
-			Values: map[string]interface{}{"key": "val"},
+			Values: map[string]any{"key": "val"},
 		},
 	}
 	// Valid JSON but references a non-existent $ref — should fail compilation.
@@ -654,7 +654,7 @@ func TestValidateConfigValues_InvalidValue(t *testing.T) {
 		{
 			Name:   "default",
 			Schema: "config-schema.json",
-			Values: map[string]interface{}{"DB_PORT": "not-a-number"},
+			Values: map[string]any{"DB_PORT": "not-a-number"},
 		},
 	}
 	bundleFS := fstest.MapFS{
@@ -678,7 +678,7 @@ func TestValidateConfigValues_ExternalRef(t *testing.T) {
 		{
 			Name:   "default",
 			Ref:    "oci://ghcr.io/acme/config-pacto:1.0.0",
-			Values: map[string]interface{}{"key": "val"},
+			Values: map[string]any{"key": "val"},
 		},
 	}
 	var result ValidationResult
@@ -1156,12 +1156,12 @@ func TestValidateConfigValues_MultiConfigs(t *testing.T) {
 		{
 			Name:   "app",
 			Schema: "config/app.json",
-			Values: map[string]interface{}{"PORT": 8080},
+			Values: map[string]any{"PORT": 8080},
 		},
 		{
 			Name:   "db",
 			Schema: "config/db.json",
-			Values: map[string]interface{}{"HOST": "localhost"},
+			Values: map[string]any{"HOST": "localhost"},
 		},
 	}
 	bundleFS := fstest.MapFS{
@@ -1181,7 +1181,7 @@ func TestValidateConfigValues_MultiConfigsInvalid(t *testing.T) {
 		{
 			Name:   "app",
 			Schema: "config/app.json",
-			Values: map[string]interface{}{"PORT": "not-a-number"},
+			Values: map[string]any{"PORT": "not-a-number"},
 		},
 	}
 	bundleFS := fstest.MapFS{
@@ -1336,7 +1336,7 @@ func TestValidateConfigValues_MultiConfigsWithoutSchema(t *testing.T) {
 	c.Configurations = []contract.ConfigurationSource{
 		{
 			Name:   "app",
-			Values: map[string]interface{}{"PORT": 8080},
+			Values: map[string]any{"PORT": 8080},
 		},
 	}
 	var result ValidationResult
@@ -1465,7 +1465,7 @@ func TestValidateConfigValues_MultiConfigsExternalRef(t *testing.T) {
 		{
 			Name:   "app",
 			Ref:    "oci://ghcr.io/acme/config:1.0",
-			Values: map[string]interface{}{"PORT": 8080},
+			Values: map[string]any{"PORT": 8080},
 		},
 	}
 	var result ValidationResult

--- a/pkg/validation/runtime_test.go
+++ b/pkg/validation/runtime_test.go
@@ -69,7 +69,7 @@ func TestValidateRuntime_ConfigPresent(t *testing.T) {
 		Configurations: []contract.ConfigurationSource{
 			{
 				Name: "default",
-				Values: map[string]interface{}{
+				Values: map[string]any{
 					"DB_HOST": "localhost",
 				},
 			},
@@ -96,7 +96,7 @@ func TestValidateRuntime_ConfigMissing(t *testing.T) {
 		Configurations: []contract.ConfigurationSource{
 			{
 				Name: "default",
-				Values: map[string]interface{}{
+				Values: map[string]any{
 					"DB_HOST": "localhost",
 				},
 			},
@@ -154,7 +154,7 @@ func TestValidateRuntime_ConfigValuesWithEmptyEnvVars(t *testing.T) {
 		Configurations: []contract.ConfigurationSource{
 			{
 				Name: "default",
-				Values: map[string]interface{}{
+				Values: map[string]any{
 					"DB_HOST": "localhost",
 				},
 			},
@@ -177,11 +177,11 @@ func TestValidateRuntime_MultiConfigs(t *testing.T) {
 		Configurations: []contract.ConfigurationSource{
 			{
 				Name:   "app",
-				Values: map[string]interface{}{"APP_PORT": "8080"},
+				Values: map[string]any{"APP_PORT": "8080"},
 			},
 			{
 				Name:   "db",
-				Values: map[string]interface{}{"DB_HOST": "localhost"},
+				Values: map[string]any{"DB_HOST": "localhost"},
 			},
 		},
 	}

--- a/pkg/validation/structural.go
+++ b/pkg/validation/structural.go
@@ -59,7 +59,7 @@ const schemaResourceURL = "pacto.schema.json"
 func compileSchema(data []byte) (*jsonschema.Schema, error) {
 	c := jsonschema.NewCompiler()
 
-	var schemaDoc interface{}
+	var schemaDoc any
 	if err := json.Unmarshal(data, &schemaDoc); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal schema: %w", err)
 	}
@@ -77,14 +77,14 @@ func compileSchema(data []byte) (*jsonschema.Schema, error) {
 }
 
 // Function variable for testing.
-var schemaValidateFn = func(schema *jsonschema.Schema, data interface{}) error {
+var schemaValidateFn = func(schema *jsonschema.Schema, data any) error {
 	return schema.Validate(data)
 }
 
 // pactoVersionOf extracts the declared pactoVersion from a generic contract doc.
 // It returns an empty string when the doc is not an object or omits the field.
-func pactoVersionOf(data interface{}) string {
-	m, ok := data.(map[string]interface{})
+func pactoVersionOf(data any) string {
+	m, ok := data.(map[string]any)
 	if !ok {
 		return ""
 	}
@@ -97,7 +97,7 @@ func pactoVersionOf(data interface{}) string {
 // matches the declared pactoVersion, and validates against it. An unrecognized
 // or missing pactoVersion is a hard error (fail closed) rather than silently
 // validating against an arbitrary schema.
-func ValidateStructural(data interface{}) ValidationResult {
+func ValidateStructural(data any) ValidationResult {
 	var result ValidationResult
 
 	version := pactoVersionOf(data)

--- a/pkg/validation/structural_test.go
+++ b/pkg/validation/structural_test.go
@@ -39,12 +39,12 @@ func TestMustCompileSchema_Panics(t *testing.T) {
 
 func TestValidateStructural_NonValidationError(t *testing.T) {
 	old := schemaValidateFn
-	schemaValidateFn = func(*jsonschema.Schema, interface{}) error { return fmt.Errorf("internal error") }
+	schemaValidateFn = func(*jsonschema.Schema, any) error { return fmt.Errorf("internal error") }
 	defer func() { schemaValidateFn = old }()
 
 	// Use a recognized pactoVersion so selection succeeds and the injected
 	// schema-validate error is reached.
-	result := ValidateStructural(map[string]interface{}{"pactoVersion": "1.0"})
+	result := ValidateStructural(map[string]any{"pactoVersion": "1.0"})
 	if result.IsValid() {
 		t.Error("expected invalid result")
 	}
@@ -74,7 +74,7 @@ func TestCompileSchema_AddResourceError(t *testing.T) {
 
 func TestYamlToGeneric_UnmarshalError(t *testing.T) {
 	old := jsonUnmarshalFn
-	jsonUnmarshalFn = func([]byte, interface{}) error {
+	jsonUnmarshalFn = func([]byte, any) error {
 		return fmt.Errorf("injected unmarshal error")
 	}
 	defer func() { jsonUnmarshalFn = old }()
@@ -199,7 +199,7 @@ service:
 
 func TestValidateStructural_MissingVersion_Unsupported(t *testing.T) {
 	// A generic doc with no pactoVersion at all.
-	result := ValidateStructural(map[string]interface{}{"service": map[string]interface{}{}})
+	result := ValidateStructural(map[string]any{"service": map[string]any{}})
 	if result.IsValid() {
 		t.Fatal("expected missing version to be invalid")
 	}
@@ -209,7 +209,7 @@ func TestValidateStructural_MissingVersion_Unsupported(t *testing.T) {
 }
 
 func TestValidateStructural_NonMapData_Unsupported(t *testing.T) {
-	result := ValidateStructural([]interface{}{"not", "a", "map"})
+	result := ValidateStructural([]any{"not", "a", "map"})
 	if result.IsValid() {
 		t.Fatal("expected non-map data to be invalid")
 	}
@@ -383,13 +383,13 @@ readiness:
 func TestConvertYAMLToJSON_NonStringKey(t *testing.T) {
 	// Simulate a map[interface{}]interface{} with a non-string key,
 	// which can occur in YAML when keys are integers or booleans.
-	input := map[interface{}]interface{}{
+	input := map[any]any{
 		42:     "int-key-value",
 		"name": "string-key-value",
 	}
 
 	result := convertYAMLToJSON(input)
-	m, ok := result.(map[string]interface{})
+	m, ok := result.(map[string]any)
 	if !ok {
 		t.Fatalf("expected map[string]interface{}, got %T", result)
 	}

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -1,3 +1,7 @@
+// Package validation checks a contract across four layers — structural (JSON
+// Schema), cross-field consistency, semantic rules, and policy enforcement — and
+// reports errors and warnings. It supports local-only policy resolution as well
+// as recursive, ref-based resolution through a pluggable BundleResolver.
 package validation
 
 import (

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -81,8 +81,8 @@ var jsonUnmarshalFn = json.Unmarshal
 // yamlToGeneric converts YAML bytes to a generic interface{} suitable for
 // JSON Schema validation. It goes through JSON to ensure type compatibility
 // with the JSON Schema library.
-func yamlToGeneric(data []byte) (interface{}, error) {
-	var yamlObj interface{}
+func yamlToGeneric(data []byte) (any, error) {
+	var yamlObj any
 	if err := yaml.Unmarshal(data, &yamlObj); err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func yamlToGeneric(data []byte) (interface{}, error) {
 		return nil, err
 	}
 
-	var result interface{}
+	var result any
 	if err := jsonUnmarshalFn(jsonBytes, &result); err != nil {
 		return nil, err
 	}
@@ -105,16 +105,16 @@ func yamlToGeneric(data []byte) (interface{}, error) {
 }
 
 // convertYAMLToJSON recursively converts YAML-style maps to JSON-compatible maps.
-func convertYAMLToJSON(v interface{}) interface{} {
+func convertYAMLToJSON(v any) any {
 	switch v := v.(type) {
-	case map[string]interface{}:
-		result := make(map[string]interface{}, len(v))
+	case map[string]any:
+		result := make(map[string]any, len(v))
 		for key, val := range v {
 			result[key] = convertYAMLToJSON(val)
 		}
 		return result
-	case map[interface{}]interface{}:
-		result := make(map[string]interface{}, len(v))
+	case map[any]any:
+		result := make(map[string]any, len(v))
 		for key, val := range v {
 			strKey, ok := key.(string)
 			if !ok {
@@ -123,8 +123,8 @@ func convertYAMLToJSON(v interface{}) interface{} {
 			result[strKey] = convertYAMLToJSON(val)
 		}
 		return result
-	case []interface{}:
-		result := make([]interface{}, len(v))
+	case []any:
+		result := make([]any, len(v))
 		for i, val := range v {
 			result[i] = convertYAMLToJSON(val)
 		}

--- a/pkg/validation/validator_internal_test.go
+++ b/pkg/validation/validator_internal_test.go
@@ -25,17 +25,17 @@ func TestYamlToGeneric_ValidScalar(t *testing.T) {
 }
 
 func TestConvertYAMLToJSON_MapInterfaceNested(t *testing.T) {
-	input := map[interface{}]interface{}{
-		"nested": map[interface{}]interface{}{
+	input := map[any]any{
+		"nested": map[any]any{
 			"key": "value",
 		},
 	}
 	result := convertYAMLToJSON(input)
-	m, ok := result.(map[string]interface{})
+	m, ok := result.(map[string]any)
 	if !ok {
 		t.Fatal("expected map[string]interface{}")
 	}
-	nested, ok := m["nested"].(map[string]interface{})
+	nested, ok := m["nested"].(map[string]any)
 	if !ok {
 		t.Fatal("expected nested map[string]interface{}")
 	}
@@ -45,16 +45,16 @@ func TestConvertYAMLToJSON_MapInterfaceNested(t *testing.T) {
 }
 
 func TestConvertYAMLToJSON_Slice(t *testing.T) {
-	input := []interface{}{"a", "b", map[interface{}]interface{}{"key": "val"}}
+	input := []any{"a", "b", map[any]any{"key": "val"}}
 	result := convertYAMLToJSON(input)
-	s, ok := result.([]interface{})
+	s, ok := result.([]any)
 	if !ok {
 		t.Fatal("expected []interface{}")
 	}
 	if len(s) != 3 {
 		t.Errorf("expected 3 items, got %d", len(s))
 	}
-	m, ok := s[2].(map[string]interface{})
+	m, ok := s[2].(map[string]any)
 	if !ok {
 		t.Fatal("expected nested map in slice")
 	}
@@ -64,15 +64,15 @@ func TestConvertYAMLToJSON_Slice(t *testing.T) {
 }
 
 func TestConvertYAMLToJSON_MapStringNested(t *testing.T) {
-	input := map[string]interface{}{
-		"a": []interface{}{1, 2},
+	input := map[string]any{
+		"a": []any{1, 2},
 	}
 	result := convertYAMLToJSON(input)
-	m, ok := result.(map[string]interface{})
+	m, ok := result.(map[string]any)
 	if !ok {
 		t.Fatal("expected map[string]interface{}")
 	}
-	s, ok := m["a"].([]interface{})
+	s, ok := m["a"].([]any)
 	if !ok {
 		t.Fatal("expected []interface{}")
 	}
@@ -109,7 +109,7 @@ func TestValidate_InvalidYAMLBytes(t *testing.T) {
 
 func TestValidateStructural_InvalidData(t *testing.T) {
 	// Missing required fields
-	data := map[string]interface{}{
+	data := map[string]any{
 		"pactoVersion": "1.0",
 	}
 	result := ValidateStructural(data)

--- a/tests/e2e/diff_test.go
+++ b/tests/e2e/diff_test.go
@@ -67,7 +67,7 @@ func TestDiffCommand(t *testing.T) {
 			t.Fatalf("diff json failed: %v\noutput: %s", err, output)
 		}
 
-		var result map[string]interface{}
+		var result map[string]any
 		if err := json.Unmarshal([]byte(output), &result); err != nil {
 			t.Fatalf("expected valid JSON output, got: %s", output)
 		}
@@ -175,12 +175,12 @@ func TestDiffOpenAPIDeep(t *testing.T) {
 		t.Parallel()
 		output, _ := runCommand(t, nil, "--output-format", "json", "diff", v1Path, v2Path)
 
-		var result map[string]interface{}
+		var result map[string]any
 		if err := json.Unmarshal([]byte(output), &result); err != nil {
 			t.Fatalf("expected valid JSON output, got: %s", output)
 		}
 
-		changes, ok := result["changes"].([]interface{})
+		changes, ok := result["changes"].([]any)
 		if !ok || len(changes) == 0 {
 			t.Fatal("expected non-empty changes array")
 		}
@@ -189,7 +189,7 @@ func TestDiffOpenAPIDeep(t *testing.T) {
 		hasResponseChange := false
 		hasParameterChange := false
 		for _, c := range changes {
-			change, ok := c.(map[string]interface{})
+			change, ok := c.(map[string]any)
 			if !ok {
 				continue
 			}
@@ -304,15 +304,15 @@ func TestDiffGraphChanges(t *testing.T) {
 
 		output, _ := runCommand(t, reg, "--output-format", "json", "diff", oldPath, newPath)
 
-		var result map[string]interface{}
+		var result map[string]any
 		if err := json.Unmarshal([]byte(output), &result); err != nil {
 			t.Fatalf("expected valid JSON output, got: %s", output)
 		}
-		gd, ok := result["graphDiff"].(map[string]interface{})
+		gd, ok := result["graphDiff"].(map[string]any)
 		if !ok {
 			t.Fatal("expected graphDiff object in JSON output")
 		}
-		changes, ok := gd["changes"].([]interface{})
+		changes, ok := gd["changes"].([]any)
 		if !ok || len(changes) == 0 {
 			t.Error("expected non-empty changes array in graphDiff")
 		}
@@ -364,15 +364,15 @@ func TestSBOMDiff(t *testing.T) {
 
 		output, _ := runCommand(t, nil, "--output-format", "json", "diff", v1Path, v2Path)
 
-		var result map[string]interface{}
+		var result map[string]any
 		if err := json.Unmarshal([]byte(output), &result); err != nil {
 			t.Fatalf("expected valid JSON output, got: %s", output)
 		}
-		sbomDiff, ok := result["sbomDiff"].(map[string]interface{})
+		sbomDiff, ok := result["sbomDiff"].(map[string]any)
 		if !ok {
 			t.Fatal("expected sbomDiff object in JSON output")
 		}
-		changes, ok := sbomDiff["changes"].([]interface{})
+		changes, ok := sbomDiff["changes"].([]any)
 		if !ok || len(changes) == 0 {
 			t.Error("expected non-empty SBOM changes array")
 		}

--- a/tests/e2e/doc_test.go
+++ b/tests/e2e/doc_test.go
@@ -48,7 +48,7 @@ func testDocJSON(t *testing.T) {
 		t.Fatalf("doc json failed: %v\noutput: %s", err, output)
 	}
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(output), &result); err != nil {
 		t.Fatalf("expected valid JSON output, got: %s", output)
 	}

--- a/tests/e2e/explain_test.go
+++ b/tests/e2e/explain_test.go
@@ -35,7 +35,7 @@ func TestExplainCommand(t *testing.T) {
 			t.Fatalf("explain json failed: %v\noutput: %s", err, output)
 		}
 
-		var result map[string]interface{}
+		var result map[string]any
 		if err := json.Unmarshal([]byte(output), &result); err != nil {
 			t.Fatalf("expected valid JSON output, got: %s", output)
 		}
@@ -129,11 +129,11 @@ func TestExplainStructuredOwner(t *testing.T) {
 			t.Fatalf("explain json failed: %v\noutput: %s", err, output)
 		}
 
-		var result map[string]interface{}
+		var result map[string]any
 		if err := json.Unmarshal([]byte(output), &result); err != nil {
 			t.Fatalf("expected valid JSON, got: %s", output)
 		}
-		owner, ok := result["owner"].(map[string]interface{})
+		owner, ok := result["owner"].(map[string]any)
 		if !ok {
 			t.Fatalf("expected owner to be object, got %T: %v", result["owner"], result["owner"])
 		}

--- a/tests/e2e/generate_test.go
+++ b/tests/e2e/generate_test.go
@@ -69,7 +69,7 @@ func testGenerateJSON(t *testing.T) {
 		t.Fatalf("generate json failed: %v\noutput: %s", err, output)
 	}
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(output), &result); err != nil {
 		t.Fatalf("expected valid JSON output, got: %s", output)
 	}

--- a/tests/e2e/graph_test.go
+++ b/tests/e2e/graph_test.go
@@ -74,7 +74,7 @@ func TestGraphCommand(t *testing.T) {
 			t.Fatalf("graph json failed: %v\noutput: %s", err, output)
 		}
 
-		var result map[string]interface{}
+		var result map[string]any
 		if err := json.Unmarshal([]byte(output), &result); err != nil {
 			t.Fatalf("expected valid JSON output, got: %s", output)
 		}
@@ -229,12 +229,12 @@ scaling:
 			t.Fatalf("graph json failed: %v\noutput: %s", err, output)
 		}
 
-		var result map[string]interface{}
+		var result map[string]any
 		if err := json.Unmarshal([]byte(output), &result); err != nil {
 			t.Fatalf("expected valid JSON output, got: %s", output)
 		}
 
-		root, ok := result["root"].(map[string]interface{})
+		root, ok := result["root"].(map[string]any)
 		if !ok {
 			t.Fatal("expected root object in JSON output")
 		}
@@ -242,7 +242,7 @@ scaling:
 			t.Errorf("expected root name=my-app, got %v", root["name"])
 		}
 
-		deps, ok := root["dependencies"].([]interface{})
+		deps, ok := root["dependencies"].([]any)
 		if !ok || len(deps) == 0 {
 			t.Error("expected non-empty dependencies array in root")
 		}

--- a/tests/e2e/init_test.go
+++ b/tests/e2e/init_test.go
@@ -51,7 +51,7 @@ func TestInitCommand(t *testing.T) {
 			t.Fatalf("init failed: %v\noutput: %s", err, output)
 		}
 
-		var result map[string]interface{}
+		var result map[string]any
 		if err := json.Unmarshal([]byte(output), &result); err != nil {
 			t.Fatalf("expected valid JSON output, got: %s", output)
 		}

--- a/tests/e2e/login_test.go
+++ b/tests/e2e/login_test.go
@@ -52,17 +52,17 @@ func testLoginConfigWrite(t *testing.T) {
 		t.Fatalf("expected pacto config at %s: %v", configPath, err)
 	}
 
-	var cfg map[string]interface{}
+	var cfg map[string]any
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		t.Fatalf("invalid pacto config JSON: %v", err)
 	}
 
-	auths, ok := cfg["auths"].(map[string]interface{})
+	auths, ok := cfg["auths"].(map[string]any)
 	if !ok {
 		t.Fatal("expected auths in pacto config")
 	}
 
-	regAuth, ok := auths["registry.example.com"].(map[string]interface{})
+	regAuth, ok := auths["registry.example.com"].(map[string]any)
 	if !ok {
 		t.Fatal("expected registry.example.com in auths")
 	}
@@ -101,9 +101,9 @@ func testLoginConfigMerge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var cfg map[string]interface{}
+	var cfg map[string]any
 	json.Unmarshal(data, &cfg)
-	auths := cfg["auths"].(map[string]interface{})
+	auths := cfg["auths"].(map[string]any)
 
 	if _, ok := auths["registry1.example.com"]; !ok {
 		t.Error("expected registry1.example.com in auths after merge")

--- a/tests/e2e/pack_test.go
+++ b/tests/e2e/pack_test.go
@@ -85,7 +85,7 @@ func testPackJSON(t *testing.T) {
 		t.Fatalf("pack json failed: %v\noutput: %s", err, output)
 	}
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(output), &result); err != nil {
 		t.Fatalf("expected valid JSON output, got: %s", output)
 	}

--- a/tests/e2e/push_pull_test.go
+++ b/tests/e2e/push_pull_test.go
@@ -48,7 +48,7 @@ func testPushJSON(t *testing.T) {
 		t.Fatalf("push json failed: %v\noutput: %s", err, output)
 	}
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(output), &result); err != nil {
 		t.Fatalf("expected valid JSON output, got: %s", output)
 	}
@@ -226,7 +226,7 @@ func testPullJSON(t *testing.T) {
 		t.Fatalf("pull json failed: %v\noutput: %s", err, output)
 	}
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal([]byte(output), &result); err != nil {
 		t.Fatalf("expected valid JSON output, got: %s", output)
 	}


### PR DESCRIPTION
## Why

After the v2 module migration (`module github.com/trianalab/pacto/v2`), the docs and badges drifted, and pkg.go.dev rendered the packages with little documentation.

## What

**v2 paths**
- Point the **PkgGoDev** and **Go Report Card** badges at `.../v2` (README).
- Update every `go install` snippet to `github.com/trianalab/pacto/v2/cmd/pacto@latest` (README, `docs/installation.md` ×2, `docs/quickstart.md`).

**godoc — package level**
- Add `// Package …` doc comments to the nine public packages that lacked them: `contract`, `dashboard`, `diff`, `doc`, `graph`, `oci`, `override`, `plugin`, `validation` — matching the style of the already-documented packages. pkg.go.dev now shows a synopsis + overview for every package.

**godoc — method level**
- Document every exported method on an exported type that was previously bare, so pkg.go.dev shows per-method docs and not just package synopses:
  - error types' `Error`/`Unwrap` across `contract`, `lock`, `oci` (each notes the error code it formats, e.g. `LOCK_STALE`),
  - `diff.Classification` / `diff.ChangeType` `String` + `MarshalJSON`,
  - `oci.CachedStore` cache methods (memory → disk → wrapped store behavior),
  - the `dashboard` `DataSource` implementations (`Local`, `OCI`, `K8s`, `Cache`, `Resolved`, `CachedDataSource`) — each notes where its data comes from.

**Folded-in cleanups** (noticed during the first pass)
- `docs/installation.md`: Go requirement `1.25` → `1.26` to match `go.mod`.
- Clear the `modernize` lints: `interface{}` → `any` across the tree (via `gofmt -r`), and replace the `inPath` helper with `slices.Contains`.
- The `omitzero` suggestion is **intentionally not applied** — `omitempty` → `omitzero` changes YAML/JSON serialization semantics and doesn't belong in a docs change.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `gofmt -l` clean ✅
- `go doc ./pkg/<pkg>` prints synopsis + overview for all nine packages (with the `/v2` import path); no exported method on an exported type is left undocumented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
