### PR TITLE
docs(readme): add the Artifact Hub badge for the operator chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/trianalab/pacto/v3)](https://pkg.go.dev/github.com/trianalab/pacto/v3)
 [![codecov](https://codecov.io/github/TrianaLab/pacto/graph/badge.svg?token=p3AJpP3BbO)](https://codecov.io/github/TrianaLab/pacto)
 [![GitHub Release](https://img.shields.io/github/v/release/TrianaLab/pacto)](https://github.com/TrianaLab/pacto/releases/latest)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/pacto-operator)](https://artifacthub.io/packages/search?repo=pacto-operator)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 # Pacto


### PR DESCRIPTION
Adds the Artifact Hub badge to the root README, restoring the one that lived in the pacto-operator repo now that the operator ships from this monorepo. Same repository slug (`pacto-operator`) as `integrations/kubernetes/README.md`.

README-only change: the CI path filter auto-skips the heavy legs (kind e2e, release-dry-run, operator-build); only the light engine/static/gates legs run.