### PR TITLE
docs: subtle page-transition animation for instant navigation

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -349,3 +349,22 @@
 [data-md-color-scheme="slate"] .mermaid text.actor {
     fill: var(--md-default-fg-color) !important;
 }
+
+/* ---- Page-navigation motion ------------------------------------------------
+   navigation.instant (mkdocs.yml) swaps pages client-side with no full reload; these
+   add a clean, subtle transition on top. The main content gently fades/rises in on each
+   page render, and — where the browser + Material support the View Transitions API — the
+   root cross-fade is tuned. Both are disabled under prefers-reduced-motion. */
+@media (prefers-reduced-motion: no-preference) {
+  .md-content__inner {
+    animation: pacto-page-in 0.28s ease both;
+  }
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation-duration: 0.28s;
+  }
+}
+@keyframes pacto-page-in {
+  from { opacity: 0; transform: translateY(0.5rem); }
+  to   { opacity: 1; transform: none; }
+}


### PR DESCRIPTION
`navigation.instant` (already enabled in mkdocs.yml) swaps pages client-side with no full reload. This layers a clean, subtle transition on top:

- Main content gently fades/rises in on each page render (`pacto-page-in`).
- Where the browser + Material support the View Transitions API, the root cross-fade duration is tuned to match.
- Both disabled under `prefers-reduced-motion`; opacity/transform only.

CSS only — no mkdocs.yml change needed (instant nav was already on).
