### PR TITLE
docs(demo): serve WASM dashboard demo from a domain-agnostic relative base

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,7 +59,7 @@ jobs:
       # than silently shipping. Same gate the PR "Docs check" runs.
       - run: mkdocs build --strict
       # Build the in-browser (WebAssembly) dashboard demo and fold it into the
-      # same Pages artifact at /pacto/demo/ (two Pages deploys in one repo
+      # same Pages artifact at /demo/ (two Pages deploys in one repo
       # conflict; one upload below publishes both docs and demo).
       - uses: actions/setup-go@v7
         with:
@@ -68,7 +68,7 @@ jobs:
         with:
           node-version: '22'
       - name: Build the WASM dashboard demo
-        run: make -C examples/demo build BASE=/pacto/demo/
+        run: make -C examples/demo build
       - name: Smoke test the wasm engine
         run: make -C examples/demo smoke
       # Guardrail: on a release-driven deploy the baked navbar version MUST match

--- a/Makefile
+++ b/Makefile
@@ -43,16 +43,16 @@ gen-cli-docs:
 # Documentation (MkDocs Material). Install via `brew install mkdocs-material`
 # or `pip install -r docs/requirements.txt`. Both targets first build the
 # in-browser WASM demo into docs/demo/ so the local preview exposes it, mirroring
-# the deployed site. mkdocs honors site_url, so it serves under /pacto/ locally
-# and the demo lives at /pacto/demo/ both locally and in production.
+# the deployed site. mkdocs honors site_url, so it serves at root locally
+# and the demo lives at /demo/ both locally and in production.
 docs: $(DOCS_DEMO)/app.wasm
 	mkdocs serve
 
 docs-build: $(DOCS_DEMO)/app.wasm
 	mkdocs build
 
-# Build the WASM dashboard demo into docs/demo/ (gitignored) at the same base as
-# production (/pacto/demo/) so `mkdocs serve`/`build` serve it correctly. Rebuilt
+# Build the WASM dashboard demo into docs/demo/ (gitignored) with a relative
+# asset base, so `mkdocs serve`/`build` serve it correctly at any mount. Rebuilt
 # when missing OR when any demo source changes (dashboard frontend, demo bundles,
 # demo Go/boot glue) so `make docs` always reflects the current source. Force a
 # full refresh with `make demo-preview-clean`.
@@ -60,7 +60,7 @@ DEMO_SOURCES := $(shell find pkg/dashboard/frontend/src examples/demo/bundles -t
 	$(wildcard examples/demo/*.go) examples/demo/boot.js examples/demo/Makefile \
 	pkg/dashboard/frontend/package.json pkg/dashboard/frontend/package-lock.json
 $(DOCS_DEMO)/app.wasm: $(DEMO_SOURCES)
-	$(MAKE) -C examples/demo build BASE=/pacto/demo/ DIST=$(CURDIR)/$(DOCS_DEMO)
+	$(MAKE) -C examples/demo build DIST=$(CURDIR)/$(DOCS_DEMO)
 
 demo-preview-clean:
 	rm -rf $(DOCS_DEMO)

--- a/examples/demo/Makefile
+++ b/examples/demo/Makefile
@@ -4,15 +4,18 @@
 # dashboard UI rebuilt for the target base path, and the glue that routes the
 # UI's API calls into wasm. No backend, no live OCI.
 #
-#   make build                 # build at the default base (/pacto/demo/)
-#   make build BASE=/          # build at site root (local preview)
-#   make serve                 # preview at the project base path
+# Assets are referenced with a RELATIVE base (./), so the built site works at
+# any mount point (root, /demo/, /pacto/demo/, …) with no domain assumptions.
+# Override BASE only if you need absolute asset URLs for a specific deploy.
+#
+#   make build                 # relative base (works anywhere)
+#   make serve                 # preview locally
 #
 # Bundles live in ./bundles and are embedded directly (no copy step). The UI is
 # built from this repo's frontend source into a scratch dir and copied into
 # $(DIST) — the committed pkg/dashboard/ui build is never touched.
 
-BASE        ?= /pacto/demo/
+BASE        ?= ./
 DIST        ?= dist
 GOROOT      := $(shell go env GOROOT)
 SERVE_PORT  ?= 8088

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Pacto
 site_description: An open, OCI-distributed contract standard for cloud-native services.
-site_url: https://trianalab.github.io/pacto/
+site_url: https://pacto.run/
 repo_url: https://github.com/TrianaLab/pacto
 repo_name: TrianaLab/pacto
 edit_uri: edit/main/docs/


### PR DESCRIPTION
## Problem

After the docs site moved from `trianalab.github.io/pacto/` (served under the `/pacto/` subpath) to the custom domain **pacto.run** (served at root `/`), the live in-browser WASM dashboard demo stopped loading.

The demo was Vite-built with an **absolute base** (`--base=/pacto/demo/`), so its `index.html` requested the JS/CSS bundles, `wasm_exec.js`, `boot.js` and the `.wasm` from `/pacto/demo/...`. Under `pacto.run` those paths 404, so the engine never loaded. Docs pages kept working because mkdocs uses relative inter-page links.
