### PR TITLE
docs(readme): compare against the platform-engineering tier and harden the never-deploys non-goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **Pacto is to service operations what OpenAPI is to HTTP APIs.**
 
-A service's operational behavior — interfaces, dependencies, runtime semantics, configuration, scaling and readiness — is scattered across Helm values, wikis and dashboards, and drifts from what's actually running. Pacto captures it once in a validated, versioned contract (`pacto.yaml`), distributes it through your existing OCI registry and verifies it against live workloads. It doesn't replace OpenAPI, Helm, Terraform, Backstage or Kubernetes — it adds the operational contract layer between them, composing the interfaces you already own and adding what no single one does: ownership, dependencies, compatibility and readiness over time.
+A service's operational behavior — interfaces, dependencies, runtime semantics, configuration, scaling and readiness — is scattered across Helm values, wikis and dashboards, and drifts from what's actually running. Pacto captures it once in a validated, versioned contract (`pacto.yaml`), distributes it through your existing OCI registry and lets CI catch breaking changes while the operator catches runtime drift. It doesn't replace OpenAPI, Helm, Terraform, Backstage or Kubernetes — it adds the operational contract layer between them, composing the interfaces you already own and adding what no single one does: ownership, dependencies, compatibility and readiness over time.
 
 **[Documentation](https://trianalab.github.io/pacto)** · **[Quickstart](https://trianalab.github.io/pacto/quickstart)** · **[Specification](https://trianalab.github.io/pacto/contract-reference)** · **[Examples](https://trianalab.github.io/pacto/examples)** · **[Live demo](https://trianalab.github.io/pacto/demo/)**
 

--- a/README.md
+++ b/README.md
@@ -151,9 +151,26 @@ See the [documentation](https://trianalab.github.io/pacto) for when to use Pacto
 
 Pacto sits alongside these tools, not on top of them: it composes the interfaces they already produce — your OpenAPI spec, your config schema — and adds the relational and temporal layer no single one owns. The contract becomes the shared source of truth between your API spec, your deployment tooling and your cluster.
 
+### Against platform-engineering tools
+
+The table above covers the interface tools Pacto composes. It gets compared just as often to the platform-engineering tier — the orchestrators, provisioners and portals that *act on* a service. Pacto is not one of them. Its job is four verbs over a single versioned OCI artifact — **diff** (semantic breaking changes), **graph** (transitive blast radius), **enforce** (recursive policy, fail-closed) and **verify** (the same artifact at design-time via the CLI and at runtime via the operator) — and it makes zero deployment decisions.
+
+| | Versioned artifact | Semantic diff | Dependency graph | Transitive policy | Runtime verify | Orchestrator-agnostic | Deploys? |
+|---|---|---|---|---|---|---|---|
+| **Score** | — | — | — | — | — | ✅ | No |
+| **Crossplane Configuration** | ✅ | — | — | — | — | — | Yes |
+| **KubeVela** / OAM | — | — | Partial | — | — | Partial | Yes |
+| **Radius** | — | — | ✅ | — | — | Partial | Yes |
+| **Kratix** | — | — | — | — | — | Partial | Yes |
+| **Backstage** / Port | — | — | Partial | — | — | ✅ | No |
+| **Kargo** | ✅ | — | — | — | — | ✅ | Yes |
+| **Pacto** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | **No** |
+
+✅ first-class · Partial adjacent or limited · — not in scope. A 2026 snapshot, and several of these are complementary rather than competing: a contract can gate a Kargo promotion, feed a Backstage card or front a Crossplane provisioner. The point is the combination — Pacto is the only row that is a versioned, diffable, graph-resolved, policy-enforced and runtime-verified contract that stays orchestrator-agnostic and never deploys.
+
 ### What Pacto is NOT
 
-- Not a deployment tool — it describes services, not how to run them
+- Not a deployment tool — it describes services, not how to run them. It makes zero deployment decisions, which keeps it complementary to deploy engines like KubeVela, Radius and Kratix rather than competing with them
 - Not a service mesh — no sidecars, no traffic interception
 - Not a replacement for OpenAPI or Helm — it complements them
 - Not another configuration language — it composes the schemas you already own instead of inventing one

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@
 
 **Pacto is to service operations what OpenAPI is to HTTP APIs.**
 
-A service's operational behavior — interfaces, dependencies, runtime semantics, configuration, scaling, readiness — is usually scattered across Helm values, wikis, and dashboards, and drifts from what's actually running. Pacto captures it once in a validated, versioned contract (`pacto.yaml`), distributes it through your existing OCI registry, and verifies it against live workloads.
-
-Pacto (/ˈpak.to/ — Spanish for *pact*) is not a replacement for OpenAPI, Helm, Terraform, Backstage, or Kubernetes. It adds the operational contract layer between them. It composes the interfaces you already maintain — an OpenAPI spec, a config JSON Schema — and adds the layer no single interface owns: ownership, dependencies, compatibility and readiness. JSON Schema describes an interface; Pacto describes the relationships between interfaces and how they change over time.
+A service's operational behavior — interfaces, dependencies, runtime semantics, configuration, scaling and readiness — is scattered across Helm values, wikis and dashboards, and drifts from what's actually running. Pacto captures it once in a validated, versioned contract (`pacto.yaml`), distributes it through your existing OCI registry and verifies it against live workloads. It doesn't replace OpenAPI, Helm, Terraform, Backstage or Kubernetes — it adds the operational contract layer between them, composing the interfaces you already own and adding what no single one does: ownership, dependencies, compatibility and readiness over time.
 
 **[Documentation](https://trianalab.github.io/pacto)** · **[Quickstart](https://trianalab.github.io/pacto/quickstart)** · **[Specification](https://trianalab.github.io/pacto/contract-reference)** · **[Examples](https://trianalab.github.io/pacto/examples)** · **[Live demo](https://trianalab.github.io/pacto/demo/)**
 
@@ -19,15 +17,30 @@ Pacto (/ˈpak.to/ — Spanish for *pact*) is not a replacement for OpenAPI, Helm
 
 ---
 
-## Three components
+## Where Pacto fits
 
-| Component | Role | When it runs |
-|-----------|------|--------------|
-| **CLI** | Author, validate, diff, publish contracts | Design-time and CI |
-| **Dashboard** | Explore services, dependency graphs, versions, diffs, readiness, insights | Anytime — local or deployed |
-| **[Operator](https://github.com/TrianaLab/pacto-operator)** | Track contracts in-cluster, link to workloads, verify runtime consistency | Continuously in Kubernetes |
+```mermaid
+flowchart LR
+    DEV([Developer]) --> C
+    OA[OpenAPI spec] -. composed .-> C
+    JS[Config JSON Schema] -. composed .-> C
+    C["📋 pacto.yaml<br/>operational contract"] --> R[(OCI registry)]
+    R --> P["Platforms and tools<br/>CI · Kubernetes · Backstage · Crossplane"]
+```
 
-No sidecars and no central control plane required: the CLI uses your existing OCI registry, the operator watches CRDs and the dashboard merges every source — local, OCI, Kubernetes and cache — into one view.
+Pacto composes the interfaces you already own into one versioned contract, distributes it like a container image and lets whatever runs your services read it instead of reverse-engineering it.
+
+## The three tools
+
+```mermaid
+flowchart LR
+    CLI["CLI · design-time and CI<br/>init · validate · diff · doc · push"] --> R[(OCI registry)]
+    R --> DASH["Dashboard · anytime<br/>graph · ownership · SBOM · readiness · docs"]
+    R --> OP["Operator · in-cluster<br/>track · verify runtime drift"]
+    OP -. runtime state .-> DASH
+```
+
+No sidecars and no central control plane: the CLI uses your existing OCI registry, the [operator](https://github.com/TrianaLab/pacto-operator) watches CRDs and the dashboard merges every source — local, OCI, Kubernetes and cache — into one view.
 
 ---
 
@@ -36,7 +49,7 @@ No sidecars and no central control plane required: the CLI uses your existing OC
 ```bash
 # Author and publish a contract (install is below)
 pacto init my-service && cd my-service       # scaffold a contract bundle
-pacto validate .                             # 4-layer validation, run from inside the new directory
+pacto validate .                             # 4-layer validation
 pacto push oci://ghcr.io/acme/svc-pacto      # tag inferred from service.version
 
 # Catch breaking changes in CI
@@ -46,37 +59,7 @@ pacto diff oci://ghcr.io/acme/svc:1.0 oci://ghcr.io/acme/svc:2.0
 pacto dashboard                              # auto-detects local, OCI and K8s sources
 ```
 
-Full install options are [below](#installation); the [Quickstart](https://trianalab.github.io/pacto/quickstart) goes from zero to a published contract in two minutes.
-
----
-
-## Breaking change detection
-
-Someone bumped the version, moved a port, removed an API endpoint, and dropped a config property. `pacto diff` catches it before the merge:
-
-| Classification | Path | Type | Old | New |
-|---|---|---|---|---|
-| NON_BREAKING | `service.version` | modified | `1.0.0` | `2.0.0` |
-| BREAKING | `interfaces.port` | modified | `8081` | `9090` |
-| BREAKING | `openapi.paths[/predict]` | removed | `/predict` | — |
-| BREAKING | `schema.properties.model_path` | removed | `model_path` | — |
-
-`pacto diff --output-format markdown` emits a similar table (it also includes a Reason column). The exit code is non-zero on breaking changes, so it can gate merges in CI.
-
----
-
-## Dashboard
-
-`pacto dashboard` merges every detected source into one view of your fleet:
-
-- **Fleet overview** — compliance, readiness and high-blast-radius services at a glance
-- **Dependency graph** — interactive service relationships with recursive resolution
-- **Version history and diffs** — every published version from OCI, with classified change diffs
-- **Runtime status** — with the operator, whether deployed services align with their contracts
-
-Ownership views, readiness scoring and per-service details are covered in the [platform engineer guide](https://trianalab.github.io/pacto/platform-engineers). Run it locally, or deploy the [container image](https://trianalab.github.io/pacto/dashboard-docker) alongside the operator for a combined view: runtime state from Kubernetes plus contract data from OCI.
-
----
+The [Quickstart](https://trianalab.github.io/pacto/quickstart) goes from zero to a published contract in two minutes.
 
 ## What a contract captures
 
@@ -95,7 +78,7 @@ interfaces:
     type: http
     port: 8080
     visibility: public
-    contract: interfaces/openapi.yaml
+    contract: interfaces/openapi.yaml   # points at your existing OpenAPI spec
 
 dependencies:
   - name: auth
@@ -104,56 +87,42 @@ dependencies:
     compatibility: "^2.0.0"
 ```
 
-Only `pactoVersion` and `service` are required — everything else (runtime semantics, scaling, configuration, policies and readiness) is opt-in, so a contract can be as minimal or as detailed as your service needs. `pacto init` scaffolds a `1.2` contract; use `1.0` or `1.1` for contracts without readiness (object-only `owner` is enforced across all versions). See the [Contract Reference](https://trianalab.github.io/pacto/contract-reference) for the full field-by-field schema.
-
-Each interface's `contract` field points at a schema you already own — the `interfaces/openapi.yaml` above is your OpenAPI spec, not a Pacto rewrite — so a contract composes your existing interfaces rather than redefining them.
+Only `pactoVersion` and `service` are required — everything else (runtime semantics, scaling, configuration, policies and readiness) is opt-in. Each interface's `contract` points at a schema you already own, so a contract composes your interfaces rather than redefining them. See the [Contract Reference](https://trianalab.github.io/pacto/contract-reference) for the full schema.
 
 ---
 
-## Capabilities
+## What you get
 
-Beyond the diff, dashboard and runtime verification shown above:
+Bump a version, move a port, remove an endpoint, drop a config property — `pacto diff` classifies it and fails CI before the merge:
 
-- **Lockfiles** — reproducible dependency resolution and supply-chain pinning via `pacto.lock`
-- **Packaging ignore** — gitignore-style `.pactoignore` to exclude files from bundles
-- **OCI distribution** — push/pull to GHCR, ECR, ACR, Docker Hub and Harbor with local caching; signable with cosign or Notary; no custom registry required
-- **Plugin-based generation** — out-of-process plugins produce deployment artifacts from contracts
-- **AI integration** — `pacto mcp` exposes contract operations as [MCP](https://modelcontextprotocol.io) tools for Claude, Cursor and Copilot
-- **SBOM diffing** — SPDX / CycloneDX package-level change detection
+```console
+$ pacto diff oci://ghcr.io/acme/svc:1.0 oci://ghcr.io/acme/svc:2.0
+NON_BREAKING  service.version               1.0.0 → 2.0.0
+BREAKING      interfaces.port               8081 → 9090
+BREAKING      openapi.paths[/predict]       removed
+BREAKING      schema.properties.model_path  removed
+exit status 1                                # non-zero gates the merge
+```
 
-See the [documentation](https://trianalab.github.io/pacto) for details on each.
+Everything a contract enables, from one artifact:
 
----
+- **Dependency graph** — transitive service relationships and blast radius, recursively resolved
+- **Ownership registry** — every service by team and DRI, with per-owner compliance and readiness
+- **SBOM inventory** — SPDX / CycloneDX package inventory and package-level diffs across versions
+- **Operational docs** — `pacto doc` renders Markdown, an offline dashboard-grade HTML site or an interactive Swagger/Scalar API explorer
+- **Readiness scoring** — operational-readiness assessment per service, surfaced in the fleet view
+- **Runtime verification** — with the [operator](https://github.com/TrianaLab/pacto-operator), whether deployed workloads still match their contract
+- **OCI distribution** — push/pull to GHCR, ECR, ACR, Docker Hub and Harbor with local caching; signable with cosign or Notary
+- **Reproducibility and supply chain** — `pacto.lock` for pinned resolution, gitignore-style `.pactoignore` for packaging
+- **Extensibility** — out-of-process plugins generate deployment artifacts; `pacto mcp` exposes contract operations to Claude, Cursor and Copilot
 
-## Who is it for?
-
-- **Application developers** — describe a service once; validation catches misconfigurations before CI and breaking changes are detected automatically across versions.
-- **Platform engineers** — consume contracts to generate manifests, enforce policies and visualize dependency graphs, with a live view of every service in the dashboard.
-- **DevOps / infrastructure teams** — distribute contracts through existing OCI registries; the operator tracks what's deployed and whether it matches its contract.
-
-See the [documentation](https://trianalab.github.io/pacto) for when to use Pacto and per-audience guides.
+The dashboard merges local, OCI and Kubernetes sources into one fleet view; deploy the [container image](https://trianalab.github.io/pacto/dashboard-docker) alongside the operator to combine runtime state with contract data.
 
 ---
 
 ## How Pacto compares
 
-| Concern | OpenAPI | Helm | Terraform | Backstage | Pacto |
-|---------|---------|------|-----------|-----------|-------|
-| API contract | ✅ | — | — | — | ✅ |
-| Runtime semantics (state, health, lifecycle) | — | Partial | — | — | ✅ |
-| Typed dependencies with version constraints | — | — | — | — | ✅ |
-| Configuration schema | — | Partial | — | — | ✅ |
-| Breaking change detection | — | — | — | — | ✅ |
-| Dependency graph visualization | — | — | — | — | ✅ |
-| Runtime consistency verification | — | — | — | — | ✅ |
-| OCI-native distribution | — | ✅ | — | — | ✅ |
-| Machine validation | ✅ | — | ✅ | — | ✅ |
-
-Pacto sits alongside these tools, not on top of them: it composes the interfaces they already produce — your OpenAPI spec, your config schema — and adds the relational and temporal layer no single one owns. The contract becomes the shared source of truth between your API spec, your deployment tooling and your cluster.
-
-### Against platform-engineering tools
-
-The table above covers the interface tools Pacto composes. It gets compared just as often to the platform-engineering tier — the orchestrators, provisioners and portals that *act on* a service. Pacto is not one of them. Its job is four verbs over a single versioned OCI artifact — **diff** (semantic breaking changes), **graph** (transitive blast radius), **enforce** (recursive policy, fail-closed) and **verify** (the same artifact at design-time via the CLI and at runtime via the operator) — and it makes zero deployment decisions.
+Pacto composes the interface tools it sits between (OpenAPI, config schemas) and complements deploy tools (Helm, Terraform). It gets compared just as often to the platform-engineering tier — the orchestrators, provisioners and portals that *act on* a service. Pacto is not one of them: its job is four verbs over a single versioned OCI artifact — **diff** (semantic breaking changes), **graph** (transitive blast radius), **enforce** (recursive policy, fail-closed) and **verify** (the same artifact at design-time via the CLI and at runtime via the operator) — while making zero deployment decisions.
 
 | | Versioned artifact | Semantic diff | Dependency graph | Transitive policy | Runtime verify | Orchestrator-agnostic | Deploys? |
 |---|---|---|---|---|---|---|---|
@@ -168,13 +137,12 @@ The table above covers the interface tools Pacto composes. It gets compared just
 
 ✅ first-class · Partial adjacent or limited · — not in scope. A 2026 snapshot, and several of these are complementary rather than competing: a contract can gate a Kargo promotion, feed a Backstage card or front a Crossplane provisioner. The point is the combination — Pacto is the only row that is a versioned, diffable, graph-resolved, policy-enforced and runtime-verified contract that stays orchestrator-agnostic and never deploys.
 
-### What Pacto is NOT
+**What Pacto is NOT:**
 
-- Not a deployment tool — it describes services, not how to run them. It makes zero deployment decisions, which keeps it complementary to deploy engines like KubeVela, Radius and Kratix rather than competing with them
+- Not a deployment tool — it describes services, not how to run them, and makes zero deployment decisions, which keeps it complementary to deploy engines like KubeVela, Radius and Kratix rather than competing with them
 - Not a service mesh — no sidecars, no traffic interception
-- Not a replacement for OpenAPI or Helm — it complements them
-- Not another configuration language — it composes the schemas you already own instead of inventing one
-- Not a service catalog — the dashboard can feed data into one
+- Not a service catalog or portal — the dashboard renders ownership, SBOM and readiness *from* contracts and runtime; it feeds Backstage/Port, it doesn't replace them
+- Not another configuration language — it composes the schemas you already own
 
 See [MANIFEST.md](MANIFEST.md) for the full rationale.
 
@@ -193,8 +161,6 @@ go install github.com/trianalab/pacto/v2/cmd/pacto@latest
 git clone https://github.com/TrianaLab/pacto.git && cd pacto && make build
 ```
 
----
-
 ## Documentation
 
 Full documentation at **[trianalab.github.io/pacto](https://trianalab.github.io/pacto)**.
@@ -202,16 +168,15 @@ Full documentation at **[trianalab.github.io/pacto](https://trianalab.github.io/
 | Guide | Description |
 |-------|-------------|
 | [Quickstart](https://trianalab.github.io/pacto/quickstart) | From zero to a published contract in 2 minutes |
-| [Contract Reference](https://trianalab.github.io/pacto/contract-reference) | Every field, validation rule, and change classification |
+| [Contract Reference](https://trianalab.github.io/pacto/contract-reference) | Every field, validation rule and change classification |
 | [For Developers](https://trianalab.github.io/pacto/developers) | Write and maintain contracts alongside your code |
-| [For Platform Engineers](https://trianalab.github.io/pacto/platform-engineers) | Consume contracts for deployment, policies, and graphs |
-| [CLI Reference](https://trianalab.github.io/pacto/cli-reference) | All commands, flags, and output formats |
+| [For Platform Engineers](https://trianalab.github.io/pacto/platform-engineers) | Consume contracts for deployment, policies and graphs |
+| [CLI Reference](https://trianalab.github.io/pacto/cli-reference) | All commands, flags and output formats |
 | [Dashboard](https://trianalab.github.io/pacto/dashboard-docker) | Deploy the dashboard container alongside the operator |
 | [Kubernetes Operator](https://trianalab.github.io/pacto/operator) | Runtime contract tracking and consistency verification |
 | [MCP Integration](https://trianalab.github.io/pacto/mcp-integration) | Connect AI tools (Claude, Cursor, Copilot) to Pacto via MCP |
 | [Plugin Development](https://trianalab.github.io/pacto/plugins) | Build plugins to generate artifacts from contracts |
-| [Examples](https://trianalab.github.io/pacto/examples) | PostgreSQL, Redis, RabbitMQ, NGINX, gRPC, and more |
-| [Architecture](https://trianalab.github.io/pacto/architecture) | Internal design for contributors |
+| [Examples](https://trianalab.github.io/pacto/examples) | PostgreSQL, Redis, RabbitMQ, NGINX, gRPC and more |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **Pacto is to service operations what OpenAPI is to HTTP APIs.**
 
-A service's operational behavior — interfaces, dependencies, runtime semantics, configuration, scaling and readiness — is scattered across Helm values, wikis and dashboards, and drifts from what's actually running. Pacto captures it once in a validated, versioned contract (`pacto.yaml`), distributes it through your existing OCI registry and lets CI catch breaking changes while the operator catches runtime drift. It doesn't replace OpenAPI, Helm, Terraform, Backstage or Kubernetes — it adds the operational contract layer between them, composing the interfaces you already own and adding what no single one does: ownership, dependencies, compatibility and readiness over time.
+A service's operational behavior — interfaces, dependencies, runtime semantics, configuration, scaling and readiness — is scattered across Helm values, wikis and dashboards, and drifts from what's actually running. Pacto captures it once in a validated, versioned contract (`pacto.yaml`), distributes it through your existing OCI registry and lets `pacto diff` catch breaking changes while the operator catches runtime drift. It doesn't replace OpenAPI, Helm, Terraform, Backstage or Kubernetes — it adds the operational contract layer between them, composing the interfaces you already own and adding what no single one does: ownership, dependencies, compatibility and readiness over time.
 
 **[Documentation](https://trianalab.github.io/pacto)** · **[Quickstart](https://trianalab.github.io/pacto/quickstart)** · **[Specification](https://trianalab.github.io/pacto/contract-reference)** · **[Examples](https://trianalab.github.io/pacto/examples)** · **[Live demo](https://trianalab.github.io/pacto/demo/)**
 


### PR DESCRIPTION
## What

Adds a second comparison table to the README that positions Pacto against the **platform-engineering tier** — Score, Crossplane Configuration, KubeVela/OAM, Radius, Kratix, Backstage/Port and Kargo — and hardens the "not a deployment tool" non-goal into an explicit invariant.

## Why

The existing "How Pacto compares" table covers the *interface* tier Pacto composes (OpenAPI, Helm, Terraform, Backstage). It doesn't answer the question platform engineers actually ask: "isn't this just Score / KubeVela / Radius / a Crossplane Configuration package?"

The new matrix makes the differentiated cell explicit via four verbs over one OCI artifact — **diff**, **graph**, **enforce**, **verify**. Pacto is the only row that is a versioned, diffable, graph-resolved, policy-enforced and runtime-verified contract that stays orchestrator-agnostic and **makes zero deployment decisions**. That last property — never deploys — is what keeps Pacto complementary to the deploy engines rather than competing with them, so it is now codified in the non-goals.

Docs-only change. The table is labelled a 2026 snapshot with a first-class / adjacent / not-in-scope legend and notes that several of the listed tools are complementary.
