### PR TITLE
fix(k8s-docs): correct the operator chart coordinate and cosign identity

### DIFF
--- a/integrations/kubernetes/README.md
+++ b/integrations/kubernetes/README.md
@@ -31,7 +31,7 @@ The CLI is the authoring tool. The operator is the runtime feedback loop. The da
 
 ```bash
 # Install (dashboard enabled by default)
-helm install pacto-operator oci://ghcr.io/trianalab/charts/pacto-operator \
+helm install pacto-operator oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
   --namespace pacto-operator-system --create-namespace
 ```
 
@@ -216,7 +216,7 @@ ContractStatus reflects **contract validation/compliance**, not runtime health. 
 ### Helm (recommended)
 
 ```bash
-helm install pacto-operator oci://ghcr.io/trianalab/charts/pacto-operator \
+helm install pacto-operator oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
   --namespace pacto-operator-system --create-namespace
 ```
 
@@ -344,7 +344,7 @@ Verify the Helm chart:
 cosign verify \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp 'github\.com/TrianaLab/pacto/\.github/workflows/release\.yml' \
-  ghcr.io/trianalab/charts/pacto-operator:<version>
+  ghcr.io/trianalab/pacto-operator/charts/pacto-operator:<version>
 ```
 
 ---
@@ -401,7 +401,7 @@ See the repository-root [CONTRIBUTING.md](/CONTRIBUTING.md) for the full develop
 | Artifact | Location |
 |----------|----------|
 | Controller image | `ghcr.io/trianalab/pacto-operator/pacto-controller` |
-| Helm chart | `oci://ghcr.io/trianalab/charts/pacto-operator` |
+| Helm chart | `oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator` |
 
 ## License
 

--- a/integrations/kubernetes/charts/pacto-operator/Chart.yaml
+++ b/integrations/kubernetes/charts/pacto-operator/Chart.yaml
@@ -19,6 +19,12 @@ sources:
   - https://github.com/TrianaLab/pacto/tree/main/integrations/kubernetes
   - https://github.com/TrianaLab/pacto
 annotations:
+  artifacthub.io/license: MIT
+  artifacthub.io/links: |
+    - name: support
+      url: https://github.com/TrianaLab/pacto/issues
+    - name: documentation
+      url: https://trianalab.github.io/pacto/integrations/kubernetes/overview/
   artifacthub.io/images: |
     - name: pacto-controller
       image: ghcr.io/trianalab/pacto-operator/pacto-controller:4.7.0

--- a/integrations/kubernetes/charts/pacto-operator/README.md
+++ b/integrations/kubernetes/charts/pacto-operator/README.md
@@ -57,14 +57,14 @@ The chart installs the controller and its supporting resources. The dashboard an
 ## Installation
 
 ```bash
-helm install pacto-operator oci://ghcr.io/trianalab/charts/pacto-operator \
+helm install pacto-operator oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
   --namespace pacto-operator-system --create-namespace
 ```
 
 Pin to a specific version:
 
 ```bash
-helm install pacto-operator oci://ghcr.io/trianalab/charts/pacto-operator \
+helm install pacto-operator oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
   --version 4.7.0 \
   --namespace pacto-operator-system --create-namespace
 ```
@@ -346,8 +346,8 @@ The Helm chart and controller image are signed with [Cosign](https://docs.sigsto
 ```bash
 cosign verify \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp 'github\.com/TrianaLab/pacto-operator' \
-  ghcr.io/trianalab/charts/pacto-operator:<version>
+  --certificate-identity-regexp 'github.com/TrianaLab/pacto/.github/workflows/release.yml' \
+  ghcr.io/trianalab/pacto-operator/charts/pacto-operator:<version>
 ```
 
 ## Values

--- a/integrations/kubernetes/charts/pacto-operator/README.md.gotmpl
+++ b/integrations/kubernetes/charts/pacto-operator/README.md.gotmpl
@@ -57,14 +57,14 @@ The chart installs the controller and its supporting resources. The dashboard an
 ## Installation
 
 ```bash
-helm install pacto-operator oci://ghcr.io/trianalab/charts/pacto-operator \
+helm install pacto-operator oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
   --namespace pacto-operator-system --create-namespace
 ```
 
 Pin to a specific version:
 
 ```bash
-helm install pacto-operator oci://ghcr.io/trianalab/charts/pacto-operator \
+helm install pacto-operator oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
   --version {{ template "chart.version" . }} \
   --namespace pacto-operator-system --create-namespace
 ```
@@ -346,8 +346,8 @@ The Helm chart and controller image are signed with [Cosign](https://docs.sigsto
 ```bash
 cosign verify \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp 'github\.com/TrianaLab/pacto-operator' \
-  ghcr.io/trianalab/charts/pacto-operator:<version>
+  --certificate-identity-regexp 'github.com/TrianaLab/pacto/.github/workflows/release.yml' \
+  ghcr.io/trianalab/pacto-operator/charts/pacto-operator:<version>
 ```
 
 {{ template "chart.valuesSection" . }}


### PR DESCRIPTION
The operator docs (integration README + chart README + template) still referenced the **old pacto-operator-repo** chart coordinate `ghcr.io/trianalab/charts/pacto-operator` in the `helm install` and `cosign verify` commands, and the chart README used a stale cosign signing identity (`github.com/TrianaLab/pacto-operator`).

Following those documented commands would fail: the chart is published at `ghcr.io/trianalab/pacto-operator/charts/pacto-operator` (per release-manifest.json + release.yml) and signed keyless from the monorepo's `release.yml`.

- Chart coordinate → `ghcr.io/trianalab/pacto-operator/charts/pacto-operator`
- Cosign identity → `github.com/TrianaLab/pacto/.github/workflows/release.yml`

Chart README regenerated via helm-docs. Frozen v4 test fixtures left unchanged.