### PR TITLE
fix(deps): sync package-lock.json with @changesets/cli 2.31.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,18 @@
         }
       }
     },
+    "node_modules/@changesets/cli/node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@changesets/config": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.4.tgz",
@@ -1284,6 +1296,15 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/universalify": {
       "version": "0.1.2",


### PR DESCRIPTION
The lockfile from #258 (dependabot) was missing transitive deps of `@changesets/cli@2.31.1` (`@types/node`, `undici-types`) under **npm 10 / node 22** — CI's version. The push-only changesets job therefore failed `npm ci` on main after #258 merged (it is not exercised by PR CI). Regenerated the lockfile with node 22 so `npm ci` is in sync. Verified `npm ci --ignore-scripts` passes in a node:22 container. package.json unchanged.