### PR TITLE
fix(release): dashboard bundle push uses -p for the bundle dir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -356,7 +356,7 @@ jobs:
           PACTO_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash release/orchestrator/publish-oci-unit.sh dashboard-contract-bundle "$REF" "$VER" -- \
-            go run ./cmd/pacto push "oci://$REF" ./pactos/pacto-dashboard --set service.version="$VER"
+            go run ./cmd/pacto push "oci://$REF" -p ./pactos/pacto-dashboard --set service.version="$VER"
 
   # pacto-publishes: demo-bundles
   # demo-bundles is a MULTI-artifact unit (one immutable tag per demo service),


### PR DESCRIPTION
`pacto push` takes one positional arg (the ref); the bundle directory is `-p/--path`. The dashboard-contract-bundle publisher passed the dir as a 2nd positional (`pacto push oci://REF ./dir`) → `accepts 1 arg(s), received 2`. Fixed to `pacto push oci://REF -p ./dir`. Surfaced only now that gen-bundle reaches the push (plugin-install + coord fixes cleared the earlier failures). Last blocker for dashboard-contract-bundle + the GitHub Release.