### PR TITLE
chore(deps): bump @changesets/cli to 2.31.1 and tmp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "release/units/*"
       ],
       "devDependencies": {
-        "@changesets/cli": "2.27.11"
+        "@changesets/cli": "2.31.1"
       }
     },
     "node_modules/@babel/runtime": {
@@ -72,34 +72,32 @@
       }
     },
     "node_modules/@changesets/cli": {
-      "version": "2.27.11",
-      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.27.11.tgz",
-      "integrity": "sha512-1QislpE+nvJgSZZo9+Lj3Lno5pKBgN46dAV8IVxKJy9wX8AOrs9nn5pYVZuDpoxWJJCALmbfOsHkyxujgetQSg==",
+      "version": "2.31.1",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.31.1.tgz",
+      "integrity": "sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/apply-release-plan": "^7.0.7",
-        "@changesets/assemble-release-plan": "^6.0.5",
-        "@changesets/changelog-git": "^0.2.0",
-        "@changesets/config": "^3.0.5",
+        "@changesets/apply-release-plan": "^7.1.1",
+        "@changesets/assemble-release-plan": "^6.0.10",
+        "@changesets/changelog-git": "^0.2.1",
+        "@changesets/config": "^3.1.4",
         "@changesets/errors": "^0.2.0",
-        "@changesets/get-dependents-graph": "^2.1.2",
-        "@changesets/get-release-plan": "^4.0.6",
-        "@changesets/git": "^3.0.2",
+        "@changesets/get-dependents-graph": "^2.1.4",
+        "@changesets/get-release-plan": "^4.0.16",
+        "@changesets/git": "^3.0.4",
         "@changesets/logger": "^0.1.1",
-        "@changesets/pre": "^2.0.1",
-        "@changesets/read": "^0.6.2",
-        "@changesets/should-skip-package": "^0.1.1",
-        "@changesets/types": "^6.0.0",
-        "@changesets/write": "^0.3.2",
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.7",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@changesets/write": "^0.4.0",
+        "@inquirer/external-editor": "^1.0.2",
         "@manypkg/get-packages": "^1.1.3",
         "ansi-colors": "^4.1.3",
-        "ci-info": "^3.7.0",
         "enquirer": "^2.4.1",
-        "external-editor": "^3.1.0",
         "fs-extra": "^7.0.1",
         "mri": "^1.2.0",
-        "p-limit": "^2.2.0",
         "package-manager-detector": "^0.2.0",
         "picocolors": "^1.1.0",
         "resolve-from": "^5.0.0",
@@ -109,6 +107,28 @@
       },
       "bin": {
         "changeset": "bin.js"
+      }
+    },
+    "node_modules/@changesets/cli/node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@changesets/config": {
@@ -256,15 +276,15 @@
       "license": "MIT"
     },
     "node_modules/@changesets/write": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.3.2.tgz",
-      "integrity": "sha512-kDxDrPNpUgsjDbWBvUo27PzKX4gqeKOlhibaOXDJA6kuBisGqNHv/HwGJrAu8U/dSf8ZEFIeHIPtvSlZI1kULw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz",
+      "integrity": "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/types": "^6.0.0",
+        "@changesets/types": "^6.1.0",
         "fs-extra": "^7.0.1",
-        "human-id": "^1.0.2",
+        "human-id": "^4.1.1",
         "prettier": "^2.7.1"
       }
     },
@@ -478,27 +498,11 @@
       }
     },
     "node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -572,21 +576,6 @@
       "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -699,23 +688,30 @@
       "license": "ISC"
     },
     "node_modules/human-id": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/human-id/-/human-id-1.0.2.tgz",
-      "integrity": "sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.2.0.tgz",
+      "integrity": "sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "bin": {
+        "human-id": "dist/cli.js"
+      }
     },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -876,16 +872,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/outdent": {
@@ -1284,19 +1270,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "release:plan": "node release/scripts/build-release-plan.mjs"
   },
   "devDependencies": {
-    "@changesets/cli": "2.27.11"
+    "@changesets/cli": "2.31.1"
   }
 }


### PR DESCRIPTION
Folds in dependabot #257 (the release-tooling npm bump) onto current main so it sits on top of the release-gate fix (#255) without clobbering the new `release:version:docs` script.

- `@changesets/cli` 2.27.11 -> 2.31.1 (+ `tmp` transitively)
- Cherry-picked dependabot's exact commit, preserving its verified lockfile.

Supersedes #257.