### PR TITLE
fix(release): recognize the changesets Version PR in CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,10 @@ jobs:
 
   ci-oci:
     needs: changes
+    # The changesets Version PR commits a ready release-transaction.json (by design);
+    # the "committed transaction releases nothing" invariant is a feature-PR check, so
+    # skip it there. Skipped != failure, so the `required` aggregate stays green.
+    if: ${{ !startsWith(github.head_ref, 'changeset-release/') }}
     runs-on: ubuntu-latest
     services:
       registry:
@@ -199,7 +203,9 @@ jobs:
 
   release-dry-run:
     needs: changes
-    if: needs.changes.outputs.e2e == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    # Skip on the changesets Version PR: its changesets are already consumed, so the
+    # dry-run's "pending bump" scenarios do not apply (feature-PR / main gate only).
+    if: (needs.changes.outputs.e2e == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && !startsWith(github.head_ref, 'changeset-release/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -257,7 +263,9 @@ jobs:
   # throwaway clone with pending changesets -> ready transaction detect.mjs acts on.
   release-version-test:
     needs: changes
-    if: needs.changes.outputs.release == 'true'
+    # Skip on the changesets Version PR (committed txn is ready there, by design); the
+    # feature-PR "committed txn not ready" invariant this asserts does not apply.
+    if: needs.changes.outputs.release == 'true' && !startsWith(github.head_ref, 'changeset-release/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,25 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
+      # Go + Python: the version command also regenerates the version-derived
+      # integration docs (release:version:docs), so the Version PR never carries
+      # stale generated docs. docs-generate runs `go run .../cmd --help` + a pyyaml
+      # script — kept here (push-only job) so the release-version-test clone stays
+      # dependency-free.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.12'
+      - run: pip install pyyaml
       - run: npm ci --ignore-scripts
       - name: Open or update the Version Packages PR
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
-          version: npm run release:version
+          version: npm run release:version:docs
+          title: "chore: version packages"
+          commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "release:version": "changeset version && node release/scripts/build-release-plan.mjs --transaction && node release/scripts/apply-release-plan.mjs",
+    "release:version:docs": "npm run release:version && make -C integrations/kubernetes docs-generate",
     "release:plan": "node release/scripts/build-release-plan.mjs"
   },
   "devDependencies": {


### PR DESCRIPTION
## Recognize the changesets Version PR in CI gates

The release-safety gates were written for feature PRs and `main`: they assume
pending changesets and a not-ready committed transaction. On the changesets
**Version PR** (`changeset-release/*`) both assumptions invert — the changesets
are consumed and the committed `release-transaction.json` is ready by design — so
five checks failed on what is actually correct state.

### Changes

- **Skip the feature-PR invariant gates on `changeset-release/*`.** `ci-oci`,
  `release-dry-run` and `release-version-test` each assert an invariant that only
  holds before the Version PR (committed transaction not ready / pending bump
  present). They now skip on the Version PR branch. Skipped legs do not fail the
  `required` aggregate, so the Version PR still gates on `required`.
- **Conventional title for the Version PR.** The changesets action now opens the
  PR with a `chore: version packages` title and commit message, so the PR-title
  check (`validate`) passes.
- **Regenerate version-derived docs at version time.** A new `release:version:docs`
  script regenerates the integration docs after the version bump, so the Version
  PR never carries stale generated docs (operator/chart/module + core versions).
  It runs only in the push-only changesets job (Go + pyyaml added there), leaving
  the `release-version-test` throwaway clone dependency-free.

### Effect

Merging this re-generates the open Version PR with a conventional title,
regenerated docs and the skip conditions on its HEAD, so its checks go green.
No publishing behavior changes.
