### PR TITLE
fix(ci): tolerate GHA build-cache export failures in docker-build

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -203,7 +203,9 @@ jobs:
           platforms: ${{ matrix.platform }}
           tags: ghcr.io/trianalab/pacto-dashboard:${{ steps.meta.outputs.version }}
           cache-from: type=gha,scope=${{ matrix.platform }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          # ignore-error keeps a flaky/unavailable GHA build cache from failing the
+          # release: the image still builds and pushes, only the cache export is skipped.
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }},ignore-error=true
           build-args: |
             VERSION=${{ needs.release.outputs.tag }}
             GIT_COMMIT=${{ github.sha }}


### PR DESCRIPTION
## Problem
The post-merge **Auto release** run for #217 failed at `docker-build` → *"error writing layer blob: failed to reserve cache"*.

The image **builds and pushes successfully** (`pushing manifest for ghcr.io/trianalab/pacto-dashboard:2.3.1 ... done`); the job fails only on the `cache-to: type=gha` **build-cache export**. That's a known-flaky GitHub Actions cache backend (aggravated by today's GitHub outage). One arch's failure then cancels the other (matrix fail-fast) and skips `docker-merge`.

This is a latent workflow bug, not related to the merged content — `docker-build` only runs on release-triggering merges, and dependabot `chore(deps)` merges skip the release, so this path hadn't been exercised in a while.

## Fix
Add `ignore-error=true` to `cache-to`, so a cache-export hiccup is skipped rather than failing the release. The image build + push are unaffected.
