### PR TITLE
fix(release): keep go.work core replace in lockstep with the go.mod pin

### DIFF
--- a/release/scripts/apply-release-plan.mjs
+++ b/release/scripts/apply-release-plan.mjs
@@ -59,6 +59,21 @@ function assert(cond, msg) {
   }
 }
 
+// ---- 1b. go.work: keep the versioned replace in lockstep with the pinned core ----
+// The workspace resolves the not-yet-published core via a version-pinned replace
+// (`<module> vX.Y.Z => .`). When the core version bumps, this pin MUST move with the
+// go.mod require, or the workspace tries to fetch the unpublished new version and
+// `go mod download` fails ("unknown revision"). Unlike the go.mod, a go.work replace
+// is legitimate (it is the dev/CI workspace, never a published module).
+{
+  const rel = 'go.work';
+  const after = edit(rel, (s) =>
+    s.replace(new RegExp(`(replace ${esc(pin.module)} )v${SEMVER}( => \\.)`),
+      `$1${pin.version}$2`));
+  assert(after.includes(`replace ${pin.module} ${pin.version} => .`),
+    `${rel}: versioned core replace not pinned to ${pin.version}`);
+}
+
 // ---- 2. operator chart Chart.yaml: version, appVersion, artifacthub image ----
 {
   const rel = 'integrations/kubernetes/charts/pacto-operator/Chart.yaml';


### PR DESCRIPTION
apply-release-plan repins the k8s `go.mod` core require to the new version but left the `go.work` versioned replace (`github.com/trianalab/pacto/v3 vX.Y.Z => .`) at the old version. On a patch/minor release the workspace then tries to fetch the unpublished new core (v3.0.1) and `go mod download` fails with 'unknown revision' — breaking every Go job on the Version PR (#266). Now apply-release-plan moves the go.work replace with the go.mod pin. Surfaced by the first patch release after v3.0.0.