### PR TITLE
fix(docs): interface-composition framing, accuracy audit and de-duplication

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -27,7 +27,9 @@ A service that exposes HTTP on port 8080, depends on auth-service ^2.0.0, persis
 
 Pacto is that contract.
 
-It is a single file (`pacto.yaml`) that captures what a service *is* operationally. Not how to deploy it. Not how to build it. What it is. The contract is the interface between developers who build services and platforms that run them.
+It is a single file (`pacto.yaml`) that captures what a service *is* operationally. Not how to deploy it. Not how to build it. What it is.
+
+A single schema describes one interface in isolation — it cannot express how interfaces relate, or how they change. That is the contract's job: ownership, dependencies, compatibility, readiness and lifecycle. JSON Schema describes an interface; Pacto describes the relationships between interfaces and how they change over time.
 
 If a platform has to guess whether a service is stateful, the contract is incomplete. If a dependency relationship only exists in someone's head, the contract is incomplete. If a breaking change reaches production undetected, the contract is incomplete.
 
@@ -41,6 +43,8 @@ If a platform has to guess whether a service is stateful, the contract is incomp
 
 **Distributed through existing infrastructure.** Contracts are OCI artifacts. They use the same registries, the same auth, and the same tooling as container images. No new infrastructure.
 
+**Compose, don't reinvent.** The interfaces a service exposes already have schemas — an OpenAPI spec for its API, a JSON Schema for its configuration. Pacto references those schemas instead of inventing a new configuration language. If an interface is already described and owned elsewhere, compose it. Pacto is deliberately not another abstraction to learn.
+
 **Runtime-aware.** If the contract doesn't capture state management, persistence, health checks, scaling bounds, and dependency relationships, it's just another API spec. Runtime semantics are what make it an operational contract.
 
 **Invalid contracts must not propagate.** Every contract passes structural, cross-field, and semantic validation before it can be published. If it's invalid, it doesn't reach the registry. If it introduces a breaking change, CI catches it.
@@ -51,15 +55,13 @@ A standard for describing how a service behaves operationally.
 
 The contract captures interfaces, dependencies, runtime semantics, configuration, scaling, readiness, and policy. It can be validated, diffed, distributed as an OCI artifact, resolved into a dependency graph, verified against running workloads, and explored through a dashboard.
 
-It is the minimum viable description that lets a platform run a service correctly without guessing.
-
 ## What Pacto Is NOT
 
 **Not a deployment tool.** Pacto describes services. It does not deploy, orchestrate, or manage infrastructure. Platforms consume contracts and decide how to act.
 
 **Not a service mesh.** No sidecars, no traffic interception. The operator watches custom resources and compares declared state to running workloads.
 
-**Not a replacement for OpenAPI or Helm.** Pacto references OpenAPI specs as interface contracts and complements deployment tools by providing the operational context they lack.
+**Not a replacement for OpenAPI, JSON Schema or Helm.** Pacto references the schemas that already describe a service's interfaces — its OpenAPI spec, its config JSON Schema — and complements deployment tools by adding the operational context and cross-interface relationships they lack.
 
 **Not a service catalog.** The dashboard visualizes contracts and runtime state. It is not a developer portal. It can feed data into one.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 A service's operational behavior — interfaces, dependencies, runtime semantics, configuration, scaling, readiness — is usually scattered across Helm values, wikis, and dashboards, and drifts from what's actually running. Pacto captures it once in a validated, versioned contract (`pacto.yaml`), distributes it through your existing OCI registry, and verifies it against live workloads.
 
-Pacto (/ˈpak.to/ — Spanish for *pact*) is not a replacement for OpenAPI, Helm, Terraform, Backstage, or Kubernetes. It adds the operational contract layer between them.
+Pacto (/ˈpak.to/ — Spanish for *pact*) is not a replacement for OpenAPI, Helm, Terraform, Backstage, or Kubernetes. It adds the operational contract layer between them. It composes the interfaces you already maintain — an OpenAPI spec, a config JSON Schema — and adds the layer no single interface owns: ownership, dependencies, compatibility and readiness. JSON Schema describes an interface; Pacto describes the relationships between interfaces and how they change over time.
 
 **[Documentation](https://trianalab.github.io/pacto)** · **[Quickstart](https://trianalab.github.io/pacto/quickstart)** · **[Specification](https://trianalab.github.io/pacto/contract-reference)** · **[Examples](https://trianalab.github.io/pacto/examples)** · **[Live demo](https://trianalab.github.io/pacto/demo/)**
 
@@ -27,38 +27,26 @@ Pacto (/ˈpak.to/ — Spanish for *pact*) is not a replacement for OpenAPI, Helm
 | **Dashboard** | Explore services, dependency graphs, versions, diffs, readiness, insights | Anytime — local or deployed |
 | **[Operator](https://github.com/TrianaLab/pacto-operator)** | Track contracts in-cluster, link to workloads, verify runtime consistency | Continuously in Kubernetes |
 
-No sidecars and no central control plane required: the CLI uses your existing OCI registry, the operator watches CRDs, and the dashboard reads from all sources.
+No sidecars and no central control plane required: the CLI uses your existing OCI registry, the operator watches CRDs and the dashboard merges every source — local, OCI, Kubernetes and cache — into one view.
 
 ---
 
 ## Try it
 
 ```bash
-# Install
-curl -fsSL https://raw.githubusercontent.com/TrianaLab/pacto/main/scripts/get-pacto.sh | bash
-
-# Author and publish a contract
-pacto init                                   # scaffold a pacto.yaml
-pacto validate .                             # 4-layer validation
+# Author and publish a contract (install is below)
+pacto init my-service && cd my-service       # scaffold a contract bundle
+pacto validate .                             # 4-layer validation, run from inside the new directory
 pacto push oci://ghcr.io/acme/svc-pacto      # tag inferred from service.version
 
 # Catch breaking changes in CI
 pacto diff oci://ghcr.io/acme/svc:1.0 oci://ghcr.io/acme/svc:2.0
 
 # Explore everything in a browser
-pacto dashboard                              # auto-detects local, OCI, and K8s sources
+pacto dashboard                              # auto-detects local, OCI and K8s sources
 ```
 
 Full install options are [below](#installation); the [Quickstart](https://trianalab.github.io/pacto/quickstart) goes from zero to a published contract in two minutes.
-
----
-
-## How it fits together
-
-1. A developer defines a `pacto.yaml` alongside the service code.
-2. The CLI validates it and publishes it to an OCI registry.
-3. The operator discovers the contract in-cluster, tracks every version, and checks runtime alignment (ports, replicas, health).
-4. The dashboard merges all sources — local, OCI, Kubernetes, cache — into one explorable view.
 
 ---
 
@@ -66,30 +54,27 @@ Full install options are [below](#installation); the [Quickstart](https://triana
 
 Someone bumped the version, moved a port, removed an API endpoint, and dropped a config property. `pacto diff` catches it before the merge:
 
-| Classification | Path | Change | Old | New |
+| Classification | Path | Type | Old | New |
 |---|---|---|---|---|
 | NON_BREAKING | `service.version` | modified | `1.0.0` | `2.0.0` |
 | BREAKING | `interfaces.port` | modified | `8081` | `9090` |
 | BREAKING | `openapi.paths[/predict]` | removed | `/predict` | — |
-| BREAKING | `configuration.properties[model_path]` | removed | `model_path` | — |
+| BREAKING | `schema.properties.model_path` | removed | `model_path` | — |
 
-The table comes from `pacto diff --output-format markdown`. The exit code is non-zero on breaking changes, so it can gate merges in CI.
+`pacto diff --output-format markdown` emits a similar table (it also includes a Reason column). The exit code is non-zero on breaking changes, so it can gate merges in CI.
 
 ---
 
 ## Dashboard
 
-Run `pacto dashboard` and open your browser. It auto-detects every available source — Kubernetes (via the operator), OCI registries, local directories, and disk cache — and merges them into a single view of your fleet:
+`pacto dashboard` merges every detected source into one view of your fleet:
 
-- **Fleet overview** — compliance, readiness, and high-blast-radius services at a glance
+- **Fleet overview** — compliance, readiness and high-blast-radius services at a glance
 - **Dependency graph** — interactive service relationships with recursive resolution
-- **Ownership views** — compliance and blast radius per owner, with drill-down and owner-filtered graphs
-- **Readiness overview** — readiness scores, status, and check gaps (expired or invalid) across services
 - **Version history and diffs** — every published version from OCI, with classified change diffs
-- **Service details** — interfaces, configuration schemas, policy references, readiness, documentation
 - **Runtime status** — with the operator, whether deployed services align with their contracts
 
-Run it locally, or deploy the [container image](https://trianalab.github.io/pacto/dashboard-docker) alongside the operator for a combined view: runtime state from Kubernetes plus contract data from OCI.
+Ownership views, readiness scoring and per-service details are covered in the [platform engineer guide](https://trianalab.github.io/pacto/platform-engineers). Run it locally, or deploy the [container image](https://trianalab.github.io/pacto/dashboard-docker) alongside the operator for a combined view: runtime state from Kubernetes plus contract data from OCI.
 
 ---
 
@@ -113,68 +98,40 @@ interfaces:
     contract: interfaces/openapi.yaml
 
 dependencies:
-  - ref: oci://ghcr.io/acme/auth-pacto@sha256:abc123
+  - name: auth
+    ref: oci://ghcr.io/acme/auth-pacto@sha256:abc123
     required: true
     compatibility: "^2.0.0"
-
-runtime:
-  workload: service
-  state:
-    type: stateful
-    persistence:
-      scope: local
-      durability: persistent
-    dataCriticality: high
-  health:
-    interface: rest-api
-    path: /health
-
-scaling:
-  min: 2
-  max: 10
 ```
 
-Only `pactoVersion` and `service` are required — everything else is opt-in, so a contract can be as minimal or as detailed as your service needs. `pacto init` scaffolds a `1.2` contract; use `1.0` or `1.1` for contracts without readiness (object-only `owner` is enforced across all versions).
+Only `pactoVersion` and `service` are required — everything else (runtime semantics, scaling, configuration, policies and readiness) is opt-in, so a contract can be as minimal or as detailed as your service needs. `pacto init` scaffolds a `1.2` contract; use `1.0` or `1.1` for contracts without readiness (object-only `owner` is enforced across all versions). See the [Contract Reference](https://trianalab.github.io/pacto/contract-reference) for the full field-by-field schema.
+
+Each interface's `contract` field points at a schema you already own — the `interfaces/openapi.yaml` above is your OpenAPI spec, not a Pacto rewrite — so a contract composes your existing interfaces rather than redefining them.
 
 ---
 
 ## Capabilities
 
-- **One contract per service** — a single `pacto.yaml` captures interfaces, dependencies, runtime semantics, configuration, scaling, and readiness
-- **4-layer validation** — structural (JSON Schema), cross-field, semantic, and policy enforcement
-- **Breaking change detection** — deep OpenAPI diffing plus dependency-graph diff with full blast radius; non-zero exit gates CI
-- **Dependency graph resolution** — recursive transitive resolution from OCI registries, siblings fetched in parallel
+Beyond the diff, dashboard and runtime verification shown above:
+
 - **Lockfiles** — reproducible dependency resolution and supply-chain pinning via `pacto.lock`
 - **Packaging ignore** — gitignore-style `.pactoignore` to exclude files from bundles
-- **Readiness contracts** — declare operational readiness evidence (URLs, docs, tickets, reports) with weights and expiry dates; Pacto can derive readiness scores and flag expired or invalid evidence
-- **OCI distribution** — push/pull to GHCR, ECR, ACR, Docker Hub, and Harbor with local caching; signable with cosign or Notary; no custom registry required
-- **Runtime verification** — the Kubernetes operator tracks every contract version and checks ports, replicas, and health against running workloads
+- **OCI distribution** — push/pull to GHCR, ECR, ACR, Docker Hub and Harbor with local caching; signable with cosign or Notary; no custom registry required
 - **Plugin-based generation** — out-of-process plugins produce deployment artifacts from contracts
-- **AI integration** — `pacto mcp` exposes contract operations as [MCP](https://modelcontextprotocol.io) tools for Claude, Cursor, and Copilot
+- **AI integration** — `pacto mcp` exposes contract operations as [MCP](https://modelcontextprotocol.io) tools for Claude, Cursor and Copilot
 - **SBOM diffing** — SPDX / CycloneDX package-level change detection
 
 See the [documentation](https://trianalab.github.io/pacto) for details on each.
 
 ---
 
-## When should I use Pacto?
+## Who is it for?
 
-Use Pacto when you need to:
-
-- Know who owns each service and what it depends on
-- Catch operational breaking changes before merge
-- Compare contract versions across releases
-- Track whether deployed workloads still match their declared contract
-- Build dependency graphs without scraping dashboards or Helm values
-- Surface readiness gaps before production changes
-
----
-
-## Who is this for?
-
-- **Application developers** — describe your service once; validation catches misconfigurations before CI, and breaking changes are detected automatically across versions.
-- **Platform engineers** — consume contracts to generate manifests, enforce policies, and visualize dependency graphs, with a live view of every service in the dashboard.
+- **Application developers** — describe a service once; validation catches misconfigurations before CI and breaking changes are detected automatically across versions.
+- **Platform engineers** — consume contracts to generate manifests, enforce policies and visualize dependency graphs, with a live view of every service in the dashboard.
 - **DevOps / infrastructure teams** — distribute contracts through existing OCI registries; the operator tracks what's deployed and whether it matches its contract.
+
+See the [documentation](https://trianalab.github.io/pacto) for when to use Pacto and per-audience guides.
 
 ---
 
@@ -192,13 +149,14 @@ Use Pacto when you need to:
 | OCI-native distribution | — | ✅ | — | — | ✅ |
 | Machine validation | ✅ | — | ✅ | — | ✅ |
 
-Pacto sits alongside these tools, not on top of them — the contract becomes the shared source of truth between your API spec, your deployment tooling, and your cluster.
+Pacto sits alongside these tools, not on top of them: it composes the interfaces they already produce — your OpenAPI spec, your config schema — and adds the relational and temporal layer no single one owns. The contract becomes the shared source of truth between your API spec, your deployment tooling and your cluster.
 
 ### What Pacto is NOT
 
 - Not a deployment tool — it describes services, not how to run them
 - Not a service mesh — no sidecars, no traffic interception
 - Not a replacement for OpenAPI or Helm — it complements them
+- Not another configuration language — it composes the schemas you already own instead of inventing one
 - Not a service catalog — the dashboard can feed data into one
 
 See [MANIFEST.md](MANIFEST.md) for the full rationale.

--- a/cmd/gendocs/main.go
+++ b/cmd/gendocs/main.go
@@ -49,7 +49,7 @@ const footer = `---
 
 | Variable | Description |
 |----------|-------------|
-| ` + "`PACTO_CACHE_DIR`" + ` | Override the OCI bundle cache directory (default: ` + "`~/.cache/pacto/oci`" + `) |
+| ` + "`PACTO_CACHE_DIR`" + ` | Cache directory for the ` + "`pacto dashboard`" + ` bundle scan. The core CLI cache location is controlled by ` + "`XDG_CACHE_HOME`" + ` (see below). |
 | ` + "`PACTO_NO_CACHE`" + ` | Set to ` + "`1`" + ` to disable OCI bundle caching (equivalent to ` + "`--no-cache`" + `) |
 | ` + "`PACTO_NO_UPDATE_CHECK`" + ` | Set to ` + "`1`" + ` to disable automatic update checks |
 | ` + "`PACTO_REGISTRY_USERNAME`" + ` | Registry username for authentication |
@@ -76,15 +76,13 @@ The following variables configure the dashboard when set (see also [Dashboard Co
 
 Pacto follows this credential resolution chain:
 
-1. Explicit CLI flags (` + "`--username`" + `, ` + "`--password`" + `)
-2. Environment variables (` + "`PACTO_REGISTRY_USERNAME`" + `, ` + "`PACTO_REGISTRY_PASSWORD`" + `, ` + "`PACTO_REGISTRY_TOKEN`" + `)
-3. Pacto config (` + "`~/.config/pacto/config.json`" + `, written by ` + "`pacto login`" + `)
-4. GitHub CLI (` + "`gh auth token`" + `, for ` + "`ghcr.io`" + ` and ` + "`docker.pkg.github.com`" + ` only)
-5. Docker config (` + "`~/.docker/config.json`" + `) and credential helpers
-6. Cloud auto-detection (ECR, GCR, ACR)
-7. Anonymous fallback
+1. Environment variables (` + "`PACTO_REGISTRY_TOKEN`" + `, or ` + "`PACTO_REGISTRY_USERNAME`" + ` + ` + "`PACTO_REGISTRY_PASSWORD`" + `)
+2. Pacto config (` + "`~/.config/pacto/config.json`" + `, written by ` + "`pacto login`" + ` — where ` + "`--username`" + ` / ` + "`--password`" + ` are persisted)
+3. GitHub CLI (` + "`gh auth token`" + `, for ` + "`ghcr.io`" + ` and ` + "`docker.pkg.github.com`" + ` only)
+4. Docker config (` + "`~/.docker/config.json`" + `) and credential helpers (including cloud-registry helpers for ECR, GCR and ACR)
+5. Anonymous fallback
 
-For GitHub registries, step 4 means you can skip ` + "`pacto login`" + ` entirely if you have ` + "`gh`" + ` authenticated with the ` + "`write:packages`" + ` scope (see [` + "`pacto login`" + `](#pacto-login) above).
+For GitHub registries, step 3 means you can skip ` + "`pacto login`" + ` entirely if you have ` + "`gh`" + ` authenticated with the ` + "`write:packages`" + ` scope (see [` + "`pacto login`" + `](#pacto-login) above).
 
 No credentials are ever stored in contract files.
 `
@@ -150,69 +148,12 @@ Sibling dependencies are resolved in parallel. OCI bundles are cached locally in
 		"The check runs asynchronously and adds no latency. Results are cached for 24 hours in `~/.config/pacto/update-check.json`.\n\n" +
 		"Notifications are suppressed when:\n" +
 		"- Running a dev build\n" +
-		"- Using `--output-format json`\n" +
+		"- Using `--output-format json` or `--output-format markdown` (the notice shows only for text output)\n" +
 		"- The `PACTO_NO_UPDATE_CHECK=1` environment variable is set",
 
-	"dashboard": "The dashboard is the exploration and observability layer of the Pacto system. " +
-		"It visualizes the same contracts the CLI manages and the operator verifies — " +
-		"making dependency graphs, version history, interfaces, configuration schemas, and diffs accessible in one place.\n\n" +
-		"### What the dashboard shows\n\n" +
-		"- **Dependency graphs** — interactive D3 visualization of service relationships, with impact chain highlighting\n" +
-		"- **Version history** — all available versions from OCI, with hash, classification, and timestamps\n" +
-		"- **Interface details** — OpenAPI endpoints, gRPC definitions, event schemas extracted from contract bundles\n" +
-		"- **Configuration schemas** — JSON Schema properties for environment variables and settings\n" +
-		"- **Policy references** — organizational standards enforcement via referenced policy contracts\n" +
-		"- **Diffs between versions** — classified changes (breaking, non-breaking, potential) between any two versions\n" +
-		"- **Runtime compliance** — when Kubernetes is available, live contract status, conditions, endpoint health, and contract-vs-runtime comparison\n\n" +
-		"### Source model\n\n" +
-		"The dashboard exposes up to **four** source types: `local`, `k8s`, `oci`, and `cache`. " +
-		"`cache` is the on-disk materialized-bundle baseline (`~/.cache/pacto/oci/`); it surfaces as a distinct source " +
-		"**only when no live OCI registry is configured** — an offline fallback. When a live OCI registry *is* configured, " +
-		"the cache stays internal to the `oci` source (used to enrich version data) and is not listed separately. " +
-		"So a session shows either `oci` **or** `cache` for the registry-backed baseline, plus `local` and/or `k8s` when available.\n\n" +
-		"### Contract-first resolution\n\n" +
-		"Sources are resolved using a contract-first model. The contract baseline comes from the highest-priority contract " +
-		"source available, in order `local` → `oci` → `cache` — exactly one contract snapshot wins per service. " +
-		"The runtime source (`k8s`) enriches the contract with live cluster state (contract status, conditions, endpoints) " +
-		"but never overrides contract content; config and policy **content** always comes from the declared contract.\n\n" +
-		"### Internal cache / materialization\n\n" +
-		"Materialized bundles on disk (`~/.cache/pacto/oci/`) back the `oci` source's version enrichment " +
-		"(contract hash, classification, timestamps). When bundles are fetched (via \"Fetch all versions\" or lazy dependency resolution), " +
-		"they are cached on disk and the source's internal view is rescanned so the enriched data surfaces immediately. " +
-		"When no live registry is configured, that same on-disk cache is promoted to a first-class `cache` source.\n\n" +
-		"### `--no-cache` semantics\n\n" +
-		"The `--no-cache` flag prevents the dashboard from scanning pre-existing cached bundles at startup (cold-start mode). " +
-		"However, bundles materialized during the current session (via fetch-all-versions, dependency resolution, or OCI pulls) " +
-		"are still cached to disk and reused for enrichment within the same session.\n\n" +
-		"### Version classification\n\n" +
-		"Each version (except the oldest) receives a classification — `NON_BREAKING`, `POTENTIAL_BREAKING`, or `BREAKING` — " +
-		"computed by diffing consecutive bundles. Classification requires materialized bundles: if a version has not been fetched " +
-		"yet, it will have no classification until its bundle is pulled (e.g. via \"Fetch all versions\").\n\n" +
-		"### Kubernetes + OCI hybrid view\n\n" +
-		"When running alongside the Kubernetes operator (no explicit OCI arguments needed), the dashboard automatically discovers OCI repositories from the `resolvedRef` fields in Pacto CRD statuses. " +
-		"This means a K8s-only dashboard deployment gets the full contract experience: version history, interface details, configuration schemas, and diffs — " +
-		"all loaded from OCI and merged with runtime state from the operator.\n\n" +
-		"### Dependency resolution\n\n" +
-		"When OCI repository names differ from contract service names (e.g., repo `my-service-pacto` but contract has `service.name: my-service`), " +
-		"the dashboard automatically builds a ref-alias map from `imageRef` and `chartRef` fields so that dependency links, graph edges, " +
-		"and cross-references resolve correctly.\n\n" +
-		"### Graph visualization\n\n" +
-		"The built-in D3 force-directed graph supports:\n" +
-		"- Drag to reposition nodes (double-click to unpin)\n" +
-		"- Zoom and pan\n" +
-		"- Impact chain highlighting on hover (broken nodes highlight dependents)\n" +
-		"- Dynamic arrow positioning (arrows connect to the closest box edge)\n" +
-		"- Source and status filtering via the legend\n\n" +
-		"### Version selection\n\n" +
-		"The dashboard selects the **current version** of each OCI-backed service as the highest valid semver tag. " +
-		"Non-semver tags (e.g. `latest`, `main`) are excluded from version lists and never selected as the current version.\n\n" +
-		"When you use \"Fetch all versions\" in the version history tab, all available versions are pulled from the OCI registry " +
-		"and cached locally (`~/.cache/pacto/oci/`). These cached versions survive dashboard restarts.\n\n" +
-		"When a remote dependency is lazily resolved (via navigation to an unresolved dependency), the resolved bundle is also " +
-		"cached on disk. Its version history can be browsed and other versions can be loaded.\n\n" +
-		"### Diagnostics mode\n\n" +
-		"Pass `--diagnostics` to enable debug endpoints (`/api/debug/sources` and `/api/debug/services`) " +
-		"that expose raw per-source data for troubleshooting.",
+	"dashboard": "The dashboard is the exploration and observability layer of the Pacto system: it visualizes the same contracts the CLI manages and the operator verifies — dependency graphs, version history, interfaces, configuration schemas, readiness and diffs — merged across `local`, `oci`, `k8s` and offline `cache` sources.\n\n" +
+		"It auto-detects sources: pass OCI repositories as arguments, or run it next to the operator (with a kubeconfig) and it discovers OCI repositories from each Pacto resource's `status.contract.resolvedRef`. Use `--no-cache` for a cold start (it skips scanning pre-existing cached bundles; bundles fetched during the session are still cached), and `--diagnostics` to expose the `/api/debug/*` endpoints.\n\n" +
+		"For the source model, contract-first merge priority (`local` > `oci` > `cache`) and version-tracking design, see [Architecture](architecture.md). For a tour of what the dashboard surfaces, see [For platform engineers](platform-engineers.md); to run it as a container, see [Dashboard container](dashboard-docker.md).",
 
 	"mcp": "The server exposes the following tools:\n\n" +
 		"| Tool | Description |\n" +
@@ -221,7 +162,7 @@ Sibling dependencies are resolved in parallel. OCI bundles are cached locally in
 		"| `pacto_edit` | Edit an existing contract — add/remove interfaces and dependencies, change runtime, update metadata. Supports dry run. |\n" +
 		"| `pacto_check` | Validate a contract and return errors, warnings, and actionable improvement suggestions. |\n" +
 		"| `pacto_schema` | Return the Pacto format explanation and full JSON Schema reference. |\n\n" +
-		"All tools accept both local directory paths and `oci://` references.\n\n" +
+		"All tools operate on local contract directories (they read and write `pacto.yaml` on disk); `oci://` references are not resolved.\n\n" +
 		"See [MCP Integration](mcp-integration.md) for detailed setup instructions with Claude and other AI tools.",
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,19 @@
 Pacto follows a layered architecture where dependencies flow predominantly in one direction. There are small, deliberate exceptions documented below. This page describes the internal design for contributors and plugin authors.
 
 ---
+
+## Conceptual model
+
+A Pacto contract describes the relationships between a service's interfaces and how they change over time — ownership, dependencies, compatibility, readiness and lifecycle. A single JSON Schema describes one interface in isolation and structurally cannot express how interfaces relate or evolve; that relational and temporal layer is Pacto's differentiator. It is why the core splits into `pkg/graph` (dependencies), `pkg/diff` (compatibility and change over time) and `pkg/validation` (enforcement).
+
+Underneath, Pacto composes the interfaces you already have rather than inventing a configuration language. An interface is a JSON Schema, OpenAPI spec or event schema — a service's config interface is its config JSON Schema, an API interface is its OpenAPI document. Where an interface is already owned by another system, Pacto composes it instead of reinventing it. Composition is the on-ramp; the operational contract is the differentiator.
+
+> This mirrors Brian Grant's 2016 [Cloud Native Application Interfaces](https://kubernetes.io/blog/2016/09/cloud-native-application-interfaces/) split between *interfaces* (configuration schema) and *requirements* (dependencies): composition covers the interfaces half, dependencies and compatibility cover the requirements half.
+
+In one line: **JSON Schema describes an interface; Pacto describes the relationships between interfaces and how they change over time.**
+
+---
+
 ## Dependency graph
 
 ```mermaid
@@ -51,8 +64,6 @@ graph TD
 
 Dependencies flow **downward only**. The OCI adapter (`pkg/oci`) is a public package, importable by external consumers such as the [Kubernetes Operator](operator.md).
 
-All core domain logic lives in `pkg/` and is reusable outside the CLI — for example, by the [Kubernetes Operator](operator.md).
-
 ---
 
 ## Layer overview
@@ -73,11 +84,9 @@ Infrastructure adapters live in `internal/` because they depend on external syst
 | `internal/logger` | Global `slog` configuration |
 | `internal/update` | Async GitHub version checking and self-update |
 
-The OCI adapter (`pkg/oci`) is a public package so it can be imported by external consumers (e.g., the Kubernetes operator).
-
 Test infrastructure lives in `internal/testutil`, which provides shared mocks and fixtures (`MockBundleStore`, `MockPluginRunner`, `TestBundle()`) used across test packages.
 
-`pkg/dashboard` is the largest package in the core layer. Unlike the other `pkg/*` packages (which are focused processing libraries), the dashboard is a self-contained application component: HTTP server, multi-source data aggregation, graph visualization, compliance engine, Kubernetes client, and embedded SPA. Its complexity is justified because it must remain reusable outside the CLI binary (the Kubernetes operator embeds the same dashboard server).
+`pkg/dashboard` is the largest core package — a self-contained app component (HTTP server, multi-source aggregation, graph, compliance, K8s client, embedded SPA) that the operator also embeds.
 
 ---
 
@@ -118,6 +127,7 @@ Compares two contracts and classifies every change using a deterministic rule ta
 - `dependency.go` -- dependency list changes
 - `openapi.go` -- deep OpenAPI diff (paths, methods, parameters, request bodies, responses)
 - `schema.go` -- recursive JSON Schema diff (properties, required fields, types, constraints)
+- `readiness.go` -- readiness assessment (all changes NonBreaking, still surfaced)
 
 ### `pkg/sbom` -- SBOM parser and differ
 
@@ -168,7 +178,7 @@ Closure building (transitive dependencies and transitive config/policy reference
 
 Gitignore-style pattern matching for `.pactoignore` filtering. Determines which files are excluded from bundle packaging.
 
-- `DefaultPatterns` -- `.git/`, `.pactoignore`, `pacto.lock`, `.DS_Store`
+- `DefaultPatterns` -- `.git/`, `.pactoignore`, `.DS_Store` (a committed `pacto.lock` is intentionally NOT default-ignored — it ships inside the bundle)
 - `alwaysKeep` guard -- ensures `pacto.yaml` is never ignorable regardless of user patterns
 - `Matcher.Ignored()` -- ancestor-aware filtering (files inside ignored directories are themselves ignored)
 - `FS()` -- filtering `fs.FS` wrapper applied at bundle load so pack, push and validation see one consistent file set
@@ -189,7 +199,7 @@ Cobra command handlers and Viper configuration. **Zero business logic** -- only 
 
 ### `pkg/oci` -- OCI adapter
 
-Wraps `go-containerregistry` to handle OCI registry operations. This is a public package, importable by external consumers such as the Kubernetes operator. Pacto distributes contracts as OCI artifacts -- the same standard behind container images -- so they work with any OCI-compliant registry (GHCR, ECR, ACR, Docker Hub, Harbor) without new infrastructure. Every pushed contract is content-addressed with a digest, making it immutable and verifiable.
+Wraps `go-containerregistry` for OCI registry operations. Public package, imported by the operator. Pushes are content-addressed (immutable digest).
 
 Key components:
 
@@ -197,12 +207,12 @@ Key components:
 - **`Client`** -- implements `BundleStore` using `go-containerregistry`. Translates between `contract.Bundle` and OCI images (tar.gz layer with metadata labels)
 - **`CachedStore`** -- wraps any `BundleStore` with in-memory and disk caching (`~/.cache/pacto/oci/<registry>/<repo>/<tag>/bundle.tar.gz`). Can be disabled at runtime via `--no-cache`
 - **`Resolver`** -- lazy version resolution with semver filtering. `Resolve()` pulls bundles in `LocalOnly` or `RemoteAllowed` mode. `FetchAllVersions()` pulls every semver tag to populate the cache. `FilterSemverTags()` selects valid semver tags sorted descending
-- **Credential chain** -- `NewKeychain()` tries sources in priority order: explicit flags/env vars, pacto config (`~/.config/pacto/config.json`), `gh` CLI token (GitHub registries), Docker config + credential helpers, cloud auto-detection (ECR/GCR/ACR), anonymous fallback
+- **Credential chain** -- `NewKeychain()` resolves credentials by priority order; see [CLI reference → Authentication](cli-reference.md#authentication) for the full chain
 - **Typed errors** -- `AuthenticationError`, `ArtifactNotFoundError`, `RegistryUnreachableError`, `InvalidRefError`, `InvalidBundleError`, `NoMatchingVersionError`
 
 ### `internal/mcp` -- MCP server
 
-Thin adapter layer that exposes Pacto operations as [Model Context Protocol](https://modelcontextprotocol.io) tools. Each MCP tool handler delegates to an `internal/app` service method -- no business logic lives here. The server communicates over stdio and is started via `pacto mcp`. Used by AI tools such as Claude, Cursor, and Copilot.
+Thin adapter layer that exposes Pacto operations as [Model Context Protocol](https://modelcontextprotocol.io) tools. Each MCP tool handler delegates to an `internal/app` service method -- no business logic lives here. The server communicates over stdio (default) or HTTP (`pacto mcp -t http`) and is started via `pacto mcp`. Used by AI tools such as Claude, Cursor and Copilot.
 
 ### `internal/logger` -- Logger setup
 
@@ -229,13 +239,7 @@ The dashboard exposes up to **four source types**:
 | `cache` | Contract baseline from the on-disk materialized cache | `CacheSource` |
 | `k8s` | Runtime enrichment from Kubernetes | `K8sSource` |
 
-`cache` is an **offline fallback**: it surfaces as a distinct source only when no
-live OCI registry is configured. When a live OCI registry *is* configured, the
-on-disk cache stays internal to the `oci` source (used for version enrichment) and
-is **not** listed separately — `ActiveSources()` in `detect.go` exposes the disk
-cache under the `"oci"` key in that case and under the `"cache"` key otherwise. So
-a session shows either `oci` **or** `cache` for the registry-backed baseline, never
-both (see [Internal materialization](#internal-materialization) below).
+`cache` is an **offline fallback**: it surfaces as a distinct source only when no live OCI registry is configured (see [Internal materialization](#internal-materialization) below).
 
 ### Discovery lifecycle
 
@@ -391,14 +395,14 @@ When running alongside the Kubernetes operator, `EnrichFromK8s()` automatically 
 
 The dashboard computes version tracking semantics from two sources:
 
-- **Version policy** (`versionPolicy`): the preferred source is the operator's `status.contract.resolutionPolicy` field (`Latest` → `"tracking"`, `PinnedTag` → `"pinned-tag"`, `PinnedDigest` → `"pinned-digest"`), normalized by `NormalizeResolutionPolicy()`. When unavailable (non-K8s sources, older operators), `ClassifyVersionPolicy()` provides a conservative fallback that only classifies unambiguous cases (digest, explicit semver tag) and returns empty for ambiguous refs.
-- **Latest available** (`latestAvailable`): the highest semver version from the existing version list. Computed by `ComputeLatestAvailable()`.
-- **Update available** (`updateAvailable`): true when `latestAvailable` is a higher semver than the current `version`. Computed by `IsUpdateAvailable()`. This is informational -- it does **not** affect contract compliance status.
-- **Current version marker** (`isCurrent`): set on the `Version` entry matching `ServiceDetails.Version` via `MarkCurrentVersion()`.
+- **Version policy** (`versionPolicy`): the preferred source is the operator's `status.contract.resolutionPolicy` field (`Latest` → `"tracking"`, `PinnedTag` → `"pinned-tag"`, `PinnedDigest` → `"pinned-digest"`), normalized by `normalizeResolutionPolicy()`. When unavailable (non-K8s sources, older operators), `classifyVersionPolicy()` provides a conservative fallback that only classifies unambiguous cases (digest, explicit semver tag) and returns empty for ambiguous refs.
+- **Latest available** (`latestAvailable`): the highest semver version from the existing version list. Computed by `computeLatestAvailable()`.
+- **Update available** (`updateAvailable`): true when `latestAvailable` is a higher semver than the current `version`. Computed by `isUpdateAvailable()`. This is informational -- it does **not** affect contract compliance status.
+- **Current version marker** (`isCurrent`): set on the `Version` entry matching `ServiceDetails.Version` via `markCurrentVersion()`.
 
-Operator-provided `resolutionPolicy` is propagated through the K8s source (`serviceDetailsFromK8sStatus`), carried forward by `enrichWithRuntime()`, and preserved by `enrichVersionTracking()` which only applies the fallback when no policy is already set.
+Operator-provided `resolutionPolicy` is propagated through the K8s source (`serviceDetailsFromK8sStatus`), carried forward by `enrichWithRuntime()`, and preserved by the index/detail enrichment in `server.go`, which applies the fallback only when no policy is already set.
 
-These fields are populated during the service index cache rebuild (`enrichVersionTracking()`) and surfaced through the existing `/api/services` and `/api/services/{name}` endpoints.
+These fields are populated during the service-index cache rebuild in `server.go` and surfaced through the existing `/api/services` and `/api/services/{name}` endpoints.
 
 ---
 
@@ -408,10 +412,11 @@ These fields are populated during the service index cache rebuild (`enrichVersio
 2. **Strict layering** -- CLI → App → Core (`pkg/`) → Domain (`pkg/contract`)
 3. **Observation separated from validation** -- runtime observation (collecting actual state from Kubernetes, CI, etc.) happens outside `pkg/`; validation against observed state happens inside `pkg/validation`
 4. **No global state** -- all instances created in the composition root (`main.go`); the only global is `slog.SetDefault()` configured once at startup
-5. **Interface-based** -- engines depend on interfaces (`DataSource`, `BundleStore`, `ContractFetcher`, `Runner`), not concrete implementations
+5. **Interface-based** -- engines depend on interfaces (`DataSource`, `BundleStore`, `ContractFetcher`, `PluginRunner`), not concrete implementations
 6. **Out-of-process plugins** -- language-agnostic, version-independent
 7. **Embedded schemas** -- JSON Schema compiled into the binary
 8. **Deterministic validation** -- no configurable rules; same input, same result
+9. **Compose, don't replace** -- an interface is a JSON Schema, OpenAPI or event schema that Pacto composes, not a new config language it invents; the contract adds only the relational and temporal layer (ownership, dependencies, compatibility, readiness, lifecycle) that no single interface owns
 
 ---
 
@@ -427,10 +432,9 @@ These rules must be preserved by future changes. Each exists for a specific reas
 | K8s enriches runtime only, never overrides contract content | Contract is the source of truth for interfaces, config, dependencies, version. K8s provides live state (contract status, conditions, endpoints), and config/policy *content* always comes from the declared contract. The computed `Validation` summary is the one runtime-recomputed field, and `SectionMeta` attributes it to `k8s` so provenance stays honest. |
 | Cache is a public source only as an offline fallback | When a live `oci` source is configured the disk cache stays internal to it (exposed under the `"oci"` key). Only when no live registry is configured is the cache promoted to a distinct `cache` source. A session shows `oci` **or** `cache` for the registry baseline, never both — so users are never confused about which is authoritative. |
 | Contract source priority is `local` > `oci` > `cache` | Explicit dev intent beats the registry baseline, which beats the offline disk cache. `cache` only participates when `oci` is absent. |
-| `resolverVersionSources` is `["k8s", "oci", "local", "cache"]` | Version history is merged in this order. With a live registry, `OCISource.GetVersions()` already includes cache enrichment so the trailing `cache` entry is a no-op; without one, `cache` supplies the catalog from disk. |
+| `resolverVersionSources` is `["k8s", "oci", "local", "cache"]` | Version history is merged in this order (see [Version history](#version-history)). |
 | Classification requires materialized bundles | `ClassifyVersions()` diffs consecutive bundles. Without both bundles available, no classification is computed. This is correct behavior, not a bug. |
-| `--no-cache` skips startup scanning, not same-session materialization | Cold-start mode ensures deterministic initial state. `DisableCache()` only skips disk reads — disk writes remain enabled so bundles fetched during the session are persisted and available for enrichment. |
-| `DisableCache()` must never disable disk writes | Same-session materialization (fetch-all-versions, resolve) relies on `CachedStore` writing bundles to disk. `CacheSource` then reads these during `RefreshCacheSources()` to provide hash, createdAt, and classification enrichment. |
+| `--no-cache` skips startup scanning, not same-session materialization | Cold-start mode ensures deterministic initial state. `DisableCache()` skips disk reads but never disk writes, so bundles fetched during the session are persisted for enrichment (see [`--no-cache` semantics](#-no-cache-semantics)). |
 | `internal/app` methods are stateless | Options in, result out. No side effects beyond the operation itself. This makes testing and composition straightforward. |
 | Validation is deterministic | No configurable rule sets. Same contract + same schema = same result, always. |
 | `SectionMeta` is populated on every service-detail path | Both the resolved (multi-source) path and the single-source `getService` path compute `SectionMeta`, so the UI can always distinguish `present` / `empty` / `not_applicable` / `unavailable` and label each section's `source`. |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -53,7 +53,7 @@ Each positional argument is a pacto source reference:
 When no arguments are given, sources are auto-detected:
   - local: enabled if pacto.yaml is found in the working directory
   - k8s:   enabled if a valid kubeconfig is found and the cluster is reachable
-  - oci:   auto-discovered from K8s resolvedRefs, or via PACTO_DASHBOARD_REPO env var
+  - oci:   auto-discovered from K8s status.contract.resolvedRef, or via PACTO_DASHBOARD_REPO env var
 
 Materialized bundles on disk (~/.cache/pacto/oci) are used internally by the
 OCI source to enrich version data (hash, classification, timestamps) without
@@ -61,7 +61,7 @@ appearing as a separate source. The --no-cache flag skips pre-existing cache
 at startup but still allows same-session materialization (e.g. fetch-all-versions).
 
 When running alongside the Kubernetes operator, OCI repositories are automatically
-discovered from the resolvedRef fields of Pacto CRD resources. This provides full
+discovered from the status.contract.resolvedRef fields of Pacto CRD resources. This provides full
 contract bundles, version history, interfaces, and diffs — without needing
 explicit OCI arguments. The result is a hybrid view: runtime truth from the
 operator combined with contract truth from OCI.
@@ -108,66 +108,11 @@ pacto dashboard [sources...] [flags]
       --port int             port for the dashboard server (default 3000)
 ```
 
-The dashboard is the exploration and observability layer of the Pacto system. It visualizes the same contracts the CLI manages and the operator verifies — making dependency graphs, version history, interfaces, configuration schemas, and diffs accessible in one place.
+The dashboard is the exploration and observability layer of the Pacto system: it visualizes the same contracts the CLI manages and the operator verifies — dependency graphs, version history, interfaces, configuration schemas, readiness and diffs — merged across `local`, `oci`, `k8s` and offline `cache` sources.
 
-### What the dashboard shows
+It auto-detects sources: pass OCI repositories as arguments, or run it next to the operator (with a kubeconfig) and it discovers OCI repositories from each Pacto resource's `status.contract.resolvedRef`. Use `--no-cache` for a cold start (it skips scanning pre-existing cached bundles; bundles fetched during the session are still cached), and `--diagnostics` to expose the `/api/debug/*` endpoints.
 
-- **Dependency graphs** — interactive D3 visualization of service relationships, with impact chain highlighting
-- **Version history** — all available versions from OCI, with hash, classification, and timestamps
-- **Interface details** — OpenAPI endpoints, gRPC definitions, event schemas extracted from contract bundles
-- **Configuration schemas** — JSON Schema properties for environment variables and settings
-- **Policy references** — organizational standards enforcement via referenced policy contracts
-- **Diffs between versions** — classified changes (breaking, non-breaking, potential) between any two versions
-- **Runtime compliance** — when Kubernetes is available, live contract status, conditions, endpoint health, and contract-vs-runtime comparison
-
-### Source model
-
-The dashboard exposes up to **four** source types: `local`, `k8s`, `oci`, and `cache`. `cache` is the on-disk materialized-bundle baseline (`~/.cache/pacto/oci/`); it surfaces as a distinct source **only when no live OCI registry is configured** — an offline fallback. When a live OCI registry *is* configured, the cache stays internal to the `oci` source (used to enrich version data) and is not listed separately. So a session shows either `oci` **or** `cache` for the registry-backed baseline, plus `local` and/or `k8s` when available.
-
-### Contract-first resolution
-
-Sources are resolved using a contract-first model. The contract baseline comes from the highest-priority contract source available, in order `local` → `oci` → `cache` — exactly one contract snapshot wins per service. The runtime source (`k8s`) enriches the contract with live cluster state (contract status, conditions, endpoints) but never overrides contract content; config and policy **content** always comes from the declared contract.
-
-### Internal cache / materialization
-
-Materialized bundles on disk (`~/.cache/pacto/oci/`) back the `oci` source's version enrichment (contract hash, classification, timestamps). When bundles are fetched (via "Fetch all versions" or lazy dependency resolution), they are cached on disk and the source's internal view is rescanned so the enriched data surfaces immediately. When no live registry is configured, that same on-disk cache is promoted to a first-class `cache` source.
-
-### `--no-cache` semantics
-
-The `--no-cache` flag prevents the dashboard from scanning pre-existing cached bundles at startup (cold-start mode). However, bundles materialized during the current session (via fetch-all-versions, dependency resolution, or OCI pulls) are still cached to disk and reused for enrichment within the same session.
-
-### Version classification
-
-Each version (except the oldest) receives a classification — `NON_BREAKING`, `POTENTIAL_BREAKING`, or `BREAKING` — computed by diffing consecutive bundles. Classification requires materialized bundles: if a version has not been fetched yet, it will have no classification until its bundle is pulled (e.g. via "Fetch all versions").
-
-### Kubernetes + OCI hybrid view
-
-When running alongside the Kubernetes operator (no explicit OCI arguments needed), the dashboard automatically discovers OCI repositories from the `resolvedRef` fields in Pacto CRD statuses. This means a K8s-only dashboard deployment gets the full contract experience: version history, interface details, configuration schemas, and diffs — all loaded from OCI and merged with runtime state from the operator.
-
-### Dependency resolution
-
-When OCI repository names differ from contract service names (e.g., repo `my-service-pacto` but contract has `service.name: my-service`), the dashboard automatically builds a ref-alias map from `imageRef` and `chartRef` fields so that dependency links, graph edges, and cross-references resolve correctly.
-
-### Graph visualization
-
-The built-in D3 force-directed graph supports:
-- Drag to reposition nodes (double-click to unpin)
-- Zoom and pan
-- Impact chain highlighting on hover (broken nodes highlight dependents)
-- Dynamic arrow positioning (arrows connect to the closest box edge)
-- Source and status filtering via the legend
-
-### Version selection
-
-The dashboard selects the **current version** of each OCI-backed service as the highest valid semver tag. Non-semver tags (e.g. `latest`, `main`) are excluded from version lists and never selected as the current version.
-
-When you use "Fetch all versions" in the version history tab, all available versions are pulled from the OCI registry and cached locally (`~/.cache/pacto/oci/`). These cached versions survive dashboard restarts.
-
-When a remote dependency is lazily resolved (via navigation to an unresolved dependency), the resolved bundle is also cached on disk. Its version history can be browsed and other versions can be loaded.
-
-### Diagnostics mode
-
-Pass `--diagnostics` to enable debug endpoints (`/api/debug/sources` and `/api/debug/services`) that expose raw per-source data for troubleshooting.
+For the source model, contract-first merge priority (`local` > `oci` > `cache`) and version-tracking design, see [Architecture](architecture.md). For a tour of what the dashboard surfaces, see [For platform engineers](platform-engineers.md); to run it as a container, see [Dashboard container](dashboard-docker.md).
 
 ---
 
@@ -405,7 +350,7 @@ pacto lock [dir] [flags]
   -h, --help                      help for lock
       --set stringArray           set a contract value (e.g. --set service.version=2.0.0)
       --update                    re-resolve dependencies to the newest version within their constraint
-      --update-name stringArray   only update the named dependency (repeatable; implies --update)
+      --update-name stringArray   re-resolve only the named dependency, preserving all other pins (repeatable)
   -f, --values stringArray        values file to merge into the contract (can be repeated; last wins)
 ```
 
@@ -521,7 +466,7 @@ The server exposes the following tools:
 | `pacto_check` | Validate a contract and return errors, warnings, and actionable improvement suggestions. |
 | `pacto_schema` | Return the Pacto format explanation and full JSON Schema reference. |
 
-All tools accept both local directory paths and `oci://` references.
+All tools operate on local contract directories (they read and write `pacto.yaml` on disk); `oci://` references are not resolved.
 
 See [MCP Integration](mcp-integration.md) for detailed setup instructions with Claude and other AI tools.
 
@@ -659,7 +604,7 @@ The check runs asynchronously and adds no latency. Results are cached for 24 hou
 
 Notifications are suppressed when:
 - Running a dev build
-- Using `--output-format json`
+- Using `--output-format json` or `--output-format markdown` (the notice shows only for text output)
 - The `PACTO_NO_UPDATE_CHECK=1` environment variable is set
 
 ---
@@ -732,7 +677,7 @@ pacto version [flags]
 
 | Variable | Description |
 |----------|-------------|
-| `PACTO_CACHE_DIR` | Override the OCI bundle cache directory (default: `~/.cache/pacto/oci`) |
+| `PACTO_CACHE_DIR` | Cache directory for the `pacto dashboard` bundle scan. The core CLI cache location is controlled by `XDG_CACHE_HOME` (see below). |
 | `PACTO_NO_CACHE` | Set to `1` to disable OCI bundle caching (equivalent to `--no-cache`) |
 | `PACTO_NO_UPDATE_CHECK` | Set to `1` to disable automatic update checks |
 | `PACTO_REGISTRY_USERNAME` | Registry username for authentication |
@@ -759,14 +704,12 @@ The following variables configure the dashboard when set (see also [Dashboard Co
 
 Pacto follows this credential resolution chain:
 
-1. Explicit CLI flags (`--username`, `--password`)
-2. Environment variables (`PACTO_REGISTRY_USERNAME`, `PACTO_REGISTRY_PASSWORD`, `PACTO_REGISTRY_TOKEN`)
-3. Pacto config (`~/.config/pacto/config.json`, written by `pacto login`)
-4. GitHub CLI (`gh auth token`, for `ghcr.io` and `docker.pkg.github.com` only)
-5. Docker config (`~/.docker/config.json`) and credential helpers
-6. Cloud auto-detection (ECR, GCR, ACR)
-7. Anonymous fallback
+1. Environment variables (`PACTO_REGISTRY_TOKEN`, or `PACTO_REGISTRY_USERNAME` + `PACTO_REGISTRY_PASSWORD`)
+2. Pacto config (`~/.config/pacto/config.json`, written by `pacto login` — where `--username` / `--password` are persisted)
+3. GitHub CLI (`gh auth token`, for `ghcr.io` and `docker.pkg.github.com` only)
+4. Docker config (`~/.docker/config.json`) and credential helpers (including cloud-registry helpers for ECR, GCR and ACR)
+5. Anonymous fallback
 
-For GitHub registries, step 4 means you can skip `pacto login` entirely if you have `gh` authenticated with the `write:packages` scope (see [`pacto login`](#pacto-login) above).
+For GitHub registries, step 3 means you can skip `pacto login` entirely if you have `gh` authenticated with the `write:packages` scope (see [`pacto login`](#pacto-login) above).
 
 No credentials are ever stored in contract files.

--- a/docs/contract-reference.md
+++ b/docs/contract-reference.md
@@ -1,6 +1,8 @@
 # Contract Reference (v1.2)
 A Pacto contract is a YAML file (`pacto.yaml`) that describes a service's operational interface — interfaces, dependencies, runtime behavior, configuration, scaling and readiness. This page covers every section, field, validation rule and change classification rule.
 
+Each `interfaces`, `configurations` and `policies` entry points at a schema you already have — an OpenAPI spec, a protobuf or event definition, a JSON Schema — so a contract composes the interfaces you already own rather than inventing a new configuration language. On top of that it adds what no single schema can express: ownership, dependencies, compatibility, readiness and how they change over time.
+
 ---
 
 The canonical JSON Schemas are available per version:
@@ -81,11 +83,7 @@ Pacto auto-detects the format by file extension. Place one or more SBOM files di
 
 **Generating an SBOM:**
 
-Use any standard SBOM generator. Recommended tools:
-
-- [Syft](https://github.com/anchore/syft) — `syft . -o spdx-json=sbom/sbom.spdx.json`
-- [Trivy](https://github.com/aquasecurity/trivy) — `trivy fs . --format spdx-json -o sbom/sbom.spdx.json`
-- [cdxgen](https://github.com/CycloneDX/cdxgen) — `cdxgen -o sbom/bom.cdx.json`
+Generate with any standard tool ([Syft](https://github.com/anchore/syft), [Trivy](https://github.com/aquasecurity/trivy), [cdxgen](https://github.com/CycloneDX/cdxgen)) writing SPDX/CycloneDX JSON into `sbom/`.
 
 ---
 
@@ -294,17 +292,13 @@ The dashboard uses a canonical owner key for aggregation and navigation:
 1. If owner has `team` → uses `team`
 2. If owner has `dri` (no team) → uses `dri`
 
-This key is used consistently across the owners aggregation view (`#/owners`), owner detail view (`#/owners/:key`), service list filtering and dependency graph highlighting.
-
-The owners aggregation view (`#/owners`) includes a stacked horizontal bar chart showing the compliance breakdown per owner — Compliant (green), Warning (yellow), Non-Compliant (red), and Reference (gray). The chart is sorted by number of services descending. Clicking any bar navigates to the owner detail view. Hovering shows a tooltip with the full breakdown and compliance percentage.
-
-The owner detail view (`#/owners/:key`) surfaces all available structured ownership metadata — team, DRI, and contacts with their type, value, and purpose — in a clean metadata block. When the owner has a dependency graph, owned services are persistently emphasized with a three-tier visual hierarchy (owned → direct dependencies → rest), auto-centered viewport, and stable highlighting that survives hover interactions.
+This key is used consistently across the owners aggregation view (`#/owners`), owner detail view (`#/owners/:key`), service list filtering and dependency graph highlighting. See [Platform engineers — dashboard](platform-engineers.md) for how the dashboard renders these views.
 
 ---
 
 ### `interfaces`
 
-Declares the service's communication boundaries. Optional — a service with no network interfaces (e.g. a batch job or shared library) may omit this section entirely.
+Declares the service's communication boundaries. Optional — a service with no network interfaces (e.g. a batch job or shared library) may omit this section entirely. The `contract` field points at the interface definition you already publish — an OpenAPI spec, a `.proto` or an event schema — so Pacto references your existing interface rather than redefining it.
 
 | Field | Type | Required | Constraints |
 |-------|------|----------|-------------|
@@ -344,7 +338,7 @@ When `schema` is used, the configuration schema is a local file within the bundl
 
 Required configuration keys are derived from the JSON Schema's `required` array.
 
-The optional `values` field provides default configuration values that are validated against the referenced JSON Schema. When using `ref`, values validation is deferred to runtime resolution. This is useful for documenting expected defaults or providing environment-specific overrides via the `--set` and `--values` flags (see [Contract overrides](#contract-overrides)).
+The optional `values` field provides default configuration values that are validated against the local `schema`. A `ref:` entry carries no `values` — the two are mutually exclusive (see above); to attach values, vendor a local `schema:`. Values are useful for documenting expected defaults or providing environment-specific overrides via the `--set` and `--values` flags (see [Contract overrides](#contract-overrides)).
 
 !!! tip
     All files referenced by the contract — including the configuration schema — are packaged into the bundle when you run `pacto push`. The bundle is a self-contained OCI artifact that includes `pacto.yaml`, interface contracts, the configuration schema, and any other files in the contract directory.
@@ -404,7 +398,7 @@ Your configuration JSON Schema should declare secret fields as strings:
 
 ### Configuration Schema Ownership Models
 
-The configurations schema field is an **interface**. It defines a boundary between a service and its environment. The schema itself is always a JSON Schema document — but its *meaning* depends on who defines it.
+The configurations schema field is an **interface**. It defines a boundary between a service and its environment. The schema itself is always a JSON Schema document — but its *meaning* depends on who defines it. Because it is a plain JSON Schema, this is usually a schema you already have rather than one written for Pacto — a service's configuration interface is often its Helm chart's `values.schema.json`, vendored into the bundle (see below). Compose the interface you already have; Pacto is deliberately not another configuration language.
 
 #### Service-Defined Schema
 
@@ -416,11 +410,7 @@ configurations:
     schema: configuration/schema.json
 ```
 
-Characteristics:
-
-- **High portability** — the contract carries its own requirements, deployable on any platform
-- **Service autonomy** — each team defines exactly what their service needs
-- **Common in** open-source projects, small teams, and services that run across multiple environments
+The contract carries its own requirements, so each team defines exactly what its service needs and the bundle deploys on any platform. See [Composition patterns](patterns.md) for when to choose this model.
 
 #### Platform-Defined Schema
 
@@ -444,12 +434,7 @@ configurations:
     ref: oci://ghcr.io/acme/platform-config-pacto:1.0.0
 ```
 
-Characteristics:
-
-- **Standardization** — all services on the platform share a common configuration vocabulary
-- **Strong governance** — the platform team controls what configuration is available and validates it centrally
-- **Platform-as-a-product model** — the schema becomes part of the platform's public interface
-- **Centralized or vendored** — choose between referencing the schema via OCI or vendoring it locally
+All services share a common configuration vocabulary the platform team controls and validates centrally — whether referenced via OCI or vendored locally. See [Platform engineers](platform-engineers.md) and [Composition patterns](patterns.md) for the platform-as-a-product recipe.
 
 !!! info
     In Pacto, the configuration schema is an **interface**. Depending on ownership, it describes either:
@@ -636,7 +621,7 @@ A plain string describing the workload type. Enum: `service`, `job`, `scheduled`
 
 #### `runtime.state`
 
-This is one of Pacto's most distinctive features. Instead of platforms guessing whether a service needs persistent storage, stable network identity, or special upgrade procedures, the contract declares it explicitly.
+Instead of platforms guessing whether a service needs persistent storage, stable network identity or special upgrade procedures, the contract declares it explicitly.
 
 | Field | Type | Required | Enum values |
 |-------|------|----------|-------------|
@@ -654,17 +639,7 @@ This is one of Pacto's most distinctive features. Instead of platforms guessing 
 
 **How platforms interpret state:**
 
-The combination of `state.type`, `persistence.scope`, and `persistence.durability` tells a platform exactly what infrastructure a service needs:
-
-| State | Persistence | Platform reasoning |
-|-------|-------------|--------------------|
-| `stateless` | `local/ephemeral` | No persistent storage needed. Horizontally scalable. Use a Deployment with HPA. |
-| `stateful` | `local/persistent` | Needs stable identity and local durable storage. Use a StatefulSet with PVCs. |
-| `stateful` | `shared/persistent` | Needs durable storage shared across instances. Provision network-attached or shared storage. |
-| `hybrid` | `local/ephemeral` | Tolerates instance loss. Can use a Deployment, but consider warm-up time if caches are large. |
-| `hybrid` | `local/persistent` | Wants persistent local state but survives without it. StatefulSet with PVC, but can fall back to emptyDir if needed. |
-
-These aren't Kubernetes prescriptions — they're platform-agnostic signals. Whether you deploy to Kubernetes, Nomad, ECS, or a custom platform, the reasoning is the same.
+The combination of `state.type`, `persistence.scope` and `persistence.durability` tells a platform exactly what infrastructure a service needs — these are platform-agnostic signals, not Kubernetes prescriptions. See [Platform engineers](platform-engineers.md) for the full contract-field → platform-decision mapping (Deployment/StatefulSet/PVC and the equivalents on Nomad, ECS or a custom platform).
 
 **Data criticality:**
 
@@ -758,11 +733,11 @@ scaling:
   max: 10
 ```
 
-**How the two forms relate.** `replicas` is shorthand: at parse time it is
-normalized to `min = max = replicas`, so downstream tooling (diff, operator,
-dashboard) always works with a `min`/`max` range. This is why the diff table has
-no distinct `scaling.replicas` behavior — a `replicas` change manifests as `min`
-and `max` changes.
+**How the two forms relate.** `replicas` is shorthand: at parse time `min` and
+`max` are also set to `replicas` so state-based tooling (operator, dashboard)
+reads a `min`/`max` range. `pacto diff` still distinguishes the forms: two
+replicas-form contracts report a `scaling.replicas` change; switching between
+forms reports a whole-`scaling` change.
 
 !!! warning
     Scaling must not be applied to `job` workloads.
@@ -839,10 +814,10 @@ is present. `readiness.minScore`, `readiness.partialCredit` and `readiness.histo
 | `expires` | string | Yes | Assessment-level expiry as a strict `YYYY-MM-DD` date. If the current date is past this date, ALL checks earn 0 weight regardless of status. Parsing is exact round-trip: zero-padded fields required and the value must re-serialize unchanged, so `2026-1-1`, RFC 3339 timestamps and impossible dates (e.g. `2026-02-30`) are rejected. |
 | `minScore` | integer | No | Gate threshold on the same 0–100 scale as the score. Omitted ⇒ `100` (full compliance required). Enforced by `pacto validate --readiness` and the operator. |
 | `partialCredit` | number | No | Multiplier for `partial` status checks (0.0–1.0). Omitted ⇒ `0.5` (half credit). |
-| `checks` | [Check](#readiness-check-fields)[] | Yes | At least one check. |
-| `history` | [HistoryEntry](#readiness-history-entry)[] | No | Audit trail of readiness assessment changes. |
+| `checks` | [Check](#check-fields)[] | Yes | At least one check. |
+| `history` | [HistoryEntry](#history-entry)[] | No | Audit trail of readiness assessment changes. |
 
-**Check fields:**
+#### Check fields
 
 | Field | Type | Required | Constraints |
 |-------|------|----------|-------------|
@@ -850,11 +825,11 @@ is present. `readiness.minScore`, `readiness.partialCredit` and `readiness.histo
 | `type` | string | Yes | Enum: `url`, `document`, `ticket`, `report`, `artifact`, `identifier`, `other`. Evidence type. |
 | `status` | string | Yes | Enum: `done`, `partial`, `not-done`, `deferred`. Completion state for the check. |
 | `category` | string | No | Enum: `architecture`, `testing`, `code-quality`, `observability`, `security`, `documentation`, `infrastructure`, `ci-cd`, `deployment`, `resilience`, `backup-recovery`, `incident-response`, `compliance`, `other`. Categorizes the requirement type. |
-| `weight` | integer | Yes | Contribution to the readiness score. Range `1`–`100`. |
+| `weight` | integer | Yes | Contribution to the readiness score. Range `0`–`100`. |
 | `evidence` | string | Yes | Evidence location (URL, file path, ticket ID, etc.). Non-empty. |
 | `description` | string | No | Optional human-readable explanation (non-blank when present). |
 
-**History entry:**
+#### History entry
 
 | Field | Type | Required | Constraints |
 |-------|------|----------|-------------|
@@ -1003,6 +978,9 @@ Validates semantic references and consistency:
 |---|---|
 | `service.version` is valid semver | `INVALID_SEMVER` |
 | Interface names are unique | `DUPLICATE_INTERFACE_NAME` |
+| Configuration names are unique | `DUPLICATE_CONFIGURATION_NAME` |
+| Policy names are unique | `DUPLICATE_POLICY_NAME` |
+| Dependency names are unique | `DUPLICATE_DEPENDENCY_NAME` |
 | `http`/`grpc` interfaces have `port` | `PORT_REQUIRED` |
 | `event` interfaces with `port` set | `PORT_IGNORED` (warning) |
 | `grpc`/`event` interfaces have `contract` | `CONTRACT_REQUIRED` |
@@ -1029,11 +1007,14 @@ Validates semantic references and consistency:
 | `readiness.checks[].description` (when present) is not blank | `EMPTY_READINESS_DESCRIPTION` |
 | `readiness.expires` is a strict `YYYY-MM-DD` date | `INVALID_READINESS_EXPIRES` |
 | `readiness.history[].{date,version,author,description}` are valid/non-blank | `INVALID_READINESS_REVISION` |
+| `configurations[].schema` file is not valid JSON | `INVALID_CONFIG_JSON` |
 | `configurations[].schema` file is not valid JSON Schema | `INVALID_CONFIG_SCHEMA` |
 | `configurations[].values` don't match the schema | `CONFIG_VALUES_VALIDATION_FAILED` |
-| `policies` entry has neither `schema` nor `ref` | `POLICY_EMPTY` |
 | `policies[].schema` file does not exist in the bundle | `FILE_NOT_FOUND` |
+| `policies[].schema` file is not valid JSON | `INVALID_POLICY_JSON` |
+| `policies[].schema` file is not valid JSON Schema | `INVALID_POLICY_SCHEMA` |
 | `policies[].ref` is not a valid OCI reference | `INVALID_POLICY_REF` |
+| `interfaces[].contract` (YAML) file is not valid YAML | `INVALID_CONTRACT_FILE` |
 | `scaling.min` <= `scaling.max` | `SCALING_MIN_EXCEEDS_MAX` |
 | Job workloads cannot have scaling | `JOB_SCALING_NOT_ALLOWED` |
 | Stateless + persistent is invalid | `STATELESS_PERSISTENT_CONFLICT` |
@@ -1060,10 +1041,11 @@ Resolves and enforces all declared policies against the contract. Policies are a
 `POLICY_REF_UNRESOLVED` is a **hard error** — validation fails closed when a referenced policy cannot be resolved. This ensures that missing or unreachable policies are never silently skipped.
 
 **When ref-based policies are resolved.** Recursive resolution of
-`policies[].ref` happens only when a resolver is configured. `pacto validate`
-supplies one (it can reach OCI/file refs), so a `ref` policy that cannot be
-fetched fails closed with `POLICY_REF_UNRESOLVED`. Local-only paths that pass no
-resolver — `pacto pack`/`pacto push`, and the **operator** — enforce only the
+`policies[].ref` happens only when a resolver is configured. `pacto validate` and
+`pacto push` both supply one (they can reach OCI/file refs), so a `ref` policy
+that cannot be fetched fails closed with `POLICY_REF_UNRESOLVED` — this is how
+`pacto push` enforces remote policies before publishing. Local-only paths that
+pass no resolver — `pacto pack` and the **operator** — enforce only the
 locally-compiled `schema`-based policies and skip `ref` policies by design (they
 never reach the unresolved error). Cycle detection is per chain: a `ref` is a
 cycle only when it reappears in its own resolution chain (`A → B → A`); two
@@ -1073,7 +1055,7 @@ sibling policies pointing at the same `ref` resolve independently.
 
 ## Contract overrides
 
-Pacto supports a Helm-style override system that lets you modify contract values without editing `pacto.yaml` directly. Overrides are available on all commands that take a contract reference (`validate`, `explain`, `diff`, `doc`, `generate`, `graph`, `pack`, `push`).
+Pacto supports a Helm-style override system that lets you modify contract values without editing `pacto.yaml` directly. Overrides are available on all commands that take a contract reference (`validate`, `explain`, `diff`, `doc`, `generate`, `graph`, `pack`, `push`, `lock`).
 
 ### Override flags
 
@@ -1150,18 +1132,6 @@ pacto diff old-service new-service \
   --new-set service.version=3.0.0
 ```
 
-### Type inference
-
-`--set` values are automatically parsed into their most specific type:
-
-| Input | Parsed as |
-|-------|-----------|
-| `42` | integer |
-| `3.14` | float |
-| `true` / `false` | boolean |
-| `hello` | string |
-| `1.0.0` | string (not a float — contains multiple dots) |
-
 ### Schema validation
 
 All overrides are validated against the Pacto JSON Schema after they are applied. This means invalid enum values, unknown fields, and type mismatches are rejected by every command — not just `validate` and `push`.
@@ -1202,55 +1172,14 @@ scaling:
   replicas: 1
 ```
 
-```yaml
-# values/staging.yaml
-configurations:
-  - name: default
-    values:
-      DB_HOST: staging-db.internal
-      DB_PORT: 5432
-      DB_PASSWORD: secret://vault/payments-staging/db-password
-      LOG_LEVEL: info
-scaling:
-  min: 2
-  max: 4
-```
-
-```yaml
-# values/production.yaml
-configurations:
-  - name: default
-    values:
-      DB_HOST: prod-db.internal
-      DB_PORT: 5432
-      DB_PASSWORD: secret://vault/payments-prod/db-password
-      LOG_LEVEL: warn
-scaling:
-  min: 3
-  max: 10
-```
-
-Validate each environment independently:
+`staging.yaml` and `production.yaml` follow the same shape, differing only in host, secret reference and scaling bounds. Apply one per command with `-f`:
 
 ```bash
 pacto validate my-service -f values/dev.yaml
-pacto validate my-service -f values/staging.yaml
-pacto validate my-service -f values/production.yaml
-```
-
-Compare what changes between environments:
-
-```bash
-pacto diff my-service my-service \
-  --old-values values/staging.yaml \
-  --new-values values/production.yaml
-```
-
-Push a release with production configuration:
-
-```bash
 pacto push my-service --values values/production.yaml --set service.version=2.1.0
 ```
+
+See [Developers — values files](developers.md) for the full per-environment workflow.
 
 ### Configuration values validation
 
@@ -1279,6 +1208,8 @@ Each change is classified as:
 - **`BREAKING`** — a change that will break consumers or platforms relying on the previous contract
 - **`POTENTIAL_BREAKING`** — a change that *may* break consumers depending on how they use the field
 - **`NON_BREAKING`** — a safe change that doesn't affect compatibility
+
+Any change not matched by a specific rule below defaults to **POTENTIAL_BREAKING**.
 
 ### Service identity
 
@@ -1499,5 +1430,3 @@ SBOM changes are reported separately from contract changes. They are **informati
 | Package version modified | A package's version changed |
 | Package license modified | A package's license changed |
 | Package supplier modified | A package's supplier changed |
-
-Unknown changes default to **POTENTIAL_BREAKING**.

--- a/docs/dashboard-docker.md
+++ b/docs/dashboard-docker.md
@@ -1,7 +1,7 @@
 # Dashboard Container
 ---
 
-The Pacto dashboard is published as a container image for production and Kubernetes deployments. It provides the same contract exploration experience as the CLI's `pacto dashboard` command — dependency graphs, version history, interfaces, configuration schemas, and diffs — in a deployable container.
+The Pacto dashboard is published as a container image for production and Kubernetes deployments. It runs the same `pacto dashboard` server in a deployable container.
 
 ## Image
 
@@ -47,6 +47,7 @@ make docker-run
 | `PACTO_DASHBOARD_NAMESPACE` | Kubernetes namespace filter (empty = all) | `""` |
 | `PACTO_DASHBOARD_REPO` | Comma-separated OCI repositories to scan | `""` |
 | `PACTO_DASHBOARD_DIAGNOSTICS` | Enable source diagnostics panel (`true`) | `false` |
+| `PACTO_DASHBOARD_CORS_ORIGIN` | Trusted cross-origin allowed to call the API | `""` (same-origin only) |
 | `PACTO_CACHE_DIR` | OCI bundle cache directory | `/home/pacto/.cache/pacto/oci` |
 | `PACTO_NO_CACHE` | Disable OCI bundle caching (`1`) | `0` |
 | `PACTO_NO_UPDATE_CHECK` | Disable update checks (`1`) | `1` (set in image) |
@@ -60,10 +61,10 @@ All `PACTO_DASHBOARD_*` variables map to the corresponding `--host`, `--port`, `
 
 ## Data Sources
 
-The dashboard auto-detects available data sources at startup:
+The dashboard auto-detects available data sources at startup. See the [source model](architecture.md#source-model) and [resolution model](architecture.md#resolution-model) in architecture.md for how sources merge and prioritize; the container-specific bindings are:
 
-- **oci**: Enabled when `PACTO_DASHBOARD_REPO` is set, or **automatically discovered from K8s `resolvedRef` fields** when the Kubernetes source is active. Scans OCI registries for published contracts — providing full contract bundles, version history, interfaces, and diffs. Materialized bundles on disk (`/home/pacto/.cache/pacto/oci/`) are used internally by the OCI source to enrich version data without appearing as a separate source.
-- **cache**: The on-disk OCI cache (`~/.cache/pacto/oci/`) is **internal to the OCI source** and normally stays hidden. It surfaces as a distinct `cache` source **only** when no live registry is reachable **and** the cache already has entries — an offline baseline of previously pulled bundles. When both a live registry and the cache hold data, **OCI takes priority** and the cache remains internal.
+- **oci**: Enabled when `PACTO_DASHBOARD_REPO` is set, or auto-discovered from K8s `resolvedRef` fields. Provides contract bundles, version history, interfaces and diffs. (On-disk cache at `/home/pacto/.cache/pacto/oci/` is used internally — see [architecture](architecture.md#source-model).)
+- **cache**: The on-disk OCI cache is internal to the OCI source; it surfaces as a distinct `cache` source only as an offline baseline when no registry is configured and the cache has entries.
 - **k8s**: Enabled when a valid kubeconfig is mounted or when running inside a Kubernetes cluster (in-cluster config). Provides runtime state from the [Pacto operator](operator.md).
 - **local**: Enabled when a `pacto.yaml` is found in the working directory (mount via volume).
 
@@ -74,7 +75,7 @@ When deployed alongside the Pacto operator in Kubernetes, the dashboard automati
 **Prerequisites.** Hybrid mode only activates when all of the following hold:
 
 - A mounted kubeconfig **or** in-cluster config so the Kubernetes source is active.
-- The Pacto operator is running and has populated `status.resolvedRef` on the Pacto resources to discover.
+- The Pacto operator is running and has populated `status.contract.resolvedRef` on the Pacto resources to discover.
 - The discovered registries are reachable and (for private repositories) authenticated via `PACTO_REGISTRY_*` credentials.
 
 If any prerequisite is missing — no `resolvedRef`, an unreachable registry, or missing credentials — the dashboard **silently degrades to k8s-only**: it still shows runtime state from the operator, but without the OCI-backed version history, interfaces, schemas, and diffs.
@@ -212,6 +213,4 @@ spec:
 
 ## Build and Release
 
-The dashboard image is built and published automatically when a new Pacto version is released. The `docker` job in the auto-release pipeline (`.github/workflows/auto-release.yml`) builds multi-architecture images (`linux/amd64`, `linux/arm64`) and pushes to `ghcr.io/trianalab/pacto-dashboard` with the matching version tag (without `v` prefix).
-
-The image version always matches the Pacto CLI version. There is no separate versioning scheme for the dashboard container.
+The dashboard image is built and published automatically when a new Pacto version is released. The `docker-build` and `docker-merge` jobs in the auto-release pipeline (`.github/workflows/auto-release.yml`) build per-architecture images (`linux/amd64`, `linux/arm64`) and merge them into a single multi-arch manifest pushed to `ghcr.io/trianalab/pacto-dashboard` with the matching version tag (without `v` prefix).

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -1,7 +1,9 @@
 # Pacto for Developers
-You own the service — and you own the contract. Pacto gives you a structured way to declare your service's operational interface alongside your code, so platform engineers, CI systems, and other teams have an accurate, machine-readable description of what your service needs to run.
+You own the service — and you own the contract. Pacto gives you a structured way to declare your service's operational interface alongside your code, so platform engineers, CI systems and other teams have an accurate, machine-readable description of what your service needs to run.
 
-No forms. No tickets. No wiki pages that go stale. One YAML file, validated by tooling, versioned in a registry.
+Under the hood, Pacto composes the interfaces you already have — your OpenAPI spec, your config's JSON Schema — instead of inventing new formats for them. What it adds is the operational contract no single schema owns: ownership, dependencies, compatibility and readiness.
+
+One validated, versioned YAML file instead of stale wiki pages and tickets.
 
 ---
 ## Your workflow
@@ -26,7 +28,7 @@ This scaffolds a contract with sensible defaults. Edit `pacto.yaml` to match you
 
 ### 2. Infer schemas from your code (optional)
 
-If your service has a configuration file, use the `schema-infer` plugin to generate a JSON Schema from it. Use `-o` to write the output directly into your bundle:
+A configuration interface in Pacto is a JSON Schema, and Pacto composes the schema you already have rather than making you redefine it. If your config already ships a JSON Schema — for example your Helm chart's `values.schema.json` — vendor that file into your bundle and point `configurations[].schema` at it. If it doesn't, the `schema-infer` plugin generates one from a config file. Use `-o` to write the output into your bundle:
 
 ```bash
 pacto generate schema-infer my-service --option file=config.yaml -o my-service
@@ -94,7 +96,7 @@ interfaces:
     contract: interfaces/events.yaml
 ```
 
-Include the actual interface files (OpenAPI specs, protobuf definitions, event schemas) in the bundle.
+Include the actual interface files (OpenAPI specs, protobuf definitions, event schemas) in the bundle. Pacto references these definitions as-is — it composes the interface contracts you already publish rather than asking you to describe them a second time.
 
 ### 4. Define your runtime semantics (optional)
 
@@ -116,13 +118,7 @@ runtime:
     path: /health
 ```
 
-**Ask yourself:**
-- Is my service long-running (`service`) or does it run to completion (`job`)?
-- Does it hold local state that survives restarts (`stateful`) or not (`stateless`)?
-- Does it keep optional in-memory state like caches (`hybrid`)?
-- How critical is the data it handles?
-
-The answers determine how platforms provision infrastructure for your service. See [runtime.state](contract-reference.md#runtimestate) in the Contract Reference for the full explanation.
+Choose your `workload` (`service` vs `job`/`scheduled`), `state.type` (`stateless`/`stateful`/`hybrid`) and `dataCriticality`; these determine how platforms provision infrastructure for your service. See [runtime.state](contract-reference.md#runtimestate) in the Contract Reference for the full explanation.
 
 ### 5. Declare dependencies
 
@@ -231,13 +227,13 @@ pacto push oci://ghcr.io/your-org/my-service-pacto -p my-service --force
 
 ## Using contract overrides
 
-Pacto supports Helm-style overrides to modify contract values without editing `pacto.yaml`. This is useful for environment-specific values, CI pipelines, or quick experimentation.
+Pacto supports Helm-style overrides to modify contract values without editing `pacto.yaml`. This is useful for environment-specific values, CI pipelines or quick experimentation.
 
 ```bash
 # Override a value inline
 pacto validate my-service --set service.version=2.0.0
 
-# Use a values file
+# Use a values file (-f is short for --values on most commands)
 pacto validate my-service -f staging-values.yaml
 
 # Combine both (--set takes precedence)
@@ -247,126 +243,30 @@ pacto validate my-service -f staging-values.yaml --set service.version=3.0.0
 pacto validate my-service --set configurations[0].values.DB_HOST=localhost
 ```
 
-Overrides work on all commands that take a contract reference. For `diff`, use `--old-set`/`--old-values` and `--new-set`/`--new-values` to override each contract independently.
+Overrides work on every command that takes a contract reference, with two exceptions: `diff` overrides each side with `--old-values`/`--old-set` and `--new-values`/`--new-set` (it has no `-f` or plain `--values`), and `pacto push` reserves `-f` for `--force`, so spell out `--values` there.
 
-### Override flag shorthands
-
-On most contract-taking commands, `-f` is the shorthand for `--values`. The exception is `pacto push`, where `-f` is `--force` — so on `push` you must spell out `--values`:
-
-```bash
-# Apply a values file when publishing (use --values, not -f, on push)
-pacto push oci://ghcr.io/your-org/my-service-pacto -p my-service \
-  --values prod-values.yaml --set service.version=2.0.0
-
-# -f on push means --force (overwrite an existing artifact), not --values
-pacto push oci://ghcr.io/your-org/my-service-pacto -p my-service -f
-```
-
-| Command | `--values` | `-f` shorthand |
-|---------|-----------|----------------|
-| `validate` | yes | `--values` |
-| `explain` | yes | `--values` |
-| `diff` | per-side (`--old-values`/`--new-values`) | `--values` |
-| `doc` | yes | `--values` |
-| `generate` | yes | `--values` |
-| `graph` | yes | `--values` |
-| `pack` | yes | `--values` |
-| `push` | yes (`--values` only) | **`--force`** |
-
-On `push`, `-f` maps to `--force`, so always use the long `--values` form there to apply overrides.
-
-See the [Contract Reference — Contract overrides](contract-reference.md#contract-overrides) section for full details.
+For the per-command flag list see the [CLI reference](cli-reference.md); for override precedence and syntax see the [Contract Reference — Contract overrides](contract-reference.md#contract-overrides).
 
 ---
 
-## Common patterns
+## Common runtime patterns
 
-### Stateless HTTP API
+The `runtime` block tells the platform what your service *is*, not how to deploy it. Each common shape has a ready-made worked example you can copy:
 
-```yaml
-runtime:
-  workload: service
-  state:
-    type: stateless
-    persistence:
-      scope: local
-      durability: ephemeral
-    dataCriticality: low
-  health:
-    interface: api
-    path: /health
-scaling:
-  min: 2
-  max: 10
-```
+| Pattern | `state.type` | Worked example |
+|---------|-------------|----------------|
+| Stateless HTTP API | `stateless` | [nginx](examples/nginx.md) |
+| Stateful service (database, cache) | `stateful` | [postgresql](examples/postgresql.md) |
+| API with local cache | `hybrid` | [hybrid-cache](examples/hybrid-cache.md) |
+| Scheduled job | `stateless` (workload `scheduled`) | [cron-worker](examples/cron-worker.md) |
 
-### Stateful service (database proxy, cache)
+A `hybrid` service handles requests statelessly but keeps a local cache, so the platform can scale it horizontally while allowing for cache warm-up. See [runtime.state](contract-reference.md#runtimestate) for the full field spec.
 
-```yaml
-runtime:
-  workload: service
-  state:
-    type: stateful
-    persistence:
-      scope: local
-      durability: persistent
-    dataCriticality: high
-  lifecycle:
-    upgradeStrategy: ordered
-    gracefulShutdownSeconds: 60
-  health:
-    interface: api
-    path: /health
-scaling:
-  min: 3
-  max: 5
-```
-
-### API with local cache (hybrid)
-
-```yaml
-runtime:
-  workload: service
-  state:
-    type: hybrid
-    persistence:
-      scope: local
-      durability: ephemeral
-    dataCriticality: low
-  health:
-    interface: api
-    path: /health
-scaling:
-  min: 2
-  max: 8
-```
-
-A `hybrid` service handles requests statelessly but keeps a local cache or session store. The platform knows it can scale horizontally, but might account for cache warm-up time.
-
-### Fixed-replica service
-
-Use `replicas` instead of `min`/`max` when the service should always run an exact number of instances:
+Use `scaling.replicas` instead of `min`/`max` when the service should always run an exact number of instances:
 
 ```yaml
 scaling:
   replicas: 1
-```
-
-### Scheduled job
-
-```yaml
-runtime:
-  workload: scheduled
-  state:
-    type: stateless
-    persistence:
-      scope: local
-      durability: ephemeral
-    dataCriticality: low
-  health:
-    interface: api
-    path: /health
-# No scaling — jobs don't scale horizontally
 ```
 
 ---
@@ -383,46 +283,22 @@ Changes (2):
   [NON_BREAKING] service.version (modified): service.version modified [1.0.0 -> 1.1.0]
 ```
 
-Integrate `pacto diff` into your CI pipeline to block merges that introduce breaking changes.
-
-!!! tip
-    Using GitHub Actions? Check out the official [Pacto CLI action](github-actions.md).
+Wire `pacto diff` into CI to block merges that introduce breaking changes — see the official [Pacto CLI action](github-actions.md).
 
 ---
 
 ## AI-assisted workflow
 
-If you use an AI assistant that supports [MCP](https://modelcontextprotocol.io) (Claude Code, Cursor, GitHub Copilot), you can connect it to Pacto so it can validate, inspect, and generate contracts on your behalf.
+If you use an AI assistant that supports [MCP](https://modelcontextprotocol.io) (Claude Code, Cursor and GitHub Copilot), connect it to Pacto so it can scaffold, edit and validate contracts inside your conversation. The server exposes exactly four tools:
 
-### Setup
+- **`pacto_create`** — scaffold a new contract from a description
+- **`pacto_edit`** — modify an existing contract
+- **`pacto_check`** — validate a local contract and return a summary plus improvement suggestions
+- **`pacto_schema`** — return the full contract JSON Schema reference
 
-Add Pacto as an MCP server in your project. For Claude Code, create `.mcp.json` in your project root:
+Inspecting a registry contract, resolving dependency graphs and generating Markdown docs are CLI-only (`pacto explain oci://...`, `pacto graph`, `pacto doc`) — they are not MCP tools.
 
-```json
-{
-  "mcpServers": {
-    "pacto": {
-      "command": "pacto",
-      "args": ["mcp"]
-    }
-  }
-}
-```
-
-For other tools, see the full [MCP Integration](mcp-integration.md) guide.
-
-### What you can do
-
-Once connected, the AI assistant can use Pacto tools directly in your conversation:
-
-- **Validate** — *"Validate my contract in ./my-service"* — catches structural, cross-field, and semantic errors without leaving your editor
-- **Inspect** — *"Show me the full contract for oci://ghcr.io/acme/auth-pacto:2.0.0"* — explore contracts from your registry
-- **Explain** — *"Explain what this service does"* — get a human-readable summary of interfaces, dependencies, and runtime behavior
-- **Generate** — *"Generate a contract for a stateless Go HTTP API called user-service"* — scaffold new contracts from a description
-- **Dependencies** — *"What does my service depend on?"* — resolve and explore the dependency graph
-- **Documentation** — *"Generate docs for this contract"* — produce Markdown documentation without running CLI commands
-
-This is particularly useful when writing a new contract from scratch — describe your service to the assistant and let it generate the initial `pacto.yaml`, then iterate with validation feedback in the same conversation.
+See the [MCP Integration](mcp-integration.md) guide for the `.mcp.json` setup across all clients.
 
 ---
 
@@ -442,7 +318,7 @@ my-service/
     integration.md
 ```
 
-Documentation travels with the contract as part of the OCI artifact, so it is versioned and distributed alongside the contract it describes. It has no effect on validation, diffing, or compatibility checks — changes to `docs/` never produce diff entries or affect classification.
+Documentation ships inside the OCI artifact, versioned and distributed with the contract; it never affects validation or diffing. See the [Contract Reference — `docs/`](contract-reference.md#docs-optional-documentation) for the full behavior.
 
 Good candidates for `docs/`:
 
@@ -466,7 +342,7 @@ my-service/
     sbom.spdx.json
 ```
 
-Pacto supports [SPDX 2.3](https://spdx.dev/) (`.spdx.json`) and [CycloneDX 1.5](https://cyclonedx.org/) (`.cdx.json`) formats. The recommended tool for generating SBOMs is [Syft](https://github.com/anchore/syft):
+Generate one with [Syft](https://github.com/anchore/syft) (or [Trivy](https://github.com/aquasecurity/trivy)/[cdxgen](https://github.com/CycloneDX/cdxgen)):
 
 ```bash
 # Generate an SPDX SBOM
@@ -476,11 +352,7 @@ syft . -o spdx-json=sbom/sbom.spdx.json
 syft . -o cyclonedx-json=sbom/bom.cdx.json
 ```
 
-Other supported generators include [Trivy](https://github.com/aquasecurity/trivy) and [cdxgen](https://github.com/CycloneDX/cdxgen).
-
-The SBOM travels with the contract as part of the OCI artifact. When both the old and new versions of a contract include an SBOM, `pacto diff` reports package-level changes (added, removed, version or license modified). These changes are informational — they never affect the overall breaking/non-breaking classification.
-
-No contract-level field references the SBOM. Pacto discovers it automatically by scanning the `sbom/` directory for recognized file extensions — the same convention-based approach used for `docs/`.
+Pacto discovers the SBOM by scanning `sbom/` for recognized extensions — no contract field references it. For the supported formats (SPDX 2.3, CycloneDX 1.5) and how `pacto diff` reports package-level changes, see the [Contract Reference — `sbom/`](contract-reference.md#sbom-optional-software-bill-of-materials).
 
 ---
 
@@ -489,8 +361,6 @@ No contract-level field references the SBOM. Pacto discovers it automatically by
 - **Version your contract alongside your code.** The `pacto.yaml` lives in your repository.
 - **Pin dependency digests in production.** Tags are mutable; digests are not.
 - **Keep interface contracts up to date.** OpenAPI specs and protobuf definitions in the bundle should match what your service actually serves.
-- **Include documentation in the bundle.** Add a `docs/` directory with runbooks, architecture notes, and integration guides. It ships with the contract but doesn't affect diffing or validation.
-- **Include an SBOM.** Add an SBOM to `sbom/` using Syft, Trivy, or cdxgen. `pacto diff` will report package-level changes between versions.
 - **Use `pacto explain` to review.** It produces a human-readable summary of your contract.
 - **Use `pacto doc` for rich documentation.** It generates Markdown with architecture diagrams and interface tables. Use `--serve` to view it in the browser.
 - **Leverage caching.** OCI bundles are cached locally in `~/.cache/pacto/oci/` and tag listings are cached in memory per command, so repeated `graph`, `doc`, and `diff` commands resolve instantly. Use `--no-cache` to force a fresh pull.

--- a/docs/examples/cron-worker.md
+++ b/docs/examples/cron-worker.md
@@ -43,9 +43,9 @@ metadata:
 ### Key decisions
 
 - **`workload: scheduled`** — runs on a cron schedule, not continuously
-- **No `scaling` section** — job workloads don't scale horizontally (enforced by validation)
+- **No `scaling` section** — batch workloads don't scale horizontally. `pacto validate` rejects a `scaling` block on `job` workloads (`JOB_SCALING_NOT_ALLOWED`); on a `scheduled` workload it is allowed but omitted here by convention
 - **No `lifecycle` section** — upgrade strategy doesn't apply to jobs
-- **Schedule in `metadata`** — the cron expression is platform-specific, so it belongs in metadata rather than in the contract's core fields
+- **Schedule in `metadata`** — the cron expression is platform-specific, so it lives in `metadata`, not the contract's core fields
 
 ### Variant: One-shot job
 

--- a/docs/examples/dashboard-demo.md
+++ b/docs/examples/dashboard-demo.md
@@ -1,22 +1,21 @@
 # Live dashboard demo
 
-The Pacto dashboard runs entirely in your browser as a static WebAssembly build —
-the Pacto engine and a curated set of demo contracts are compiled to WASM and
-served with no backend.
+The Pacto dashboard runs entirely in your browser: the engine and a curated set
+of demo contracts are compiled to WebAssembly, with no backend or live registry.
 
 <a href="../../demo/" class="md-button md-button--primary">Open the live dashboard demo →</a>
 
 It showcases the full UI against a realistic fleet:
 
-- **Fleet & compliance** — a dozen services across edge, domain, infra and
+- **Fleet & compliance** — eleven services across edge, domain, infra and
   external tiers.
 - **Dependency graph** — resolved from each contract's declared dependencies,
   with blast-radius highlighting.
 - **Version history & diff** — `payments-service` spans five versions; the
   `v1.2.0 → v2.0.0` step is a breaking change that removes the `/charges` API.
-- **Readiness** — `payments-service` 2.1.0 declares a readiness gate that fails
-  (an expired evaluation drops its score to 70, below the required 80), while
-  `orders-service` 1.2.0 passes.
+- **Readiness** — `payments-service` 2.1.0 declares a readiness gate that fails:
+  a required check (the LLM-safety eval suite) is `not-done`, dropping its score
+  to 70, below the required 80 — while `orders-service` 1.2.0 passes.
 
 The source and build harness live in
 [`examples/demo`](https://github.com/TrianaLab/pacto/tree/main/examples/demo).

--- a/docs/examples/event-processor.md
+++ b/docs/examples/event-processor.md
@@ -37,7 +37,7 @@ configurations:
 
 dependencies:
   - name: rabbitmq
-    ref: oci://ghcr.io/acme/rabbitmq-pacto@sha256:abc123
+    ref: oci://ghcr.io/acme/rabbitmq-pacto@sha256:0000000000000000000000000000000000000000000000000000000000000000
     required: true
     compatibility: "^3.13.0"
 
@@ -68,7 +68,6 @@ scaling:
   max: 8
 
 metadata:
-  team: orders
   tier: standard
   consumer-group: order-processing
 ```
@@ -76,7 +75,7 @@ metadata:
 ### Key decisions
 
 - **`type: event`** — declares that this service consumes events rather than serving HTTP/gRPC requests
-- **`contract: interfaces/order-events.yaml`** — the event contract (e.g. AsyncAPI or custom schema) is bundled and versioned alongside the service
+- **`contract: interfaces/order-events.yaml`** — the event schema (e.g. AsyncAPI) is bundled and versioned with the service
 - **`dataCriticality: medium`** — event processing failures have moderate impact; dead-letter queues provide a safety net
 - **`gracefulShutdownSeconds: 60`** — allows in-flight messages to complete processing before shutdown
-- **Secret reference** — broker credentials use `secret://` so the platform injects actual credentials at deployment time
+- **Secret reference** — broker credentials use `secret://`, an opaque convention the platform resolves at deployment time (see [Secret references](../contract-reference.md#secret-references))

--- a/docs/examples/grpc-service.md
+++ b/docs/examples/grpc-service.md
@@ -21,11 +21,6 @@ interfaces:
     visibility: internal
     contract: interfaces/user-service.proto
 
-  - name: health
-    type: http
-    port: 8080
-    visibility: internal
-
   - name: metrics
     type: http
     port: 9102
@@ -42,7 +37,7 @@ configurations:
 
 dependencies:
   - name: postgres
-    ref: oci://ghcr.io/acme/postgres-pacto@sha256:def456
+    ref: oci://ghcr.io/acme/postgres-pacto@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
     required: true
     compatibility: "^16.0.0"
 
@@ -72,13 +67,12 @@ scaling:
   max: 12
 
 metadata:
-  team: identity
   tier: critical
 ```
 
 ### Key decisions
 
-- **`type: grpc` with `contract`** — the `.proto` file is bundled in the OCI artifact, making the API contract portable and versionable
-- **Health on gRPC** — when the health interface is `grpc`, Pacto uses the [gRPC Health Checking Protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md); no `path` is needed
-- **Separate health and metrics** — the gRPC port serves application traffic, while HTTP ports expose health checks and Prometheus metrics independently
+- **`type: grpc` with `contract`** — the `.proto` file is bundled in the OCI artifact, so the API contract travels with the service version
+- **Health on gRPC** — a `grpc` health interface needs no `path`; the service is expected to implement the [gRPC Health Checking Protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md)
+- **Separate metrics port** — the gRPC port serves application traffic while a separate HTTP port exposes Prometheus metrics
 - **`stateless`** — the service itself holds no state; data lives in PostgreSQL

--- a/docs/examples/hybrid-cache.md
+++ b/docs/examples/hybrid-cache.md
@@ -38,7 +38,7 @@ configurations:
 
 dependencies:
   - name: inventory
-    ref: oci://ghcr.io/acme/inventory-pacto@sha256:789abc
+    ref: oci://ghcr.io/acme/inventory-pacto@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
     required: true
     compatibility: "^1.0.0"
 
@@ -77,17 +77,11 @@ metadata:
 ### Key decisions
 
 - **`state.type: hybrid`** — the service caches product data locally for fast reads, but can reconstruct the cache from the upstream inventory service on restart
-- **`durability: persistent`** — persisting the cache across restarts avoids cold-start latency, but the service functions correctly without it (it just needs time to warm up)
+- **`durability: persistent`** — persisting the cache across restarts avoids cold-start latency, but the service still works without it (it just warms up first)
 - **`dataCriticality: low`** — the cache is reconstructible; losing it has no business impact beyond temporary performance degradation
 - **`upgradeStrategy: rolling`** — rolling updates prevent all instances from cold-starting simultaneously
 - **Secret reference** — the API key for the upstream service uses `secret://` so credentials never appear in the contract
 
 ### When to use `hybrid`
 
-Use `hybrid` when your service:
-
-- Maintains local state that **improves** behavior (caches, pre-computed indexes, session stores)
-- Can **recover** from state loss by rebuilding from an upstream source
-- Would experience **degraded performance** but not **failure** if local state is lost
-
-If state loss would break the service, use `stateful` instead.
+Choose `hybrid` (not `stateless`) when you persist local state across restarts to avoid warm-up but the service still functions after losing it — a purely in-memory cache rebuilt on every start is `stateless`/`ephemeral`. See the [state.type table](../contract-reference.md#runtimestate) in the contract reference for the full `stateless` vs `stateful` vs `hybrid` breakdown.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,14 +1,10 @@
 # Example Contracts
-This section provides ready-to-use Pacto contracts for common infrastructure services. Use these as references when writing your own contracts or as dependencies in your service contracts.
+This section provides ready-to-use Pacto contracts for common infrastructure services. Use these as references when writing your own contracts, or as dependencies.
 
 For a complete, runnable demo, see the [live dashboard demo](dashboard-demo.md) — its source and curated contract set live in [`examples/demo`](https://github.com/TrianaLab/pacto/tree/main/examples/demo).
 
----
-
 !!! tip
-    These contracts represent the **operational interface** of each service — not a deployment recipe. They describe what the service exposes, how it behaves, and what the platform needs to know.
-
----
+    These contracts represent the **operational interface** of each service — not a deployment recipe. They describe what a service exposes and how it behaves — not how to deploy it. Each one composes schemas you already have — Protocol Buffers for gRPC APIs, JSON Schema for `configurations` — rather than inventing a new format; the contract is the relational layer Pacto adds around them: ownership, dependencies, compatibility, lifecycle.
 
 ## Available examples
 
@@ -23,9 +19,9 @@ For a complete, runnable demo, see the [live dashboard demo](dashboard-demo.md) 
 | [gRPC Service](grpc-service.md) | service | stateless/ephemeral | gRPC microservice with Proto contract |
 | [Hybrid Cache API](hybrid-cache.md) | service | hybrid/persistent | API with local cache and upstream rebuild |
 
----
-
 ## Using examples as dependencies
+
+A JSON Schema or `.proto` describes one interface in isolation; wiring these contracts together as `dependencies` — with compatibility ranges — is Pacto describing the relationships between interfaces and how they change.
 
 You can reference these contracts (once published to a registry) as dependencies in your own `pacto.yaml`:
 
@@ -41,6 +37,8 @@ dependencies:
     required: false
     compatibility: "^7.0.0"
 ```
+
+See the [contract reference](../contract-reference.md#dependencies) for the full dependency schema.
 
 Then use `pacto graph` to visualize the full dependency tree:
 

--- a/docs/examples/nginx.md
+++ b/docs/examples/nginx.md
@@ -67,8 +67,10 @@ metadata:
 
 ### Key decisions
 
-- **`state.type: stateless`** — NGINX holds no local state; any instance can serve any request
+See the [contract reference](../contract-reference.md#runtime) for what each enum value means; the notes below cover why NGINX picks these.
+
+- **`state.type: stateless`** — any instance can serve any request
 - **`durability: ephemeral`** — no persistent storage needed
-- **`upgradeStrategy: rolling`** — zero-downtime updates with gradual rollout
-- **`scaling: min 2, max 20`** — high availability with auto-scaling for traffic spikes
+- **`upgradeStrategy: rolling`** — stateless replicas update without dropping connections
+- **`scaling: min 2, max 20`** — high availability with headroom for traffic spikes
 - **`visibility: public`** — the HTTP and HTTPS interfaces are externally reachable

--- a/docs/examples/postgresql.md
+++ b/docs/examples/postgresql.md
@@ -62,12 +62,12 @@ metadata:
 ```
 
 !!! note
-    The `sql` interface uses `type: grpc` as the closest available protocol type for PostgreSQL's binary wire protocol. The Pacto schema currently supports `http`, `grpc`, and `event` — there is no dedicated `tcp` type. The `.proto` contract file is illustrative; in practice you may omit the interface or use a custom schema.
+    The `sql` interface uses `type: grpc` as the closest available protocol type for PostgreSQL's binary wire protocol — there is no dedicated `tcp` type (see [Interfaces](../contract-reference.md#interfaces) for the full list of types). The `.proto` contract file is illustrative; in practice you may omit the interface or point `contract` at your own protobuf file (the file must exist in the bundle or `pacto validate` fails with `FILE_NOT_FOUND`).
 
 ### Key decisions
 
-- **`state.type: stateful`** with **`durability: persistent`** — PostgreSQL needs persistent storage that survives pod restarts
-- **`dataCriticality: high`** — data loss is unacceptable; the platform should enable backups and strict disruption budgets
-- **`upgradeStrategy: ordered`** — replicas must be updated one at a time (primary before replicas)
-- **`scaling: replicas 1`** — single-instance; replication is handled externally
-- **`gracefulShutdownSeconds: 60`** — allow time for connections to drain and WAL to flush
+- **`state.type: stateful`** with **`durability: persistent`** — persistent storage survives pod restarts
+- **`dataCriticality: high`** — backups and strict disruption budgets expected
+- **`upgradeStrategy: ordered`** — replicas updated one at a time (primary first)
+- **`scaling: replicas 1`** — single instance; replication handled externally
+- **`gracefulShutdownSeconds: 60`** — time for connections to drain and WAL to flush

--- a/docs/examples/rabbitmq.md
+++ b/docs/examples/rabbitmq.md
@@ -69,7 +69,7 @@ metadata:
 ```
 
 !!! note
-    The `amqp` interface uses `type: grpc` as the closest available protocol type for RabbitMQ's AMQP binary protocol. The Pacto schema currently supports `http`, `grpc`, and `event` — there is no dedicated `tcp` type. The `.proto` contract file is illustrative; in practice you may omit the interface or use a custom schema.
+    The `amqp` interface uses `type: grpc` as the closest available protocol type for RabbitMQ's AMQP binary protocol — Pacto has no dedicated `tcp` type (see [interface fields](../contract-reference.md#interfaces) for the supported types). The `.proto` contract file is illustrative; you can omit the interface if you don't publish a protobuf.
 
 ### Key decisions
 

--- a/docs/examples/redis.md
+++ b/docs/examples/redis.md
@@ -61,13 +61,14 @@ metadata:
 ```
 
 !!! note
-    The `resp` interface uses `type: grpc` as the closest available protocol type for Redis's RESP binary protocol. The Pacto schema currently supports `http`, `grpc`, and `event` — there is no dedicated `tcp` type. The `.proto` contract file is illustrative; in practice you may omit the interface or use a custom schema.
+    The `resp` interface uses `type: grpc` as the closest available protocol type for Redis's RESP binary protocol — Pacto has no dedicated `tcp` type (see [interface fields](../contract-reference.md#interfaces) for the supported types). The `.proto` here is illustrative; omit the whole interface if you have no schema to publish.
 
 ### Key decisions
 
 - **`state.type: stateful`** with **`durability: persistent`** — Redis with AOF/RDB persistence enabled needs durable storage
 - **`dataCriticality: medium`** — data is important but can be rebuilt from source if needed
 - **`upgradeStrategy: ordered`** — prevents data loss during upgrades
+
 ### Variant: Ephemeral cache
 
 For a pure cache without persistence:

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -5,7 +5,7 @@ Automate contract validation, breaking-change detection, and publishing in your 
 
 ## Quick start
 
-Add the Pacto CLI action to any workflow step. The action installs the `pacto` binary and makes it available for subsequent steps.
+The action is command-driven: `command: setup` installs the `pacto` binary for later `run:` steps, while `command: validate`, `diff`, `push` or `doc` run those operations natively.
 
 ```yaml
 name: Contract CI
@@ -26,6 +26,8 @@ jobs:
 
       - name: Install Pacto CLI
         uses: TrianaLab/pacto-actions@v1
+        with:
+          command: setup
 
       - name: Validate contract
         run: pacto validate .
@@ -33,28 +35,23 @@ jobs:
 
 ## Common workflows
 
-### Validate on pull request
-
-Catch schema violations and cross-field errors before they reach main:
-
-```yaml
-      - name: Validate contract
-        run: pacto validate .
-```
+The [quick start](#quick-start) already runs `pacto validate .` on every pull request to catch schema and cross-field errors before merge. The workflows below add breaking-change detection and publishing.
 
 ### Detect breaking changes
 
-Compare the PR contract against the published version to block breaking changes:
+Compare the PR contract against the published version and block breaking changes. `pacto diff` takes the old contract first and the new one second, and exits non-zero on a `BREAKING` result (see [change classification rules](contract-reference.md#change-classification-rules)):
 
 ```yaml
       - name: Check for breaking changes
-        run: |
-          pacto diff oci://ghcr.io/acme/my-service-pacto . --output-format json > diff.json
-          if jq -e '.classification == "BREAKING"' diff.json > /dev/null 2>&1; then
-            echo "::error::Breaking contract change detected"
-            exit 1
-          fi
+        uses: TrianaLab/pacto-actions@v1
+        with:
+          command: diff
+          old: oci://ghcr.io/acme/my-service-pacto
+          new: .
+          comment-on-pr: 'true'
 ```
+
+`fail-on-breaking` defaults to `true`, so the step blocks the merge on a breaking change and `comment-on-pr` posts the diff. To gate in a plain `run:` step instead, `pacto diff oci://ghcr.io/acme/my-service-pacto .` exits non-zero on the same result.
 
 ### Publish on release
 
@@ -77,6 +74,8 @@ jobs:
 
       - name: Install Pacto CLI
         uses: TrianaLab/pacto-actions@v1
+        with:
+          command: setup
 
       - name: Log in to GHCR
         run: pacto login ghcr.io --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}"

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,19 +11,21 @@
 
 Pacto (/ˈpak.to/ — Spanish for *pact*) captures everything a platform needs to know about a service — interfaces, runtime behavior, dependencies, configuration, and scaling — in one YAML file that machines can validate and tooling can consume.
 
+Pacto doesn't invent a new configuration language. An interface is a JSON Schema, OpenAPI spec or protobuf definition you already maintain — Pacto composes the interfaces you already have instead of redefining them. On top of that it adds what no single schema can express: how interfaces relate, what they depend on and how they change over time. *JSON Schema describes an interface; Pacto describes the relationships between interfaces and how they change over time.*
+
 Pacto is a **runtime contract system** made of three complementary pieces:
 
 - **CLI** — author, validate, diff, explain, and publish contracts
 - **Dashboard** — explore contracts, dependency graphs, versions, readiness and diffs visually
 - **Kubernetes Operator** — verify that live runtime remains faithful to the contract
 
-No runtime agents. No sidecars. No new infrastructure. The CLI runs at build time and CI time. The dashboard and operator extend the same contracts into exploration and runtime verification — without duplicating logic or adding moving parts.
+No runtime agents. No sidecars. No new infrastructure. The CLI runs at build time and CI time. The dashboard and operator extend the same contracts into exploration and runtime verification.
 
 ---
 
 ## AI-native contracts
 
-Pacto contracts are machine-readable by design. Beyond platforms and CI pipelines, they can be consumed directly by AI assistants through the [Model Context Protocol](https://modelcontextprotocol.io). Running `pacto mcp` starts an MCP server that exposes contract-aware tools — allowing assistants like Claude, Cursor, and GitHub Copilot to validate contracts, inspect dependency graphs, generate new contracts, and explain breaking changes. See the [MCP Integration](mcp-integration.md) guide.
+Pacto contracts are machine-readable by design. Beyond platforms and CI pipelines, they can be consumed directly by AI assistants through the [Model Context Protocol](https://modelcontextprotocol.io). Running `pacto mcp` starts an MCP server that exposes contract-aware tools — allowing assistants like Claude, Cursor, and GitHub Copilot to generate, edit and validate contracts and surface improvement suggestions. See the [MCP Integration](mcp-integration.md) guide.
 
 ---
 
@@ -93,7 +95,7 @@ scaling:
   max: 10
 ```
 
-Every question a platform could ask — *What port? Stateful or stateless? What does it depend on? How should it scale?* — is answered in one file, validated by tooling and versioned in a registry.
+These questions are answered in one file, validated by tooling and versioned in a registry.
 
 Only `pactoVersion` and `service` are required — everything else is opt-in, so a contract can be as minimal or as detailed as your service needs.
 
@@ -140,7 +142,7 @@ Instead of filing tickets, attending meetings, and writing wiki pages, a develop
 5. The Kubernetes operator verifies runtime stays faithful to the contract
 ```
 
-The real value of Pacto appears across the full loop: **author → validate → publish → explore → verify at runtime**. Each piece has a clear responsibility — the CLI manages the contract lifecycle, the dashboard makes contracts observable, and the operator closes the gap between declaration and reality.
+The real value of Pacto appears across the full loop: **author → validate → publish → explore → verify at runtime**.
 
 ---
 
@@ -173,16 +175,7 @@ graph LR
     Bundle -- "pacto push" --> Registry["OCI Registry<br/>GHCR · ECR · ACR<br/>Docker Hub"]
 ```
 
-A bundle is a self-contained directory (or OCI artifact) containing:
-
-- **`pacto.yaml`** — the contract: interfaces, dependencies, runtime semantics, scaling, readiness *(required)*
-- **`interfaces/`** *(optional)* — OpenAPI specs, protobuf definitions, event schemas
-- **`configuration/`** *(optional)* — JSON Schema for environment variables and settings
-- **`policy/`** *(optional)* — JSON Schema that validates the contract itself (organizational standards enforcement)
-- **`docs/`** *(optional)* — service documentation (README, runbooks, architecture notes)
-- **`sbom/`** *(optional)* — Software Bill of Materials in [SPDX](https://spdx.dev/) or [CycloneDX](https://cyclonedx.org/) format. `pacto diff` reports package-level changes when present
-
-Only `pacto.yaml` is required. All other directories are optional — include them when your contract references files in them. Validation enforces that every referenced file exists within the bundle.
+A bundle is a self-contained directory (or OCI artifact): `pacto.yaml` (required) plus optional `interfaces/`, `configuration/`, `policy/`, `docs/` and `sbom/` directories. These are schemas you already maintain — an OpenAPI spec, a JSON Schema for your config — composed into the bundle rather than rewritten in a Pacto-specific format; `pacto.yaml` adds the relational layer around them (dependencies, compatibility, runtime semantics). Validation enforces that every referenced file exists within the bundle. See the [contract reference](contract-reference.md#bundle-structure) for the full bundle layout.
 
 ---
 
@@ -197,7 +190,7 @@ Only `pacto.yaml` is required. All other directories are optional — include th
 - **SBOM diffing** — optional SPDX or CycloneDX SBOM inclusion with automatic package-level change detection on `pacto diff`
 - **Contract exploration dashboard** — `pacto dashboard` launches a web UI for navigating contracts, dependency graphs, version history, interface details, configuration schemas, readiness and diffs across local, OCI, and Kubernetes sources
 - **Runtime fidelity verification** — the optional [Kubernetes Operator](operator.md) continuously checks that deployed services match their contracts — port alignment, workload existence, health endpoint reachability, and more
-- **AI assistant integration** — `pacto mcp` exposes all contract operations as [MCP](https://modelcontextprotocol.io) tools for Claude, Cursor, and GitHub Copilot
+- **AI assistant integration** — `pacto mcp` exposes contract create, edit, validate and schema operations as [MCP](https://modelcontextprotocol.io) tools for Claude, Cursor and GitHub Copilot
 
 ---
 
@@ -255,11 +248,8 @@ These primitives compose into reusable platform patterns — root + component co
 ## What Pacto is not
 
 - **Not a deployment tool** — it describes *what* to deploy, not *how*
-- **Not a generic policy engine** — policies validate contract structure, not arbitrary infrastructure rules
-- **Not just a Kubernetes linter** — the operator is one part of the system, not the whole product
+- **Not another configuration language** — an interface is a JSON Schema, OpenAPI or protobuf definition you already own; Pacto composes those rather than replacing them
 - **Not a registry** — it uses existing OCI registries (GHCR, ECR, ACR, Docker Hub)
-- **Not a service mesh or runtime agent** — no sidecars, no proxies; the operator watches CRDs, not traffic
-- **Not a replacement for Helm or Terraform** — it complements them as input
 - **Not a service catalog** — it produces the structured data that a catalog (Backstage, Port, Cortex) could consume
 
-Pacto is a **runtime contract system**. The CLI manages contracts. The dashboard makes them explorable. The operator verifies them at runtime. Together, they tell platforms, pipelines, and AI agents what a service *is* — and whether it still matches what was declared.
+Pacto is a **runtime contract system** that tells platforms, pipelines and AI agents what a service *is* — and whether it still matches what was declared.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 
 ## Via installer script
 
-The fastest way to install Pacto:
+Install with one command:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/TrianaLab/pacto/main/scripts/get-pacto.sh | bash
@@ -48,19 +48,19 @@ pacto update
 pacto update v1.2.0
 ```
 
-This downloads the new binary, **verifies its SHA-256 against the `checksums.txt` published with the release**, and only then replaces the current one. If the download is corrupted, truncated, or tampered with, the update is aborted and the existing binary is left untouched. No additional tools required.
+This downloads the new binary, **verifies its SHA-256 against the `checksums.txt` published with the release**, and only then replaces the current one. If the download fails verification, the update is aborted and the existing binary is left untouched.
 
 !!! note
     If you installed via `go install`, use `go install github.com/trianalab/pacto/v2/cmd/pacto@latest` to update instead.
 
-Pacto also checks for updates automatically and shows a notification when a newer version is available. To disable this, set `PACTO_NO_UPDATE_CHECK=1` in your environment.
+Pacto also checks for updates automatically and notifies you when a newer version is available. See the [`pacto update` reference](cli-reference.md#pacto-update) for [update notifications](cli-reference.md#update-notifications) and the [`PACTO_NO_UPDATE_CHECK` environment variable](cli-reference.md#environment-variables).
 
 ## Build targets
 
 ```bash
 make build    # Compile the pacto binary with version injection
 make test     # Run all tests
-make lint     # Run go vet
+make lint     # Run gofmt check and go vet
 make clean    # Remove build artifacts
 ```
 

--- a/docs/lockfile.md
+++ b/docs/lockfile.md
@@ -1,10 +1,8 @@
 # Lockfile
 
-Pacto lockfiles enable reproducible dependency resolution and supply-chain pinning for contract bundles. Like `go.sum` and `Chart.lock`, `pacto.lock` captures the exact resolved state of your contract's dependency closure and reference closure, committed to git, shipped inside the pushed bundle and enforced by the CLI.
+Pacto lockfiles enable reproducible dependency resolution and supply-chain pinning for contract bundles. `pacto.lock` captures the exact resolved state of your contract's dependency closure and reference closure, committed to git, shipped inside the pushed bundle and enforced by the CLI. When the lock is present, Pacto verifies that every resolved dependency and every config/policy reference matches its pinned digest; any mismatch is a hard error — you cannot validate, graph, diff or push a bundle whose lock has drifted.
 
-When a `pacto.lock` file is present, Pacto verifies that every resolved dependency and every config/policy reference matches the digest pinned in the lock. Any mismatch is a hard error — you cannot validate, graph, diff or push a bundle whose lock has drifted.
-
-The lockfile is **embedded in the pushed bundle** when `pacto push` runs, so the dashboard can surface pinned digests and drift for services sourced from OCI registries or Kubernetes clusters (not just local directories). Shipping the lock remains opt-in: if no `pacto.lock` exists next to `pacto.yaml`, nothing extra is included in the bundle.
+The lockfile is **embedded in the pushed bundle** when `pacto push` runs, so the dashboard can surface pinned digests and drift for services sourced from OCI registries or Kubernetes clusters (not just local directories). Shipping the lock remains opt-in: a contract without a `pacto.lock` next to `pacto.yaml` behaves as before — dependencies and references resolve live and nothing extra is included in the bundle. (To keep an existing lock out of a pushed bundle, see [`.pactoignore`](pactoignore.md).)
 
 ---
 
@@ -20,17 +18,13 @@ The lock does not capture configuration values (`configurations[].values`), runt
 
 ---
 
-## Opt-in behavior
-
-Lockfiles are **opt-in**. A contract without a `pacto.lock` behaves as before — dependencies and references are resolved live on every command. The lock only activates when present.
-
----
-
 ## Commands
+
+See the [CLI reference](cli-reference.md#pacto-lock) for the full flag list; this section explains what each mode does.
 
 ### `pacto lock`
 
-Creates or refreshes `pacto.lock` in the current directory. Resolves the full dependency and reference closures and writes the result to disk. Existing pins are preserved when possible (same ref, still reachable).
+Creates or refreshes `pacto.lock` in the current directory. Resolves the full dependency and reference closures and writes the result to disk. Existing pins are preserved on rewrite when the dependency's constraint is unchanged; a consistent lock is left untouched.
 
 ```bash
 # Create or refresh the lockfile
@@ -49,16 +43,13 @@ Re-resolves the entire closure from scratch, ignoring existing pins. Use this wh
 ```bash
 # Re-resolve everything
 pacto lock --update
-
-# Bump only a specific dependency or reference
-pacto lock --update --update-name auth-service
 ```
 
-The `--update-name` flag limits the re-resolution to the named dependency or reference. All other pins are preserved.
+The `--update-name` flag re-resolves only the named dependency (repeatable) to the newest version its constraint allows, leaving every other dependency pin untouched.
 
 ### `pacto lock --check`
 
-Verifies that the lockfile is up-to-date without modifying it. Exits non-zero if the lock is stale or has conflicts. Useful as a CI gate to enforce that contributors have run `pacto lock` after editing dependencies or references.
+Verifies that the lockfile is up-to-date without modifying it. Exits non-zero if the lock is stale or has conflicts. Useful as a CI gate to enforce that contributors have run `pacto lock` after editing dependencies or references. Re-lock whenever a floating (unpinned) upstream ref is republished — it changes the resolved digest, so `lock --check` fails until you re-run `pacto lock` and commit.
 
 ```bash
 pacto lock --check
@@ -82,11 +73,11 @@ If any resolved dependency or reference produces a digest that does not match th
 | `LOCK_DIGEST_MISMATCH` | A resolved OCI ref's digest does not match the lockfile |
 | `LOCK_LOCAL_DRIFT` | A local file's content hash changed since the lock was written |
 | `LOCK_STALE` | The lockfile is missing a newly added dependency or reference |
-| `LOCK_CONFLICT` | The lockfile contains a pin for a ref that no longer appears in the contract |
+| `LOCK_CONFLICT` | The dependency closure requires the same service at two incompatible versions |
 | `LOCK_UNRESOLVED` | A ref in the lockfile could not be resolved (network error, registry unreachable, bundle deleted) |
-| `LOCK_MISSING` | A dependency or reference has no corresponding lock entry |
+| `LOCK_MISSING` | `pacto lock --check` was run but no `pacto.lock` file exists (the verification commands treat a missing lock as a no-op) |
 
-Because `pacto push` enforces the lock, **you cannot publish a bundle whose lock is stale**. This makes the lock an automatic supply-chain gate — if upstream dependencies have shifted or local files have changed without a `pacto lock --update`, the push is rejected.
+Because push enforces the lock, a stale lock blocks publishing — an automatic supply-chain gate.
 
 ---
 
@@ -123,7 +114,6 @@ references:
     name: org-security
     source: oci
     ref: oci://ghcr.io/acme/org-security-policy
-    constraint: ^1.0.0
     version: 1.3.0
     digest: sha256:fff111...
   - kind: config
@@ -138,7 +128,7 @@ The lockfile starts with `lockVersion` (schema version), `pacto.version` (the CL
 
 Each `dependencies[]` entry records the `source` (oci or local), the full ref or path as written in the contract, the constraint and resolved version and the digest (for OCI) or contentHash (for local). The `dependsOn` field captures the dependency chain so Pacto can rebuild the full graph structure from the lock without re-resolving upstream refs.
 
-The `references[]` section records config and policy refs with their `kind`, `source` and digest. Local file-based refs appear here with a contentHash instead of an OCI digest.
+The `references[]` section records config and policy refs with their `kind`, `source` and digest — references carry no `constraint` (only dependencies do). Local file-based refs appear here with a contentHash instead of an OCI digest.
 
 ---
 
@@ -158,5 +148,3 @@ If you're familiar with other package managers:
 | Helm | `Chart.lock` | Chart versions and repository URLs |
 | npm | `package-lock.json` | Exact package versions and integrity hashes |
 | Pacto | `pacto.lock` | OCI digests for dependencies and references |
-
-Like these tools, Pacto's lockfile ensures that the same contract always resolves to the same closure, regardless of when or where you run the command.

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -4,9 +4,7 @@ Pacto includes a built-in [Model Context Protocol](https://modelcontextprotocol.
 ---
 ## Why MCP?
 
-[MCP](https://modelcontextprotocol.io) (Model Context Protocol) is an open standard that lets AI tools call external functions through structured tool calls — similar to how a browser calls an API, but designed for LLMs. Instead of pasting CLI output into a chat window, the assistant calls `pacto_create` or `pacto_check` directly and gets structured JSON back.
-
-This matters because Pacto contracts are already machine-readable. MCP turns that into a two-way interaction: the assistant doesn't just *read* contracts — it can create new ones from intent-level descriptions, edit existing ones, and validate them, all within a single conversation.
+[MCP](https://modelcontextprotocol.io) is an open standard that lets AI tools invoke external functions through structured tool calls. With the Pacto MCP server, an assistant calls tools like `pacto_create` or `pacto_check` and gets structured JSON back — creating, editing and validating contracts in a single conversation instead of copy-pasting CLI output.
 
 ---
 
@@ -20,7 +18,7 @@ flowchart LR
     MCP -->|"JSON responses"| AI
 ```
 
-An AI assistant sends MCP tool calls to the `pacto mcp` server. Pacto executes the operation against local contract directories and returns structured JSON results. The assistant works entirely through the tool interface — no direct file access needed.
+The assistant works entirely through the tool interface — Pacto runs each operation against local contract directories and returns JSON.
 
 ---
 
@@ -40,7 +38,7 @@ Creates a new Pacto contract from structured input. The tool infers contract det
 **Key inputs:**
 - `name` (required) — service name
 - `description` — natural-language description (triggers automatic inference of interfaces, dependencies, and runtime)
-- `interfaces` — JSON array of `{name, type, port}` objects
+- `interfaces` — JSON array of `{name, type, port?, visibility?}` objects
 - `stores_data`, `data_survives_restart`, `data_shared_across_instances` — intent-level runtime flags mapped to contract primitives
 - `dry_run` — validate and return the result without writing files
 
@@ -50,10 +48,12 @@ Creates a new Pacto contract from structured input. The tool infers contract det
 
 | Intent | Contract field |
 |--------|---------------|
-| `stores_data=true` + `data_survives_restart=false` | `state.type: ephemeral`, `persistence.durability: ephemeral` |
+| `stores_data=true` + `data_survives_restart=false` | `state.type: stateful`, `persistence.durability: ephemeral`, `dataCriticality: medium` |
 | `stores_data=true` + `data_survives_restart=true` | `state.type: stateful`, `persistence.durability: persistent` |
 | `data_shared_across_instances=true` | `persistence.scope: shared` |
 | `data_loss_impact=high` | `dataCriticality: high` |
+
+The persistence rows take effect only when `stores_data=true` — `stores_data` is what sets `state.type: stateful` and the default `dataCriticality: medium`. With `stores_data=false` the runtime stays stateless, local, ephemeral and low, and `data_shared_across_instances` is ignored.
 
 **Scaling inputs:** `replicas` and `min_replicas`/`max_replicas` are mutually exclusive. If `replicas` is set, the min/max values are silently ignored (current behavior) — set either a fixed replica count or an auto-scaling range, not both.
 
@@ -71,7 +71,7 @@ Modifies an existing contract. Reads the current `pacto.yaml`, applies changes, 
 Scaling inputs follow the same rule as `pacto_create`: `replicas` and `min_replicas`/`max_replicas` are mutually exclusive, and setting `replicas` silently ignores the min/max values (current behavior).
 
 !!! warning
-    When adding a new interface, `pacto_edit` scaffolds a stub for any referenced interface file. Errors while writing those stub files are not currently surfaced, so `pacto_edit` may report success even if a referenced interface file was not written. Verify the generated files after an edit that adds an interface.
+    `pacto_edit` only scaffolds stub files for HTTP and gRPC interfaces. Other interface types (e.g. `event`) are added to `pacto.yaml` with a `contract:` path, but no file is created for them, so `pacto_edit` can report success while a referenced interface file is missing. Create those files yourself after the edit.
 
 ### pacto_check
 
@@ -119,7 +119,7 @@ Add Pacto as an MCP server in your project's `.mcp.json` file:
 }
 ```
 
-Claude Code uses stdio transport — no port configuration needed. Once configured, Claude can create contracts, edit them, and validate changes directly from your conversation.
+Claude Code uses stdio, so no port configuration is needed.
 
 ### Claude Desktop
 
@@ -221,7 +221,7 @@ Once configured, Copilot Chat in agent mode can use Pacto tools. Try asking: *"@
 
 ## HTTP transport
 
-For tools that connect over HTTP rather than stdio, start the server with:
+For tools that connect over HTTP rather than stdio (see [Transports](#transports) for the protocol and defaults), start the server with:
 
 ```bash
 # Default port (8585)
@@ -231,7 +231,7 @@ pacto mcp -t http
 pacto mcp -t http --port 9090
 ```
 
-The server listens on `127.0.0.1` and serves the MCP Streamable HTTP protocol at `/mcp`. Connect your MCP client to `http://127.0.0.1:8585/mcp` (or your chosen port).
+Connect your client to `http://127.0.0.1:8585/mcp` (or your chosen port).
 
 ---
 

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -6,20 +6,7 @@ For installation, configuration, and CRD reference, see the [pacto-operator repo
 ---
 ## Where the operator fits
 
-Pacto is a system made of three complementary pieces:
-
-| Piece | Responsibility | When it runs |
-|-------|---------------|--------------|
-| **CLI** | Author, validate, diff, explain, publish contracts | Build time / CI |
-| **Dashboard** | Explore contracts, graphs, versions, diffs, interfaces | Any time |
-| **Operator** | Verify runtime matches the contract | Continuously in-cluster |
-
-The CLI and dashboard work with contracts as **declared artifacts** — what a service *should* be. The operator compares those declarations against **observed reality** — what the service *actually is* in a running cluster.
-
-```
-author → validate → publish → explore → verify at runtime
-  CLI      CLI        CLI    dashboard     operator
-```
+The operator is the runtime-verification piece of Pacto — see the [docs home](index.md) for how the CLI, dashboard and operator fit together. The CLI and dashboard work with contracts as **declared artifacts** — what a service *should* be. The operator compares those declarations against **observed reality** — what the service *actually is* in a running cluster.
 
 ---
 
@@ -46,7 +33,7 @@ The operator checks runtime alignment across these dimensions:
 | **Workload existence** | Does a Deployment, StatefulSet, or Job exist matching the declared workload type? |
 | **Port alignment** | Do the ports exposed by the Kubernetes Service match the ports declared in the contract's interfaces? Reports missing and unexpected ports. |
 | **Workload kind** | Does the observed workload kind (Deployment/StatefulSet) match the declared `runtime.workload` + `runtime.state.type`? |
-| **Container image** | Does the running container image match the contract's `imageRef`? |
+| **Container image** | Does the running container image match the contract's `service.image.ref`? (surfaced in operator status as `imageRef`) |
 | **Upgrade strategy** | Does the Deployment/StatefulSet strategy match `runtime.lifecycle.upgradeStrategy`? |
 | **Graceful shutdown** | Does `terminationGracePeriodSeconds` match `runtime.lifecycle.gracefulShutdownSeconds`? |
 | **State model** | Does the observed storage (PVCs, emptyDir) align with `runtime.state.persistence`? |
@@ -57,7 +44,7 @@ The operator checks runtime alignment across these dimensions:
 A few checks have deliberately shallow semantics worth calling out:
 
 - **Health and metrics endpoints** are tested for *reachability and basic structure* — the health probe expects a healthy HTTP response, and the metrics probe looks for Prometheus exposition markers (`# HELP` / `# TYPE`). Neither validates the response body against the declared OpenAPI/format.
-- **Port alignment** matches by port **number** between the contract's interface ports and the Kubernetes Service ports, reporting missing and unexpected ports.
+- **Port alignment** matches by port **number** between the contract's interface ports and the Kubernetes Service ports.
 - **Scaling** compares observed replica bounds against `scaling.min`/`max`/`replicas`. Because the contract models `min`/`max` as plain integers, an explicit `0` is indistinguishable from "unset" and is treated as unset — so a declared lower bound of `0` is not reported (see the [scaling reference](contract-reference.md#scaling)).
 
 Each check produces a structured condition on the CRD status with a type, status, reason, and severity. The operator aggregates these into a contract status:
@@ -80,7 +67,7 @@ found" result.
 
 !!! warning
     The operator does **not** currently validate:
-    - Full OpenAPI conformance of live endpoints (it checks reachability and basic structure, not response schemas)
+    - Full OpenAPI conformance of live endpoints
     - JSON Schema validation of live configuration values
     - Dependency compatibility semantics (whether transitive deps satisfy version constraints)
     - `ref`-based policy schema enforcement at runtime
@@ -97,14 +84,14 @@ found" result.
 
 ## Readiness status
 
-In addition to runtime compliance, the operator evaluates a contract's declared **readiness** — a `pactoVersion: "1.2"` feature (see the [Contract Reference](contract-reference.md#readiness)). Readiness is a **separate dimension** from contract compliance: a low readiness score never changes `ContractStatus`.
+In addition to runtime compliance, the operator evaluates a contract's declared **readiness** — a `pactoVersion: "1.2"` feature. Readiness is a **separate dimension** from contract compliance: a low readiness score never changes `ContractStatus`. See the [Contract Reference](contract-reference.md#readiness) for the scoring model (weights, `expires`, `minScore` and `partialCredit` defaults).
 
-When a contract declares `readiness`, the operator computes a derived assessment from the declared check statuses, weights, `expires`, `minScore` and `partialCredit` values against the current time, and writes it to `status.readiness`:
+When a contract declares `readiness`, the operator writes the derived assessment to `status.readiness`:
 
-- `score`, `minScore`, `passing`, `totalWeight`, `earnedWeight`, `assessmentExpired`
+- `score`, `minScore`, `passing`, `totalWeight`, `earnedWeight`, `expired`
 - per check: effective weight earned based on status
 
-It also sets a single aggregate condition, **`ReadinessSatisfied`** (the gate: `score >= minScore`, where `minScore` defaults to 100):
+It also sets a single aggregate condition, **`ReadinessSatisfied`** (the gate: `score >= minScore`):
 
 | Status | Reason | Meaning |
 |--------|--------|---------|
@@ -112,7 +99,7 @@ It also sets a single aggregate condition, **`ReadinessSatisfied`** (the gate: `
 | `False` | `BelowMinScore` | the score is below `minScore` (e.g. assessment expired or too many not-done checks) |
 | `False` | `Invalid`       | the assessment `expires` date is unparseable |
 
-On gate transitions the operator emits events sparingly: a `Warning` / `ReadinessGateUnmet` when the gate first drops and a `Normal` / `ReadinessRecovered` when it is met again. Readiness is a separate dimension — it never changes `ContractStatus`. Contracts that declare no readiness get neither `status.readiness` nor the condition.
+On gate transitions the operator emits events sparingly: a `Warning` / `ReadinessGateUnmet` when the gate first drops and a `Normal` / `ReadinessRecovered` when it is met again. Contracts that declare no readiness get neither `status.readiness` nor the condition.
 
 ---
 
@@ -120,7 +107,7 @@ On gate transitions the operator emits events sparingly: a `Warning` / `Readines
 
 - **Not the authoring surface** — contracts are authored with the CLI (`pacto init`, `pacto validate`, `pacto push`). The operator consumes them.
 - **Not the diff engine** — version comparison and breaking change detection happen in the CLI and dashboard. The operator reports current state, not historical changes.
-- **Not the whole system** — the operator is valuable because it closes the loop. But without the CLI to author and publish contracts, and without the dashboard to explore them, it is just one piece.
+- **Not the whole system** — it closes the loop the CLI and dashboard open.
 - **Not a deployment tool** — it never creates, modifies, or deletes workloads. It observes.
 - **Not a generic Kubernetes drift detector** — it specifically checks contract-declared fields. It does not monitor arbitrary resource drift.
 
@@ -140,13 +127,7 @@ When `pacto dashboard` detects a Kubernetes cluster with the Pacto CRD installed
 - Declared **configuration and policy content** — the operator extracts each scope's schema properties (and the policy schema's title/description) into status, so the dashboard renders config/policy details even for reference-only contracts with no OCI source available to it
 - Contract-vs-runtime comparison rows
 
-The dashboard also **automatically discovers OCI repositories** from the `resolvedRef` fields in Pacto CRD statuses. This means when the dashboard runs in Kubernetes (e.g., as a Deployment alongside the operator), it can load full contract bundles from OCI — providing version history, interface details, and diffs — without needing explicit OCI arguments. Configuration and policy content is available directly from status (above), so it shows even when no OCI bundle can be reached.
-
-If those registries are unreachable or unauthenticated, OCI enrichment **degrades silently** to a k8s-only view: live runtime status, conditions, endpoints, and the status-provided config/policy content still render, but version history and cross-version diffs (which require materialized bundles) are unavailable until the registries become reachable.
-
-The result is a hybrid view: **runtime truth from the operator + contract truth from OCI**, merged in one place.
-
-See [Dashboard Container](dashboard-docker.md) for deployment instructions.
+The dashboard combines this operator-provided runtime truth with contract truth loaded from OCI, and degrades gracefully to a k8s-only view when registries are unreachable. See [Dashboard Container](dashboard-docker.md) for the k8s+OCI hybrid mode and deployment instructions, and [Architecture](architecture.md) for the source model.
 
 ---
 

--- a/docs/pactoignore.md
+++ b/docs/pactoignore.md
@@ -32,9 +32,7 @@ These patterns are always applied, even when no `.pactoignore` file exists:
 - `.pactoignore`
 - `.DS_Store`
 
-You do not need to list these in your `.pactoignore` — they are excluded automatically.
-
-**Note:** `pacto.lock` is **not** in the default ignore list. When a lockfile is present, it ships inside the bundle by default so the dashboard can surface pinned digests and drift for OCI-sourced and Kubernetes-sourced services. If you do not want the lock in your pushed bundle, add an explicit `pacto.lock` line to `.pactoignore`.
+**Note:** `pacto.lock` is **not** in the default ignore list. When a lockfile is present it ships inside the bundle by default (see [lockfile.md](lockfile.md)). To keep it out of a pushed bundle, add an explicit `pacto.lock` line to `.pactoignore`.
 
 ---
 
@@ -84,12 +82,7 @@ data/*.bin
 !data/config.bin
 ```
 
-This pattern:
-
-1. Excludes all `dist/`, `build/` and `.log` files
-2. Excludes editor directories and swap files
-3. Excludes `tmp/` and `.tmp` files
-4. Excludes `.bin` files in the `data/` directory, except `data/config.bin` (negation)
+The final `!data/config.bin` re-includes one file that an earlier pattern excluded (negation).
 
 ---
 
@@ -100,62 +93,19 @@ This pattern:
 - **`pacto pack`** — files matching ignore patterns are excluded from the tar.gz archive
 - **`pacto push`** — files matching ignore patterns are excluded from the OCI artifact
 
-Other commands (`validate`, `graph`, `diff`, `doc`, `explain`) do not apply ignore patterns — they operate on the local directory as-is.
+Every command that loads a local bundle reads through the ignore filter, so ignored files are invisible to all of them (this is why ignoring a referenced file also fails `validate`, `graph`, `diff`, `doc` and `explain`). Only `pacto pack` and `pacto push` additionally package the filtered file set into the shipped artifact.
 
 ---
 
-## Typical use cases
+## Pattern examples
 
-- Exclude build artifacts and logs from the bundle
-- Exclude large generated files that are not part of the contract
-- Exclude editor-specific directories (`.vscode/`, `.idea/`)
-- Exclude temporary or cache directories
-- Exclude local development tooling files that should not be distributed
-
----
-
-## Anchoring
-
-A pattern like `/docs/` matches the `docs/` directory at the contract root but not nested directories like `subdir/docs/`.
-
-A pattern without a leading `/` matches anywhere in the tree: `*.log` matches `build.log` and also `output/build.log`.
-
----
-
-## Trailing slash
-
-A trailing `/` means "directories only": `tmp/` matches the directory `tmp/` but not a file named `tmp`.
-
-Without the trailing slash, both the directory and a file of the same name would match.
-
----
-
-## Negation
-
-Use `!` at the start of a pattern to re-include a file that was previously excluded. Last-match-wins, so place negations after the broader exclusion patterns.
-
-Example:
-
-```
-# Exclude all markdown files
-*.md
-
-# Except README.md
-!README.md
-```
-
-This excludes all `.md` files but re-includes `README.md`.
+- `/docs/` — anchored: matches `docs/` at the contract root, not `subdir/docs/`
+- `*.log` — unanchored: matches `build.log` and `output/build.log`
+- `tmp/` — trailing slash matches the directory `tmp/`, not a file named `tmp`
+- `!README.md` after `*.md` — re-includes `README.md`; place negations after the broader exclude
 
 ---
 
 ## Validation and troubleshooting
 
-If you are unsure whether a file will be included in the bundle, run `pacto pack` in verbose mode:
-
-```bash
-pacto pack -v
-```
-
-Pacto logs each file it processes and whether it was included or excluded.
-
-If a referenced file is missing due to an ignore pattern, the error message will identify the exact file and the pattern that excluded it.
+`pacto pack -v` enables debug logging of the high-level pack steps (load/validate, archive, write); there is no per-file include/exclude log. If a referenced file is excluded, validation fails with `FILE_NOT_FOUND` naming the missing file (e.g. `interface contract file "interfaces/openapi.yaml" not found in bundle`) — it does not report which ignore pattern excluded it.

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -3,6 +3,8 @@ Pacto's primitives — bundles, references, configurations, policies, metadata �
 
 Each pattern is independent. Stack what you need; ignore what you don't.
 
+Across every pattern, two things are happening. Pacto composes interfaces you already have — a Helm chart's `values.schema.json`, a provisioning claim's schema — rather than inventing a parallel configuration language: compose, don't replace. And it adds the layer no single schema owns — ownership, dependencies, compatibility and how those interfaces change over time. A JSON Schema describes one interface; Pacto describes the relationships between them.
+
 ---
 ## 1. Root + component contracts (the monorepo pattern)
 
@@ -38,7 +40,7 @@ my-service/
 **Root contract.**
 
 ```yaml
-pactoVersion: "1.0"
+pactoVersion: "1.2"
 
 service:
   name: my-service-root
@@ -70,7 +72,7 @@ dependencies:
 **Component contract.**
 
 ```yaml
-pactoVersion: "1.0"
+pactoVersion: "1.2"
 
 service:
   name: my-service-api
@@ -101,7 +103,7 @@ configurations:
     ref: oci://ghcr.io/example/pactos/platform-service:2.0.0
 ```
 
-**Why this works.** A one-component repo using this layout has near-zero overhead but pays for itself the day a second component arrives — adding one is a new bundle directory plus one root-contract dependency, not a repo-wide restructure. The root maps cleanly to a single deployment unit, while each component is independently validated, versioned, and reasoned about. Naming convention (e.g. `-root` suffix) gives downstream tooling a reliable signal to distinguish roots from components in the dependency graph.
+**Why this works.** A one-component repo pays almost nothing for this layout, and adding a second component is one new bundle dir plus one root dependency. The root maps to a single deployment unit; each component is validated and versioned independently. The root is a lean aggregator — it carries only `service`, `chart` and `dependencies[]` (plus any `policies`), deliberately omitting `runtime`, `interfaces` and `configurations`. Your own tooling can distinguish a root from a component by naming convention (e.g. a `-root` suffix) or structurally — `dependencies[]` present, `configurations` absent — since Pacto itself does not key off the name.
 
 **Cross-links:** [`service.chart`](contract-reference.md#chart) · [`dependencies`](contract-reference.md#dependencies)
 
@@ -121,7 +123,7 @@ configurations:
 **Example: a postgres infrastructure contract.**
 
 ```yaml
-pactoVersion: "1.0"
+pactoVersion: "1.2"
 
 service:
   name: postgres
@@ -141,10 +143,12 @@ policies:
 
 configurations:
   - name: provisioning
-    schema: configuration/schema.json   # derived from the provisioner XRD / module spec
+    schema: configuration/schema.json   # hand-authored mirror of the provisioner's XRD / module spec — Pacto does not derive it
 ```
 
 **The provisioning schema** validates "did the team write a sensible claim?" — instances in range, valid size enum, schedule cron syntax, etc.
+
+Pacto doesn't invent this schema — it's a hand-authored mirror of the provisioner's own interface (a Crossplane XRD, a Terraform module's variables), the team-controllable subset of the claim. Configuring the resource through the contract is configuring the underlying claim; the contract adds what the claim can't express on its own — an owner, a version, a policy and a stable ref other contracts depend on.
 
 ```json
 {
@@ -184,9 +188,11 @@ configurations:
 
 ```yaml
 # pactos/my-service-api/overrides/values.stg.yaml
+# Value-carrying entries use a local (vendored) schema — `ref:` and `values:`
+# are mutually exclusive, so a schema you supply values for must live in the bundle.
 configurations:
   - name: deployment
-    ref: oci://ghcr.io/example/pactos/platform-service:2.0.0
+    schema: configuration/deployment/schema.json
     values:
       replicas: 3
       resources:
@@ -195,7 +201,7 @@ configurations:
           memory: 1Gi
 
   - name: postgres
-    ref: oci://ghcr.io/example/pactos/postgres:17.0.0
+    schema: configuration/postgres/schema.json
     values:
       instances: 2
       size: medium
@@ -204,23 +210,23 @@ configurations:
         schedule: "0 */6 * * *"
 
   - name: secrets
-    ref: oci://ghcr.io/example/pactos/secrets:1.0.0
+    schema: configuration/secrets/schema.json
     values:
       secrets:
         - key: api-key
         - key: openai-token
 ```
 
-`pacto validate -f overrides/values.stg.yaml` validates each entry against its referenced schema. Your deployment tooling reads the same file and produces:
+`pacto validate -f overrides/values.stg.yaml` validates each entry's `values` against its local `schema`. (Values for `ref`-based configs are resolved and validated at deploy/runtime, not at validate time.) Your deployment tooling reads the same file and produces:
 
 - Helm values (`deployment` entry → values nested under the component's chart alias)
 - A Postgres claim (`postgres` entry → fields land in the claim's `spec`)
 - A secret-store claim (`secrets` entry → declared keys provisioned)
 
-**Each value is written once.** No drift between a chart's `values.yaml` and a separate `claims/postgres.yaml`. A reviewer reads one file to see what the component will look like in this environment.
+**Each value is written once** — no drift between a chart's `values.yaml` and a separate `claims/postgres.yaml`.
 
 !!! info
-    Override files use **Helm-style array replacement** for `configurations` — the override's array replaces the contract's array entirely, not merged by name. Each override file must therefore include all configurations it cares about, with their `ref` (or `schema`) and `values`. This is by design: it makes each environment file self-contained and independently validatable.
+    Override files use **Helm-style array replacement** for `configurations` — the override's array replaces the contract's array entirely, not merged by name (see [Contract overrides](contract-reference.md#contract-overrides)). Each override file must therefore include every configuration it cares about, each with its `schema` (and `values`) or a `ref` (schema-only). Inline `values` require a local `schema`; a `ref`-based entry carries neither.
 
 **Cross-links:** [`configurations`](contract-reference.md#configurations) · [Contract overrides](contract-reference.md#contract-overrides) · [Environment-specific values files](contract-reference.md#environment-specific-values-files)
 
@@ -239,7 +245,7 @@ configurations:
 
 ```yaml
 # pactos/platform-service/pacto.yaml
-pactoVersion: "1.0"
+pactoVersion: "1.2"
 
 service:
   name: platform-service
@@ -269,7 +275,7 @@ configurations:
     ref: oci://ghcr.io/example/pactos/platform-service:2.0.0
 ```
 
-**Mix and match.** Teams using the platform's standard chart reference both. Teams that ship their own chart (a third-party Keycloak chart, a custom operator) still reference the policy — contract structure rules are universal — but provide their own configuration schema locally:
+**Mix and match.** Teams using the platform's standard chart reference both. Teams that ship their own chart (a third-party Keycloak chart, a custom operator) still reference the policy — contract structure rules are universal — but vendor their own configuration schema locally. The moment a team needs inline or override `values`, it must vendor the schema: a `ref`-ed config is schema-only (see [Configuration Schema Ownership Models](contract-reference.md#configuration-schema-ownership-models)).
 
 ```yaml
 policies:
@@ -281,7 +287,7 @@ configurations:
     schema: configuration/values.schema.json   # vendored from their chart
 ```
 
-**One artifact, central control.** The platform team owns one bundle. Services pin to a version. The same JSON Schema validates the contract at CI time *and* the chart values at install time — no duplication, no drift.
+**One bundle, versioned.** The same JSON Schema validates the contract at CI time *and* the chart values at install time.
 
 **Cross-links:** [Configuration Schema Ownership Models](contract-reference.md#configuration-schema-ownership-models) · [`policies`](contract-reference.md#policies) · [Policy as a contract](platform-engineers.md#policy-enforcing-contract-standards)
 
@@ -300,15 +306,17 @@ configurations:
 | `3.0.0` | + `configurations[]` schema present, SBOM in bundle |
 | `4.0.0` | + `runtime.health` includes liveness *and* readiness, `scaling.min >= 2` for `service` workloads |
 
-A service pinned to `platform-policy:2.0.0` keeps validating against v2's rules until the team is ready to bump. The dashboard can surface "service is N major versions behind the latest policy" without the platform forcing the change.
+A service pinned to `platform-policy:2.0.0` keeps validating against v2's rules until the team is ready to bump — the platform never forces the change.
 
 **Why this works.**
 
 - **Forwards is opt-in, never forced.** Teams migrate when they have time
-- **Backwards is enforced.** A service can never weaken its policy — `pacto diff` flags removing or downgrading a policy ref as a breaking change
+- **Backwards is enforced.** A service can never silently weaken its policy — `pacto diff` flags removing or changing a policy ref as potentially breaking (classification `potentially-breaking`)
 - **The version is the negotiation point.** Conversations about "should we require X?" become "should we publish v4 that requires X, with a six-month adoption window?"
 
-**Coordinate with `pacto diff`.** When a service ref-bumps from `2.0.0` to `3.0.0`, `pacto diff` resolves both versions of the policy and shows what new validations will apply. If the service contract doesn't satisfy the new policy, validation fails *before* merge — the team sees the gap and either fixes it or stays on `2.0.0`.
+**Two dials.** Pinning the policy's major version (above) makes each new bar opt-in and negotiated. Alternatively, a rule layer referenced *transitively* through the platform contract can be left unpinned: republishing that one schema propagates a new rule fleet-wide immediately, with no per-service bump — at the cost of lockfile drift, since every republish changes the resolved digest and forces services to re-lock ([`pacto lock --check`](lockfile.md) fails until they do). Pinned is opt-in and negotiated; floating is instant and unilateral but forces re-locks.
+
+**Coordinate with `pacto validate`.** When a service ref-bumps from `2.0.0` to `3.0.0`, `pacto diff` reports the changed policy ref; `pacto validate` resolves the new policy and fails *before* merge if the contract does not satisfy it — the team sees the gap and either fixes it or stays on `2.0.0`.
 
 **Cross-links:** [`policies`](contract-reference.md#policies) · [Change classification — Policy](contract-reference.md#policy)
 
@@ -331,20 +339,20 @@ pactos/my-service-api/
     └── values.prod.yaml
 ```
 
-**One environment file is fully self-contained** — it lists every configuration the component cares about for that environment:
+Each file is self-contained and follows the same shape as [pattern 3](#3-configurations-as-composable-claims) — it lists every configuration the component cares about for that environment, value-carrying entries using a local `schema:` (a `ref:` entry is schema-only):
 
 ```yaml
 # overrides/values.prod.yaml
 configurations:
   - name: deployment
-    ref: oci://ghcr.io/example/pactos/platform-service:2.0.0
+    schema: configuration/deployment/schema.json
     values:
       replicas: 5
       resources:
         requests: { cpu: 2000m, memory: 2Gi }
 
   - name: postgres
-    ref: oci://ghcr.io/example/pactos/postgres:17.0.0
+    schema: configuration/postgres/schema.json
     values:
       instances: 3
       size: large
@@ -353,21 +361,9 @@ configurations:
         schedule: "0 */4 * * *"
 ```
 
-**Why per-component files.** A single monolithic file per environment would conflate values that are validated against different schemas (one schema per configuration entry). Per-component files mean:
+Each file is validated independently by `pacto validate -f overrides/values.<env>.yaml`, so a change scopes to one component — a typo in staging Postgres can't break an unrelated one, and reviewers see a small diff.
 
-- Each file is independently validated by `pacto validate -f overrides/values.<env>.yaml`
-- A change to staging Postgres for the worker affects exactly one file — no risk of a typo breaking an unrelated component
-- Reviewers see a small, scoped diff per change
-
-**Why files are usually small.** Good chart and contract defaults eliminate most overrides. If dev works with defaults, no `values.dev.yaml` is needed at all. A typical override is 10-20 lines: the values that genuinely differ for this environment.
-
-**Precedence at validate / deploy time:**
-
-```
-contract inline values  →  -f overrides/values.<env>.yaml  →  --set
-```
-
-Use inline values for cross-environment defaults. Use override files for environment-specific values. Reserve `--set` for values your platform tooling controls (image tag, namespace, deploy-time labels).
+**Precedence.** Contract inline `values` → `-f overrides/values.<env>.yaml` → `--set` (wins). Use inline values for cross-environment defaults, override files for environment-specific values and reserve `--set` for values your platform tooling controls (image tag, namespace, deploy-time labels). See [Precedence](contract-reference.md#precedence) for the full chain.
 
 **Cross-links:** [Contract overrides](contract-reference.md#contract-overrides) · [Precedence](contract-reference.md#precedence) · [Environment-specific values files](contract-reference.md#environment-specific-values-files)
 

--- a/docs/platform-engineers.md
+++ b/docs/platform-engineers.md
@@ -1,7 +1,5 @@
 # Pacto for Platform Engineers
-You manage the infrastructure that runs services. Pacto gives you a machine-readable, validated contract for every service — so you can stop guessing and start automating.
-
-Instead of reverse-engineering how to run a service from Helm charts, READMEs, and Slack threads, you pull a contract from an OCI registry and get everything you need: workload type, state model, interfaces, health checks, dependencies, configuration schema, and scaling intent.
+You manage the infrastructure that runs services. Pull a validated, machine-readable contract from an OCI registry and get everything needed to run a service: workload type, state model, interfaces, health checks, dependencies, config schema and scaling intent.
 
 ---
 ## What a contract tells you
@@ -10,11 +8,8 @@ Every question you'd normally have to ask the dev team — or discover in produc
 
 | Contract Field | Platform Decision |
 |---|---|
-| `runtime.workload: service` | Deploy as a long-running process (Deployment/StatefulSet) |
-| `runtime.workload: job` | Deploy as a one-shot task (Job/CronJob) |
-| `runtime.state.type: stateful` | Needs stable identity and storage (StatefulSet + PVC) |
-| `runtime.state.type: stateless` | Horizontally scalable, no persistent storage needed |
-| `runtime.state.persistence.durability: persistent` | Provision durable storage |
+| `runtime.workload` (`service` / `job` / `scheduled`) | Choose the workload kind — see [Workload type](#workload-type) below |
+| `runtime.state.type` + `runtime.state.persistence` | Choose storage + scheduling strategy — see [State model](#state-model) below |
 | `runtime.state.dataCriticality: high` | Enable backups, stricter disruption budgets |
 | `interfaces[].port` | Configure Service, Ingress |
 | `interfaces[].visibility: public` | Create external Ingress or load balancer |
@@ -24,7 +19,7 @@ Every question you'd normally have to ask the dev team — or discover in produc
 | `scaling.min` / `scaling.max` | Configure auto-scaling bounds |
 | `configurations[].schema` / `configurations[].ref` | Validate required configuration, generate config templates. Platform teams can publish a shared schema that services vendor into their bundles or reference via OCI — the schema then expresses what the platform *provides*. See [Configuration Schema Ownership Models](contract-reference.md#configuration-schema-ownership-models) |
 | `policies[].ref` | Enforce organizational standards — require health endpoints, mandate ports, enforce visibility rules. See [policies](contract-reference.md#policies) |
-| `readiness.checks[]` | Gate promotion and surface operational readiness — declare dashboard, runbook, security-review, SLO, AI-eval evidence with a weight and expiry; derive a freshness score. Enforce required checks via policies. See [readiness](contract-reference.md#readiness) |
+| `readiness.checks[]` | Gate promotion and surface operational readiness — declare dashboard, runbook, security-review, SLO, AI-eval evidence; each check carries a weight; the assessment carries a single expiry date; derive a freshness score. Enforce required checks via policies. See [readiness](contract-reference.md#readiness) |
 | `dependencies[].ref` | Validate dependency graph, check compatibility |
 | `docs/` *(optional)* | Access service documentation, runbooks, integration guides |
 | `sbom/` *(optional)* | Audit third-party packages, track license compliance |
@@ -55,7 +50,7 @@ pacto pull oci://ghcr.io/acme/payments-api-pacto:2.1.0
 ```bash
 $ pacto explain oci://ghcr.io/acme/payments-api-pacto:2.1.0
 Service: payments-api@2.1.0
-Owner: payments (team)
+Owner: payments
 Pacto Version: 1.2
 
 Runtime:
@@ -69,7 +64,7 @@ Interfaces (2):
   - grpc-api (grpc, port 9090, internal)
 
 Dependencies (1):
-  - oci://ghcr.io/acme/auth-pacto@sha256:abc123 (^2.0.0, required)
+  - auth: oci://ghcr.io/acme/auth-pacto@sha256:abc123 (^2.0.0, required)
 
 Scaling: 2-10
 ```
@@ -155,11 +150,13 @@ The state model tells you exactly what storage and scheduling strategy a service
 
 ## Configuration and policy
 
-Two features give platform teams direct control over the boundary between developers and infrastructure: **configuration schemas** and **policies**. Both can be centralized via OCI references, making them a cornerstone of the platform-as-a-product model.
+Two features give platform teams direct control over the boundary between developers and infrastructure: **configuration schemas** and **policies**. Both can be centralized via OCI references.
 
 ### Configurations: the interface between dev and platform
 
 The `configurations` section defines **the interface boundary between a service and its environment**. When a platform team publishes a shared configuration schema, it declares *what the platform provides* — database connections, observability endpoints, feature flags, secret paths. When a service author defines one, it declares *what the service requires*.
+
+An interface is a JSON Schema — and you probably already have one. A service's configuration interface is the `values.schema.json` you author for its Helm chart; an infrastructure interface is a hand-authored mirror of a provisioning claim's schema. Pacto composes the schema you already own instead of inventing a new configuration language: vendor that file as a local `schema:` (required whenever you supply values), or resolve a schema-only contract via `ref:`.
 
 There are two approaches:
 
@@ -179,34 +176,13 @@ configurations:
     ref: oci://ghcr.io/acme/platform-config-pacto:1.0.0
 ```
 
-The OCI approach enables centralized configuration management: the platform team publishes one configuration contract, all services reference it, and updates propagate through version bumps — not copy-pasting files.
-
 See [Configuration Schema Ownership Models](contract-reference.md#configuration-schema-ownership-models) for the full breakdown of service-defined vs. platform-defined schemas.
 
 ### Policy: enforcing contract standards
 
 The `policies` section lets platform teams enforce **minimum requirements on contracts themselves**. A policy is a JSON Schema that validates `pacto.yaml` — requiring health endpoints, mandating specific ports, enforcing visibility rules, or any other organizational standard.
 
-**How it works:**
-
-1. The platform team creates a policy contract containing a JSON Schema at `policy/schema.json`:
-
-```yaml
-# platform-policy/pacto.yaml
-pactoVersion: "1.2"
-service:
-  name: platform-policy
-  version: 1.0.0
-  owner:
-    team: platform
-policies:
-  - name: platform-policy
-    schema: policy/schema.json
-```
-
-2. The platform publishes it: `pacto push oci://ghcr.io/acme/platform-policy-pacto -p platform-policy`
-
-3. Services adopt the policy by referencing it:
+The platform team publishes a policy contract carrying the JSON Schema, and services adopt it by reference:
 
 ```yaml
 policies:
@@ -214,33 +190,12 @@ policies:
     ref: oci://ghcr.io/acme/platform-policy-pacto:1.0.0
 ```
 
-Example policy schema (`policy/schema.json`) requiring all contracts to have a health check:
+See [The platform-published policy + schema contract](patterns.md#4-the-platform-published-policy-schema-contract) for the authoring and publish recipe.
 
-```json
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
-  "required": ["runtime"],
-  "properties": {
-    "runtime": {
-      "type": "object",
-      "required": ["health"],
-      "properties": {
-        "health": {
-          "type": "object",
-          "required": ["interface", "path"]
-        }
-      }
-    }
-  }
-}
-```
+!!! warning "Where refs are enforced"
+    Ref-based policies are enforced by `pacto validate` (fail-closed — an unresolvable ref is a hard `POLICY_REF_UNRESOLVED` error). `pacto pack`/`pacto push` and the operator only enforce inline `schema` policies and emit a `POLICY_REF_NOT_ENFORCED` warning for refs.
 
-Policy providers SHOULD declare their schemas explicitly in `policies[]` for full control over schema paths and multi-schema support. The fixed `policy/schema.json` path is a legacy fallback used only when the referenced contract has no `policies[]` entries.
-
-Policy references support recursive resolution — if the referenced contract itself has a `policies[].ref`, Pacto follows the chain with cycle detection.
-
-See [policies](contract-reference.md#policies) in the Contract Reference for the full specification.
+See [Layer 4: Policy enforcement](contract-reference.md#layer-4-policy-enforcement) for the resolution semantics (recursive N-hop, cycle detection, error codes) and [policies](contract-reference.md#policies) for the full specification.
 
 !!! info
     Configuration and policy are complementary:
@@ -248,15 +203,13 @@ See [policies](contract-reference.md#policies) in the Contract Reference for the
     - **Configuration** defines what a service needs (or what the platform provides) — the *data interface*
     - **Policy** enforces how contracts must be structured — the *contract interface*
 
-    Together, they give platform teams a centralized, versioned, machine-validated governance model — without tickets, wikis, or manual review.
+    A single JSON Schema describes one interface in isolation; it can't express how interfaces relate or change over time. That relational layer — ownership, dependencies, compatibility, readiness — is what the contract adds around them.
 
 ---
 
 ## Breaking change detection
 
-`pacto diff` doesn't just compare contract fields — it performs deep OpenAPI diffing (paths, methods, parameters, request bodies, responses) and resolves both dependency trees to show the full blast radius.
-
-Deep diffing applies only to interfaces that reference a contract file (e.g. an OpenAPI spec). Interfaces without a contract file are compared on type, port, and visibility only. Config and policy JSON Schemas are diffed only when both bundles include the local schema files.
+`pacto diff` compares contract fields, deep-diffs referenced interface specs (e.g. OpenAPI) and resolves both dependency trees to show the full blast radius. Gate CI on its exit code — it exits non-zero when the classification is `BREAKING`.
 
 ```bash
 $ pacto diff oci://ghcr.io/acme/payments-api-pacto:1.0.0 \
@@ -274,9 +227,7 @@ payments-api
 └─ postgres      -16.0.0
 ```
 
-Every change is classified as `NON_BREAKING`, `POTENTIAL_BREAKING`, or `BREAKING`. See the [Change Classification Rules](contract-reference.md#change-classification-rules) for the full table.
-
-When both bundles include an `sbom/` directory, `pacto diff` also reports SBOM package-level changes (added, removed, version or license modified). These are informational and don't affect the classification or exit code.
+Every change is classified as `NON_BREAKING`, `POTENTIAL_BREAKING` or `BREAKING`; when both bundles include an `sbom/` directory, package-level SBOM changes are reported but stay informational (they don't affect the classification or exit code). See [Change Classification Rules](contract-reference.md#change-classification-rules) for the full table plus the OpenAPI, JSON-Schema and SBOM diff mechanics.
 
 ---
 
@@ -308,49 +259,13 @@ steps:
     run: pacto graph .
 ```
 
-Using GitHub Actions? The same workflow with [pacto-actions](https://github.com/trianalab/pacto-actions):
-
-```yaml
-steps:
-  - uses: trianalab/pacto-actions@v1
-    with:
-      command: setup
-
-  - name: Infer config schema from sample config
-    run: pacto generate schema-infer ./my-service --option file=config.yaml -o ./my-service
-
-  - name: Infer OpenAPI spec from source code
-    run: pacto generate openapi-infer ./my-service -o ./my-service
-
-  - uses: trianalab/pacto-actions@v1
-    with:
-      command: validate
-      path: ./my-service
-
-  - uses: trianalab/pacto-actions@v1
-    with:
-      command: diff
-      old: oci://ghcr.io/my-org/my-service
-      new: ./my-service
-      comment-on-pr: 'true'
-
-  - uses: trianalab/pacto-actions@v1
-    if: github.ref == 'refs/heads/main'
-    with:
-      command: push
-      ref: oci://ghcr.io/my-org/my-service
-      path: ./my-service
-```
-
-See [pacto-actions](https://github.com/trianalab/pacto-actions) for full documentation including multi-service workflows, doc generation, and authentication options.
+Using GitHub Actions? See [GitHub Actions integration](github-actions.md) for the equivalent workflow built on [pacto-actions](https://github.com/trianalab/pacto-actions), including multi-service workflows, doc generation and authentication options.
 
 ---
 
 ## Dashboard
 
-`pacto dashboard` launches the contract exploration dashboard — the same contracts the CLI manages and the operator verifies, visualized as dependency graphs, version history, interface details, configuration schemas, and diffs.
-
-The dashboard is not a separate product with a different model. It is a visualization layer over the same Pacto contracts, designed for:
+`pacto dashboard` launches the contract exploration dashboard — the same contracts the CLI manages and the operator verifies, visualized for:
 
 - Navigating service dependency chains and understanding blast radius
 - Inspecting interfaces (OpenAPI endpoints, gRPC definitions, event schemas)
@@ -358,73 +273,9 @@ The dashboard is not a separate product with a different model. It is a visualiz
 - Exploring configuration schemas and policy references
 - Monitoring runtime compliance alongside contract content
 
-### Sources and auto-detection
+Sources (local, Kubernetes, OCI) are auto-detected at startup and merged per service. The platform-relevant behavior: when running alongside the Kubernetes operator, the dashboard auto-discovers OCI repositories from the `resolvedRef` fields in Pacto CRD statuses, so a K8s deployment gives the full contract experience — version history, interface details, configuration schemas and diffs — without explicit OCI arguments.
 
-Sources are auto-detected at startup:
-
-| Source | Detected when | Provides |
-|--------|--------------|----------|
-| **local** | `pacto.yaml` found in the working directory | In-progress contract changes |
-| **k8s** | Valid kubeconfig found and cluster reachable | Runtime state: contract status, conditions, endpoints, resources |
-| **oci** | `oci://` positional arguments provided, or auto-discovered from K8s `resolvedRef` fields | Full contract bundles, registry versions, and diffs |
-
-Materialized bundles on disk (`~/.cache/pacto/oci`) are used internally by the OCI source to enrich version data (hash, classification, timestamps) without appearing as a separate source.
-
-When running alongside the Kubernetes operator, the dashboard automatically discovers OCI repositories from the `resolvedRef` fields in Pacto CRD statuses. This means a K8s deployment of the dashboard provides the full contract experience — version history, interface details, configuration schemas, and diffs — without explicit OCI arguments.
-
-Pass `--no-cache` to skip pre-existing cached bundles at startup (cold-start mode). Bundles materialized during the current session (via fetch-all-versions, dependency resolution, or OCI pulls) are still cached to disk and reused for enrichment within the same session.
-
-### Merge priority
-
-When a service appears in multiple sources, fields are merged using priority rules:
-
-1. **Kubernetes** — runtime state (contract status, resources, ports, conditions, endpoints)
-2. **Local** — in-progress contract edits
-3. **OCI** — published contract baseline
-
-The merged view is used for the service list and detail pages. Per-source data is available via the `/api/services/{name}/sources` endpoint.
-
-### Status and source filtering
-
-The dashboard provides a layered filter pipeline:
-
-1. **Source filter** — click source pills in the header to show/hide services from specific sources
-2. **Status filter** — click status pills (Compliant, Warning, Non-Compliant, Reference, Unknown) to filter by contract status
-3. **Search** — type in the search bar to filter by name, owner, version, or source
-
-All three filters compose: a service must pass all active filters to appear in both the table and graph views.
-
-### Graph visualization
-
-The built-in D3 force-directed graph shows:
-
-- **Dependency edges** (solid lines) — declared `dependencies[].ref` relationships
-- **Reference edges** (dashed lines) — `configurations[].ref` and `policies[].ref` cross-references
-- **External nodes** — dependencies that don't resolve to any known service
-
-Hover over a node to highlight its impact chain. Click a node to navigate to its detail page.
-
-### Version tracking
-
-The dashboard classifies how each service tracks its contract version:
-
-| Policy | Meaning | Source |
-|--------|---------|--------|
-| **Tracking latest** | Service follows the latest available version (no explicit pin) | Operator `resolutionPolicy=Latest` |
-| **Pinned to tag** | Service is pinned to a specific semver tag | Operator `resolutionPolicy=PinnedTag`, or fallback from semver tag in `resolvedRef` |
-| **Pinned to digest** | Service is pinned to an immutable OCI digest | Operator `resolutionPolicy=PinnedDigest`, or fallback from `@sha256:` in `resolvedRef` |
-
-The **preferred source of truth** is the operator's `status.contract.resolutionPolicy` field, available for Kubernetes-backed services. For non-Kubernetes sources (OCI-only, local) or older operator versions that don't expose `resolutionPolicy`, the dashboard falls back to a conservative heuristic based on `resolvedRef`. The fallback only classifies unambiguous cases (digest refs, explicit semver tags) — ambiguous refs are left unclassified rather than assumed to be tracking.
-
-Note: `"latest"` is not a valid Pacto contract version. The dashboard does not infer "tracking latest" from a `:latest` OCI tag.
-
-The dashboard also compares the current version against the latest available semver tag from OCI and shows an informational indicator when a newer version exists. This is purely informational — **update availability does not affect compliance status**. A service running an older version remains Compliant as long as its contract passes validation.
-
-In the version history table, the currently active version is highlighted so you can see at a glance where you stand relative to the full version timeline. You can click "Compare" to diff the current version against the latest available.
-
-### Diagnostics
-
-Pass `--diagnostics` to enable debug endpoints (`/api/debug/sources`, `/api/debug/services`) that expose raw per-source detection details and service data for troubleshooting.
+See [Dashboard architecture](architecture.md#dashboard-architecture) for the source model, merge priority, graph edges and version-tracking rules, and the [`pacto dashboard` command reference](cli-reference.md#pacto-dashboard) for flags (`--port`, `--namespace`, `--repo`, `--no-cache`, `--diagnostics`) and environment variables.
 
 ---
 
@@ -437,9 +288,5 @@ Pass `--diagnostics` to enable debug endpoints (`/api/debug/sources`, `/api/debu
 - **Use JSON output.** Every command supports `--output-format json` for programmatic consumption.
 - **Use markdown output for PR comments.** `pacto diff --output-format markdown` renders changes as tables with old/new values — pipe it into `gh pr comment` for rich CI feedback.
 - **Use `--verbose` for debugging.** Pass `-v` to any command to see debug-level logs (OCI operations, resolution steps, cache hits/misses) on stderr.
-- **Check SBOM changes.** When bundles include SBOMs, `pacto diff` reports package-level changes — useful for tracking dependency drift, license compliance, and supply chain audits across contract versions.
-- **Enforce policies.** Publish a policy contract with a JSON Schema that validates contracts against your organizational standards. Services reference it via `policies[].ref` — see [policies](contract-reference.md#policies) in the Contract Reference.
-- **Centralize configuration schemas.** Publish a configuration contract and have services reference it via `configurations[].ref` instead of vendoring schemas. See [Configuration Schema Ownership Models](contract-reference.md#configuration-schema-ownership-models).
 - **Leverage AI assistants.** Pacto contracts are machine-consumable. In addition to CI pipelines and platform controllers, AI assistants can interact with contracts directly through the [MCP interface](mcp-integration.md) — useful for ad-hoc inspection, dependency analysis, and contract generation.
 - **Close the loop with the operator.** The [Kubernetes Operator](operator.md) continuously verifies that deployed services match their contracts — port alignment, workload existence, health endpoint reachability, and more. Combined with the dashboard, you get a complete view: contract truth from OCI + runtime truth from the operator.
-- **Use the dashboard for contract observability.** Run `pacto dashboard` to explore contracts, dependency graphs, version history, interface details, and diffs. Deploy the [Dashboard Container](dashboard-docker.md) alongside the operator for a production-ready contract exploration UI.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,7 +1,7 @@
 # Plugin Development
 Pacto uses an out-of-process plugin architecture for artifact generation. A plugin is a standalone executable that receives a contract via JSON on stdin and writes generated file descriptions to stdout.
 
-This means you can turn a Pacto contract into anything — Helm charts, Terraform modules, Kubernetes manifests, monitoring configs — using any language you want.
+A plugin can turn a contract into any artifact — Helm charts, Terraform, Kubernetes manifests — in any language.
 
 ---
 ## Official plugins
@@ -13,6 +13,8 @@ Pacto ships with two official plugins that are automatically installed alongside
 | **pacto-plugin-schema-infer** | Infers a JSON Schema from sample configuration files (JSON, YAML, TOML) for use in Pacto contracts. |
 | **pacto-plugin-openapi-infer** | Auto-detects web frameworks and extracts OpenAPI 3.1 specs from source code. Currently supports FastAPI and Huma. |
 
+Both `*-infer` plugins are the composition on-ramp: they derive the interfaces you already have — a service's HTTP API from its source, its config shape from real config files — instead of asking you to hand-author a schema. Compose what already exists rather than reinvent it.
+
 These plugins are maintained in the [pacto-plugins](https://github.com/TrianaLab/pacto-plugins) repository. Refer to each plugin's README for detailed usage and options:
 
 - [pacto-plugin-schema-infer](https://github.com/TrianaLab/pacto-plugins/tree/main/plugins/pacto-plugin-schema-infer)
@@ -22,13 +24,15 @@ These plugins are maintained in the [pacto-plugins](https://github.com/TrianaLab
 
 ## Why plugins?
 
-Pacto describes *what* a service is. Plugins decide *how* to deploy it. The contract is the input; deployment artifacts are the output. This separation keeps Pacto platform-agnostic while letting each team generate exactly the artifacts their infrastructure needs.
+Pacto describes *what* a service is. Plugins decide *how* to deploy it. The contract is the input; deployment artifacts are the output.
+
+Plugins run in both directions: the `*-infer` plugins run inward (composing interfaces you already have into the contract), while generate plugins run outward (turning the contract into deployment artifacts). One schema describes a single interface; the contract describes how those interfaces relate and change.
 
 The plugin design is:
 
-- **Language-agnostic** — write plugins in Go, Python, Rust, Bash, or anything
+- **Language-agnostic** — write plugins in Go, Python, Rust, Bash or anything
 - **Version-independent** — plugins don't link against Pacto libraries
-- **Sandboxed** — plugins receive a read-only view of the contract
+- **Isolated input** — the plugin gets a serialized, read-only snapshot of the contract on stdin and cannot mutate Pacto's state; Pacto bounds it with a timeout and output cap but does not OS-sandbox the process
 
 ---
 
@@ -41,7 +45,7 @@ sequenceDiagram
     participant Plugin as pacto-plugin-helm
 
     User->>Pacto: pacto generate helm pacto.yaml
-    Pacto->>Pacto: Load and validate contract
+    Pacto->>Pacto: Load and parse contract
     Pacto->>Plugin: Spawn process, write JSON to stdin
     Plugin->>Plugin: Read contract, generate files
     Plugin->>Pacto: Write JSON response to stdout
@@ -50,7 +54,7 @@ sequenceDiagram
 ```
 
 1. The user runs `pacto generate <plugin-name> [path]`
-2. Pacto loads and validates the contract
+2. Pacto loads and parses the contract
 3. Pacto finds the plugin binary (`pacto-plugin-<name>`)
 4. Pacto writes a `GenerateRequest` JSON to the plugin's stdin
 5. The plugin reads the request, generates artifacts, and writes a `GenerateResponse` JSON to stdout
@@ -81,7 +85,7 @@ Pacto writes a JSON object to the plugin's stdin:
 {
   "protocolVersion": "1",
   "contract": {
-    "pactoVersion": "1.0",
+    "pactoVersion": "1.2",
     "service": {
       "name": "my-service",
       "version": "1.0.0"
@@ -102,11 +106,11 @@ Pacto writes a JSON object to the plugin's stdin:
 |-------|------|-------------|
 | `protocolVersion` | string | Always `"1"` for the current protocol |
 | `contract` | object | The full parsed contract (same structure as `pacto.yaml`) |
-| `bundleDir` | string | Absolute path to the bundle directory (read-only) |
+| `bundleDir` | string | Absolute path to the bundle directory. Treat as read-only (for local contracts this is the real bundle directory; Pacto does not enforce read-only). |
 | `outputDir` | string | Absolute path where output files should go |
 | `options` | object | User-provided key-value options (from CLI flags) |
 
-The contract object contains everything from `pacto.yaml` — runtime semantics, interfaces, dependencies, scaling. Your plugin can use any combination of these fields to generate artifacts.
+The contract object mirrors `pacto.yaml` exactly.
 
 ### Response (stdout)
 
@@ -137,7 +141,7 @@ The plugin writes a JSON object to stdout:
 
 #### Path safety
 
-`files[].path` must be a **relative path that stays within the output directory**. Pacto rejects any path that escapes it — absolute paths and paths containing `..` are refused. Always return relative paths scoped to `outputDir`.
+`files[].path` must be a relative path within the output directory. Absolute paths and paths containing `..` are rejected. Always return clean relative paths.
 
 ### Errors
 
@@ -203,82 +207,6 @@ pacto generate readme my-service
 
 ---
 
-## Example: Plugin in Go
-
-```go
-package main
-
-import (
-    "encoding/json"
-    "fmt"
-    "os"
-)
-
-type Contract struct {
-    Service struct {
-        Name    string `json:"name"`
-        Version string `json:"version"`
-    } `json:"service"`
-    Runtime struct {
-        Workload string `json:"workload"`
-        State struct {
-            Type string `json:"type"`
-        } `json:"state"`
-    } `json:"runtime"`
-}
-
-type Request struct {
-    ProtocolVersion string   `json:"protocolVersion"`
-    Contract        Contract `json:"contract"`
-    BundleDir       string   `json:"bundleDir"`
-    OutputDir       string   `json:"outputDir"`
-    Options         map[string]any `json:"options"`
-}
-
-type File struct {
-    Path    string `json:"path"`
-    Content string `json:"content"`
-}
-
-type Response struct {
-    Files   []File `json:"files"`
-    Message string `json:"message,omitempty"`
-}
-
-func main() {
-    var req Request
-    if err := json.NewDecoder(os.Stdin).Decode(&req); err != nil {
-        fmt.Fprintf(os.Stderr, "failed to read request: %v\n", err)
-        os.Exit(1)
-    }
-
-    content := fmt.Sprintf("# %s v%s\nWorkload: %s\nState: %s\n",
-        req.Contract.Service.Name,
-        req.Contract.Service.Version,
-        req.Contract.Runtime.Workload,
-        req.Contract.Runtime.State.Type,
-    )
-
-    resp := Response{
-        Files: []File{
-            {Path: "README.md", Content: content},
-        },
-        Message: fmt.Sprintf("Generated README for %s", req.Contract.Service.Name),
-    }
-
-    json.NewEncoder(os.Stdout).Encode(resp)
-}
-```
-
-Build and install:
-
-```bash
-go build -o pacto-plugin-readme .
-mv pacto-plugin-readme /usr/local/bin/
-```
-
----
-
 ## Example: Plugin in Python
 
 ```python
@@ -333,8 +261,6 @@ if __name__ == "__main__":
 
 - **Read only from `bundleDir`.** Don't access files outside the bundle.
 - **Write only to stdout.** Don't write files directly; return them in the response. Pacto handles file creation.
-- **Return relative paths within the output dir.** Pacto rejects file paths that escape the output directory (no `..`, no absolute paths).
-- **Use stderr for errors.** Anything on stderr is shown to the user on failure.
-- **Exit non-zero on failure.** Pacto checks the exit code.
+- **Follow the protocol.** Return clean relative paths, write errors to stderr and exit non-zero on failure — see [Path safety](#path-safety) and [Errors](#errors) above for what Pacto enforces.
 - **Be deterministic.** Given the same input, produce the same output.
 - **Handle missing optional fields.** Not all contracts have `runtime`, `configurations`, `dependencies`, `scaling`, etc.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,7 +26,9 @@ Created my-service/
   my-service/configuration/
 ```
 
-This scaffolds a bundle with a valid contract, a placeholder OpenAPI spec, and a configuration JSON Schema. Only `pacto.yaml` is required — the `interfaces/` and `configuration/` directories are optional conveniences that you can remove if your service doesn't need them.
+This scaffolds a bundle with a valid contract, a placeholder OpenAPI spec and a configuration JSON Schema. Only `pacto.yaml` is required — if your service doesn't use them, remove the `interfaces/` and `configuration/` directories along with the `interfaces:`/`configurations:` sections that reference them in `pacto.yaml` (deleting the directories alone breaks validation).
+
+These are standard formats — OpenAPI for interfaces, JSON Schema for configuration — so you can drop in the interface files you already own (for example your Helm chart's `values.schema.json`) instead of authoring new ones. Pacto composes the interfaces you already have rather than inventing a config language.
 
 ## 3. Validate
 
@@ -35,7 +37,7 @@ $ pacto validate my-service
 my-service is valid
 ```
 
-Validation runs four layers: structural (JSON Schema), cross-field (references and consistency), semantic (strategy checks), and policy enforcement. The generated contract passes all four out of the box.
+Validation runs four layers — structural, cross-field, semantic and policy enforcement. See the [Contract Reference](contract-reference.md#validation-layers) for the full rules.
 
 ## 4. Customize your contract
 
@@ -115,7 +117,7 @@ $ pacto pull oci://ghcr.io/your-org/my-service-pacto:1.0.0
 # Human-readable summary
 $ pacto explain my-service
 Service: my-service@1.0.0
-Owner: backend (team)
+Owner: backend
 Pacto Version: 1.2
 
 Runtime:

--- a/internal/app/generate.go
+++ b/internal/app/generate.go
@@ -85,6 +85,9 @@ func (s *Service) Generate(ctx context.Context, opts GenerateOptions) (*Generate
 		return nil, fmt.Errorf("failed to resolve output directory: %w", err)
 	}
 	for _, f := range resp.Files {
+		if filepath.IsAbs(f.Path) {
+			return nil, fmt.Errorf("plugin file path %q must be relative", f.Path)
+		}
 		outPath := filepath.Join(absOutput, f.Path)
 		if rel, relErr := filepath.Rel(absOutput, outPath); relErr != nil || strings.HasPrefix(rel, "..") {
 			return nil, fmt.Errorf("plugin file path %q escapes output directory", f.Path)

--- a/internal/app/generate.go
+++ b/internal/app/generate.go
@@ -85,21 +85,8 @@ func (s *Service) Generate(ctx context.Context, opts GenerateOptions) (*Generate
 		return nil, fmt.Errorf("failed to resolve output directory: %w", err)
 	}
 	for _, f := range resp.Files {
-		if filepath.IsAbs(f.Path) {
-			return nil, fmt.Errorf("plugin file path %q must be relative", f.Path)
-		}
-		outPath := filepath.Join(absOutput, f.Path)
-		if rel, relErr := filepath.Rel(absOutput, outPath); relErr != nil || strings.HasPrefix(rel, "..") {
-			return nil, fmt.Errorf("plugin file path %q escapes output directory", f.Path)
-		}
-		if strings.Contains(f.Path, "..") {
-			return nil, fmt.Errorf("plugin file path %q contains path traversal", f.Path)
-		}
-		if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
-			return nil, fmt.Errorf("failed to create directory for %s: %w", f.Path, err)
-		}
-		if err := writeFileFn(outPath, []byte(f.Content), 0644); err != nil {
-			return nil, fmt.Errorf("failed to write %s: %w", f.Path, err)
+		if err := writeGeneratedFile(absOutput, f); err != nil {
+			return nil, err
 		}
 	}
 
@@ -110,6 +97,28 @@ func (s *Service) Generate(ctx context.Context, opts GenerateOptions) (*Generate
 		FilesCount: len(resp.Files),
 		Message:    resp.Message,
 	}, nil
+}
+
+// writeGeneratedFile validates a plugin-returned file path and writes it under
+// absOutput. Paths must be relative and must not escape the output directory.
+func writeGeneratedFile(absOutput string, f plugin.GeneratedFile) error {
+	if filepath.IsAbs(f.Path) {
+		return fmt.Errorf("plugin file path %q must be relative", f.Path)
+	}
+	outPath := filepath.Join(absOutput, f.Path)
+	if rel, relErr := filepath.Rel(absOutput, outPath); relErr != nil || strings.HasPrefix(rel, "..") {
+		return fmt.Errorf("plugin file path %q escapes output directory", f.Path)
+	}
+	if strings.Contains(f.Path, "..") {
+		return fmt.Errorf("plugin file path %q contains path traversal", f.Path)
+	}
+	if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+		return fmt.Errorf("failed to create directory for %s: %w", f.Path, err)
+	}
+	if err := writeFileFn(outPath, []byte(f.Content), 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", f.Path, err)
+	}
+	return nil
 }
 
 // prepareBundleDir returns a directory path containing the bundle files.

--- a/internal/app/generate_test.go
+++ b/internal/app/generate_test.go
@@ -327,3 +327,35 @@ func TestGenerate_MkdirTempError(t *testing.T) {
 		t.Error("expected error when MkdirTemp fails")
 	}
 }
+
+// TestGenerate_AbsolutePluginPathRejected proves an absolute plugin file path is
+// refused outright rather than silently re-rooted under the output directory.
+func TestGenerate_AbsolutePluginPathRejected(t *testing.T) {
+	bundleDir := writeTestBundle(t)
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "gen-output")
+
+	runner := &mockPluginRunner{
+		RunFn: func(_ context.Context, _ string, _ plugin.GenerateRequest) (*plugin.GenerateResponse, error) {
+			return &plugin.GenerateResponse{
+				Files: []plugin.GeneratedFile{{Path: "/etc/pwned.txt", Content: "pwned"}},
+			}, nil
+		},
+	}
+
+	svc := NewService(nil, runner)
+	_, err := svc.Generate(context.Background(), GenerateOptions{
+		Path:      bundleDir,
+		OutputDir: outputDir,
+		Plugin:    "bad-plugin",
+	})
+	if err == nil {
+		t.Fatal("expected error for absolute plugin path")
+	}
+	if !strings.Contains(err.Error(), "must be relative") {
+		t.Errorf("expected 'must be relative' error, got: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outputDir, "etc", "pwned.txt")); statErr == nil {
+		t.Error("absolute path was re-rooted and written under the output dir")
+	}
+}

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -36,7 +36,7 @@ Each positional argument is a pacto source reference:
 When no arguments are given, sources are auto-detected:
   - local: enabled if pacto.yaml is found in the working directory
   - k8s:   enabled if a valid kubeconfig is found and the cluster is reachable
-  - oci:   auto-discovered from K8s resolvedRefs, or via PACTO_DASHBOARD_REPO env var
+  - oci:   auto-discovered from K8s status.contract.resolvedRef, or via PACTO_DASHBOARD_REPO env var
 
 Materialized bundles on disk (~/.cache/pacto/oci) are used internally by the
 OCI source to enrich version data (hash, classification, timestamps) without
@@ -44,7 +44,7 @@ appearing as a separate source. The --no-cache flag skips pre-existing cache
 at startup but still allows same-session materialization (e.g. fetch-all-versions).
 
 When running alongside the Kubernetes operator, OCI repositories are automatically
-discovered from the resolvedRef fields of Pacto CRD resources. This provides full
+discovered from the status.contract.resolvedRef fields of Pacto CRD resources. This provides full
 contract bundles, version history, interfaces, and diffs — without needing
 explicit OCI arguments. The result is a hybrid view: runtime truth from the
 operator combined with contract truth from OCI.

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -29,7 +29,7 @@ func newLockCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 			sp, count := startSpinnerCounted(cmd, format, "Resolving lock")
 			result, err := svc.Lock(cmd.Context(), app.LockOptions{
 				Path:        optionalArg(args),
-				Update:      update || len(names) > 0,
+				Update:      update,
 				UpdateNames: names,
 				Check:       check,
 				Overrides:   getOverrides(cmd),
@@ -48,7 +48,7 @@ func newLockCommand(svc *app.Service, v *viper.Viper) *cobra.Command {
 		},
 	}
 	cmd.Flags().Bool("update", false, "re-resolve dependencies to the newest version within their constraint")
-	cmd.Flags().StringArray("update-name", nil, "only update the named dependency (repeatable; implies --update)")
+	cmd.Flags().StringArray("update-name", nil, "re-resolve only the named dependency, preserving all other pins (repeatable)")
 	cmd.Flags().Bool("check", false, "verify pacto.lock is up to date without writing (non-zero exit on drift)")
 	addOverrideFlags(cmd)
 	return cmd

--- a/internal/cli/lock_test.go
+++ b/internal/cli/lock_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/trianalab/pacto/v2/internal/cli"
 	"github.com/trianalab/pacto/v2/internal/testutil"
 	"github.com/trianalab/pacto/v2/pkg/contract"
+	"github.com/trianalab/pacto/v2/pkg/lock"
 )
 
 func TestLockCommandWritesFile(t *testing.T) {
@@ -231,5 +232,68 @@ func TestLockCommandUpToDate(t *testing.T) {
 
 	if !strings.Contains(out.String(), "up to date") {
 		t.Errorf("expected 'up to date' in output, got %q", out.String())
+	}
+}
+
+// TestLockCommandUpdateNameSelective proves `--update-name X` re-resolves only the
+// named dependency and preserves every other pin — it must NOT re-pin the whole
+// closure the way `--update` does.
+func TestLockCommandUpdateNameSelective(t *testing.T) {
+	dir := t.TempDir()
+	yaml := "pactoVersion: \"1.0\"\nservice:\n  name: root\n  version: \"2.1.0\"\ndependencies:\n  - name: auth\n    ref: oci://ghcr.io/acme/auth\n    compatibility: ^1.0.0\n  - name: db\n    ref: oci://ghcr.io/acme/db\n    compatibility: ^1.0.0\n"
+	if err := os.WriteFile(filepath.Join(dir, "pacto.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	authDigest, dbDigest := "sha256:auth-v1", "sha256:db-v1"
+	store := &testutil.MockBundleStore{
+		ListTagsFn: func(_ context.Context, _ string) ([]string, error) { return []string{"1.2.0"}, nil },
+		ResolveFn: func(_ context.Context, ref string) (string, error) {
+			if strings.Contains(ref, "/auth") {
+				return authDigest, nil
+			}
+			return dbDigest, nil
+		},
+		PullFn: func(_ context.Context, ref string) (*contract.Bundle, error) {
+			name := "db"
+			if strings.Contains(ref, "/auth") {
+				name = "auth"
+			}
+			return &contract.Bundle{Contract: &contract.Contract{PactoVersion: "1.0", Service: contract.ServiceIdentity{Name: name, Version: "1.2.0"}}}, nil
+		},
+	}
+	svc := app.NewService(store, nil)
+
+	// Initial lock: both deps pinned at v1.
+	root1 := cli.NewRootCommand(svc, cli.VersionInfo{Version: "test"})
+	root1.SetArgs([]string{"lock", dir})
+	root1.SetOut(&bytes.Buffer{})
+	if err := root1.Execute(); err != nil {
+		t.Fatalf("initial lock: %v", err)
+	}
+
+	// Registry drifts: both deps now serve v2.
+	authDigest, dbDigest = "sha256:auth-v2", "sha256:db-v2"
+
+	// Selectively update only auth.
+	root2 := cli.NewRootCommand(svc, cli.VersionInfo{Version: "test"})
+	root2.SetArgs([]string{"lock", "--update-name", "auth", dir})
+	root2.SetOut(&bytes.Buffer{})
+	if err := root2.Execute(); err != nil {
+		t.Fatalf("lock --update-name: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "pacto.lock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	l, err := lock.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e, ok := l.Dependency("auth"); !ok || e.Digest != "sha256:auth-v2" {
+		t.Errorf("auth should be repinned to v2, got %+v", e)
+	}
+	if e, ok := l.Dependency("db"); !ok || e.Digest != "sha256:db-v1" {
+		t.Errorf("db pin should be preserved at v1, got %+v", e)
 	}
 }


### PR DESCRIPTION
## What & why
Reframes the docs around a two-layer story and runs a full accuracy + de-duplication pass over the whole documentation set, aiming for Kubernetes-docs quality.

**Framing** — lead with the operational contract (the differentiator), introduce interface *composition* as the on-ramp:
> JSON Schema describes an interface; Pacto describes the relationships between interfaces and how they change over time.
