### PR TITLE
feat(release): unify all OCI artifacts under ghcr.io/trianalab/pacto/*

### DIFF
--- a/.changeset/unify-pacto-namespace.md
+++ b/.changeset/unify-pacto-namespace.md
@@ -1,0 +1,18 @@
+---
+"@pacto/core": minor
+"@pacto/k8s-module": minor
+---
+
+Unify all published OCI artifacts under the monorepo `ghcr.io/trianalab/pacto/*` namespace.
+
+- operator image → `ghcr.io/trianalab/pacto/operator`
+- operator chart → `ghcr.io/trianalab/pacto/charts/pacto-operator`
+- dashboard image → `ghcr.io/trianalab/pacto/dashboard`
+- dashboard contract bundle → `ghcr.io/trianalab/pacto/dashboard-contract`
+- demo bundles already live under `ghcr.io/trianalab/pacto/*`
+
+All packages are now created and owned by this repository. The chart name
+`pacto-operator` and the Artifact Hub repository are preserved (re-point the AH
+repository URL to the new chart coordinate). The previous coordinates remain as
+historical — their already-published versions are unaffected. Go module paths
+(`/v3`, `/v5`) are unchanged.

--- a/.github/workflows/pacto.yml
+++ b/.github/workflows/pacto.yml
@@ -80,7 +80,7 @@ jobs:
         continue-on-error: true
         run: |
           pacto diff \
-            oci://ghcr.io/trianalab/pactos/pacto-dashboard \
+            oci://ghcr.io/trianalab/pacto/dashboard-contract \
             ./pactos/pacto-dashboard \
             --new-set service.version=0.0.0-pr.${{ github.event.pull_request.number }} \
             -o markdown || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,7 +266,7 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Publish + sign the dashboard image (shared adapter)
         env:
-          REF: ghcr.io/trianalab/pacto-dashboard:${{ needs.detect.outputs.core_version }}
+          REF: ghcr.io/trianalab/pacto/dashboard:${{ needs.detect.outputs.core_version }}
           VER: ${{ needs.detect.outputs.core_version }}
           SRC: ${{ needs.detect.outputs.source_sha }}
           PACTO_EXPECT_REVISION: ${{ needs.detect.outputs.source_sha }}
@@ -350,7 +350,7 @@ jobs:
           go run ./cmd/pacto validate ./pactos/pacto-dashboard --set service.version=${{ needs.detect.outputs.core_version }}
       - name: Publish the contract bundle (shared adapter)
         env:
-          REF: ghcr.io/trianalab/pactos/pacto-dashboard:${{ needs.detect.outputs.core_version }}
+          REF: ghcr.io/trianalab/pacto/dashboard-contract:${{ needs.detect.outputs.core_version }}
           VER: ${{ needs.detect.outputs.core_version }}
           PACTO_REGISTRY_USERNAME: ${{ github.actor }}
           PACTO_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
@@ -467,10 +467,10 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Publish + sign the operator image (shared adapter)
         env:
-          REF: ghcr.io/trianalab/pacto-operator/pacto-controller:${{ needs.detect.outputs.k8s_version }}
+          REF: ghcr.io/trianalab/pacto/operator:${{ needs.detect.outputs.k8s_version }}
           VER: ${{ needs.detect.outputs.k8s_version }}
           SRC: ${{ needs.detect.outputs.source_sha }}
-          DASH: ghcr.io/trianalab/pacto-dashboard:${{ needs.detect.outputs.core_version }}
+          DASH: ghcr.io/trianalab/pacto/dashboard:${{ needs.detect.outputs.core_version }}
           PACTO_EXPECT_REVISION: ${{ needs.detect.outputs.source_sha }}
           PACTO_EXPECT_VERSION: ${{ needs.detect.outputs.k8s_version }}
         run: |
@@ -537,7 +537,7 @@ jobs:
         working-directory: .
         run: |
           want="$(bash release/orchestrator/ledger.sh digest "$PACTO_RELEASE_TXN" operator-chart)"
-          state="$(bash release/orchestrator/verify-oci.sh "ghcr.io/trianalab/pacto-operator/charts/pacto-operator:${{ needs.detect.outputs.k8s_version }}" "$want")"
+          state="$(bash release/orchestrator/verify-oci.sh "ghcr.io/trianalab/pacto/charts/pacto-operator:${{ needs.detect.outputs.k8s_version }}" "$want")"
           echo "state=$state" >> "$GITHUB_OUTPUT"
       # Item 8: the IMMUTABLE chart and the MUTABLE Artifact Hub alias are separate
       # publication results. Package + push + RECORD the chart digest immediately
@@ -548,16 +548,16 @@ jobs:
           VERSION: ${{ needs.detect.outputs.k8s_version }}
         run: |
           helm package charts/pacto-operator
-          out=$(helm push "pacto-operator-${VERSION}.tgz" oci://ghcr.io/trianalab/pacto-operator/charts 2>&1)
+          out=$(helm push "pacto-operator-${VERSION}.tgz" oci://ghcr.io/trianalab/pacto/charts 2>&1)
           echo "$out"
           digest=$(echo "$out" | grep -oE 'sha256:[a-f0-9]+')
           [ -n "$digest" ] || { echo "::error::no chart digest from helm push"; exit 1; }
           # Record the immutable chart digest NOW, before the mutable metadata step,
           # so an Artifact Hub failure can never leave a published-but-unrecorded chart.
           bash "$GITHUB_WORKSPACE/release/orchestrator/ledger.sh" record "$PACTO_RELEASE_TXN" \
-            operator-chart "ghcr.io/trianalab/pacto-operator/charts/pacto-operator" "$VERSION" "$digest" complete
+            operator-chart "ghcr.io/trianalab/pacto/charts/pacto-operator" "$VERSION" "$digest" complete
           cosign sign --yes --new-bundle-format=false --use-signing-config=false \
-            "ghcr.io/trianalab/pacto-operator/charts/pacto-operator:${VERSION}@${digest}"
+            "ghcr.io/trianalab/pacto/charts/pacto-operator:${VERSION}@${digest}"
       # The artifacthub.io tag is an intentional MUTABLE repo-level alias (NOT an
       # immutable SemVer chart version): Artifact Hub reads repository ownership from
       # this one well-known tag, so re-pushing + round-tripping the SAME metadata is
@@ -567,11 +567,11 @@ jobs:
       - name: Publish + verify Artifact Hub metadata (mutable alias)
         if: steps.v.outputs.state == 'absent' || steps.v.outputs.state == 'identical'
         run: |
-          oras push ghcr.io/trianalab/pacto-operator/charts/pacto-operator:artifacthub.io \
+          oras push ghcr.io/trianalab/pacto/charts/pacto-operator:artifacthub.io \
             --config /dev/null:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml \
             artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
           bash "$GITHUB_WORKSPACE/release/orchestrator/verify-artifacthub.sh" \
-            ghcr.io/trianalab/pacto-operator/charts/pacto-operator:artifacthub.io \
+            ghcr.io/trianalab/pacto/charts/pacto-operator:artifacthub.io \
             artifacthub-repo.yml
 
   # pacto-publishes: k8s-docs

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 GOBIN := $(GOPATH)/bin
 endif
 
-IMAGE := ghcr.io/trianalab/pacto-dashboard
+IMAGE := ghcr.io/trianalab/pacto/dashboard
 
 .PHONY: build test e2e coverage lint check-section clean docs docs-build demo-preview-clean gen-cli-docs docker-build docker-run
 

--- a/docs/dashboard-docker.md
+++ b/docs/dashboard-docker.md
@@ -6,7 +6,7 @@ The Pacto dashboard is published as a container image for production and Kuberne
 ## Image
 
 ```
-ghcr.io/trianalab/pacto-dashboard:<version>
+ghcr.io/trianalab/pacto/dashboard:<version>
 ```
 
 The image tag always matches the Pacto release version (e.g., `1.2.3`). There is no `latest` tag. The container runs the exact `pacto` binary for that version.
@@ -17,13 +17,13 @@ The image tag always matches the Pacto release version (e.g., `1.2.3`). There is
 # Run with OCI registry sources
 docker run -p 3000:3000 \
   -e PACTO_DASHBOARD_REPO=ghcr.io/org/svc-a,ghcr.io/org/svc-b \
-  ghcr.io/trianalab/pacto-dashboard:1.2.3
+  ghcr.io/trianalab/pacto/dashboard:1.2.3
 
 # Run with registry authentication
 docker run -p 3000:3000 \
   -e PACTO_DASHBOARD_REPO=ghcr.io/org/svc-a \
   -e PACTO_REGISTRY_TOKEN=ghp_xxx \
-  ghcr.io/trianalab/pacto-dashboard:1.2.3
+  ghcr.io/trianalab/pacto/dashboard:1.2.3
 ```
 
 ## Local Development
@@ -88,7 +88,7 @@ To enable the Kubernetes data source, mount a kubeconfig:
 docker run -p 3000:3000 \
   -v ~/.kube/config:/home/pacto/.kube/config:ro \
   -e PACTO_DASHBOARD_NAMESPACE=production \
-  ghcr.io/trianalab/pacto-dashboard:1.2.3
+  ghcr.io/trianalab/pacto/dashboard:1.2.3
 ```
 
 When running inside a Kubernetes cluster, the in-cluster config is used automatically (no mount needed).
@@ -100,7 +100,7 @@ To scan a local contract directory:
 ```bash
 docker run -p 3000:3000 \
   -v /path/to/contracts:/data:ro \
-  ghcr.io/trianalab/pacto-dashboard:1.2.3 \
+  ghcr.io/trianalab/pacto/dashboard:1.2.3 \
   dashboard /data
 ```
 
@@ -154,7 +154,7 @@ spec:
     spec:
       containers:
         - name: dashboard
-          image: ghcr.io/trianalab/pacto-dashboard:1.2.3
+          image: ghcr.io/trianalab/pacto/dashboard:1.2.3
           ports:
             - containerPort: 3000
           env:
@@ -213,4 +213,4 @@ spec:
 
 ## Build and Release
 
-The dashboard image is built and published automatically when a new Pacto version is released. The `docker-build` and `docker-merge` jobs in the auto-release pipeline (`.github/workflows/auto-release.yml`) build per-architecture images (`linux/amd64`, `linux/arm64`) and merge them into a single multi-arch manifest pushed to `ghcr.io/trianalab/pacto-dashboard` with the matching version tag (without `v` prefix).
+The dashboard image is built and published automatically when a new Pacto version is released. The `docker-build` and `docker-merge` jobs in the auto-release pipeline (`.github/workflows/auto-release.yml`) build per-architecture images (`linux/amd64`, `linux/arm64`) and merge them into a single multi-arch manifest pushed to `ghcr.io/trianalab/pacto/dashboard` with the matching version tag (without `v` prefix).

--- a/integrations/kubernetes/Makefile
+++ b/integrations/kubernetes/Makefile
@@ -44,7 +44,7 @@ PACTO_VERSION := $(shell node -e 'const fs=require("fs");process.stdout.write(JS
 else
 PACTO_VERSION := $(shell echo '$(call gomodver,github.com/trianalab/pacto/v3)' | sed 's/^v//')
 endif
-DASHBOARD_IMG := ghcr.io/trianalab/pacto-dashboard:$(PACTO_VERSION)
+DASHBOARD_IMG := ghcr.io/trianalab/pacto/dashboard:$(PACTO_VERSION)
 
 # Ldflags for version injection
 LDFLAGS := -ldflags "-s -w \
@@ -54,7 +54,7 @@ LDFLAGS := -ldflags "-s -w \
   -X main.dashboardImage=$(DASHBOARD_IMG)"
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/trianalab/pacto-operator/pacto-controller:$(VERSION)
+IMG ?= ghcr.io/trianalab/pacto/operator:$(VERSION)
 
 # Namespace used when running locally (defaults to HELM_NAMESPACE)
 POD_NAMESPACE ?= $(HELM_NAMESPACE)

--- a/integrations/kubernetes/README.md
+++ b/integrations/kubernetes/README.md
@@ -31,7 +31,7 @@ The CLI is the authoring tool. The operator is the runtime feedback loop. The da
 
 ```bash
 # Install (dashboard enabled by default)
-helm install pacto-operator oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
+helm install pacto-operator oci://ghcr.io/trianalab/pacto/charts/pacto-operator \
   --namespace pacto-operator-system --create-namespace
 ```
 
@@ -216,7 +216,7 @@ ContractStatus reflects **contract validation/compliance**, not runtime health. 
 ### Helm (recommended)
 
 ```bash
-helm install pacto-operator oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
+helm install pacto-operator oci://ghcr.io/trianalab/pacto/charts/pacto-operator \
   --namespace pacto-operator-system --create-namespace
 ```
 
@@ -335,7 +335,7 @@ Verify the controller image:
 cosign verify \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp 'github\.com/TrianaLab/pacto/\.github/workflows/release\.yml' \
-  ghcr.io/trianalab/pacto-operator/pacto-controller:<version>
+  ghcr.io/trianalab/pacto/operator:<version>
 ```
 
 Verify the Helm chart:
@@ -344,7 +344,7 @@ Verify the Helm chart:
 cosign verify \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp 'github\.com/TrianaLab/pacto/\.github/workflows/release\.yml' \
-  ghcr.io/trianalab/pacto-operator/charts/pacto-operator:<version>
+  ghcr.io/trianalab/pacto/charts/pacto-operator:<version>
 ```
 
 ---
@@ -400,8 +400,8 @@ See the repository-root [CONTRIBUTING.md](/CONTRIBUTING.md) for the full develop
 
 | Artifact | Location |
 |----------|----------|
-| Controller image | `ghcr.io/trianalab/pacto-operator/pacto-controller` |
-| Helm chart | `oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator` |
+| Controller image | `ghcr.io/trianalab/pacto/operator` |
+| Helm chart | `oci://ghcr.io/trianalab/pacto/charts/pacto-operator` |
 
 ## License
 

--- a/integrations/kubernetes/charts/pacto-operator/Chart.yaml
+++ b/integrations/kubernetes/charts/pacto-operator/Chart.yaml
@@ -27,4 +27,4 @@ annotations:
       url: https://trianalab.github.io/pacto/integrations/kubernetes/overview/
   artifacthub.io/images: |
     - name: pacto-controller
-      image: ghcr.io/trianalab/pacto-operator/pacto-controller:5.0.0
+      image: ghcr.io/trianalab/pacto/operator:5.0.0

--- a/integrations/kubernetes/charts/pacto-operator/README.md
+++ b/integrations/kubernetes/charts/pacto-operator/README.md
@@ -57,14 +57,14 @@ The chart installs the controller and its supporting resources. The dashboard an
 ## Installation
 
 ```bash
-helm install pacto-operator oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
+helm install pacto-operator oci://ghcr.io/trianalab/pacto/charts/pacto-operator \
   --namespace pacto-operator-system --create-namespace
 ```
 
 Pin to a specific version:
 
 ```bash
-helm install pacto-operator oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
+helm install pacto-operator oci://ghcr.io/trianalab/pacto/charts/pacto-operator \
   --version 5.0.0 \
   --namespace pacto-operator-system --create-namespace
 ```
@@ -347,7 +347,7 @@ The Helm chart and controller image are signed with [Cosign](https://docs.sigsto
 cosign verify \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp 'github.com/TrianaLab/pacto/.github/workflows/release.yml' \
-  ghcr.io/trianalab/pacto-operator/charts/pacto-operator:<version>
+  ghcr.io/trianalab/pacto/charts/pacto-operator:<version>
 ```
 
 ## Values
@@ -375,7 +375,7 @@ cosign verify \
 | dashboard.service.type | string | `"ClusterIP"` | Dashboard exposure Service type (ClusterIP, NodePort, LoadBalancer). The operator manages an internal ClusterIP Service (pacto-dashboard) for pod-to-pod communication. This chart-managed Service provides configurable external access and serves as the backend for Ingress/HTTPRoute resources. Selects dashboard pods via operator-defined labels. |
 | fullnameOverride | string | `""` | Override the full release name |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| image.repository | string | `"ghcr.io/trianalab/pacto-operator/pacto-controller"` | Controller image repository |
+| image.repository | string | `"ghcr.io/trianalab/pacto/operator"` | Controller image repository |
 | image.tag | string | `""` | Overrides the image tag (default is the chart appVersion) |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries |
 | leaderElection.enabled | bool | `true` | Enable leader election for HA deployments |

--- a/integrations/kubernetes/charts/pacto-operator/README.md.gotmpl
+++ b/integrations/kubernetes/charts/pacto-operator/README.md.gotmpl
@@ -57,14 +57,14 @@ The chart installs the controller and its supporting resources. The dashboard an
 ## Installation
 
 ```bash
-helm install pacto-operator oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
+helm install pacto-operator oci://ghcr.io/trianalab/pacto/charts/pacto-operator \
   --namespace pacto-operator-system --create-namespace
 ```
 
 Pin to a specific version:
 
 ```bash
-helm install pacto-operator oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
+helm install pacto-operator oci://ghcr.io/trianalab/pacto/charts/pacto-operator \
   --version {{ template "chart.version" . }} \
   --namespace pacto-operator-system --create-namespace
 ```
@@ -347,7 +347,7 @@ The Helm chart and controller image are signed with [Cosign](https://docs.sigsto
 cosign verify \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp 'github.com/TrianaLab/pacto/.github/workflows/release.yml' \
-  ghcr.io/trianalab/pacto-operator/charts/pacto-operator:<version>
+  ghcr.io/trianalab/pacto/charts/pacto-operator:<version>
 ```
 
 {{ template "chart.valuesSection" . }}

--- a/integrations/kubernetes/charts/pacto-operator/tests/deployment_test.yaml
+++ b/integrations/kubernetes/charts/pacto-operator/tests/deployment_test.yaml
@@ -14,7 +14,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "ghcr.io/trianalab/pacto-operator/pacto-controller:.*"
+          pattern: "ghcr.io/trianalab/pacto/operator:.*"
 
   - it: should set security context
     asserts:
@@ -81,7 +81,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/trianalab/pacto-operator/pacto-controller:v1.2.3"
+          value: "ghcr.io/trianalab/pacto/operator:v1.2.3"
 
   - it: should disable leader election
     set:

--- a/integrations/kubernetes/charts/pacto-operator/values.yaml
+++ b/integrations/kubernetes/charts/pacto-operator/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 
 image:
   # -- Controller image repository
-  repository: ghcr.io/trianalab/pacto-operator/pacto-controller
+  repository: ghcr.io/trianalab/pacto/operator
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag (default is the chart appVersion)

--- a/integrations/kubernetes/docs/generated/artifact-hub.md
+++ b/integrations/kubernetes/docs/generated/artifact-hub.md
@@ -12,8 +12,8 @@ Published artifact coordinates for the Kubernetes integration. All coordinates a
 
 | Artifact | Kind | Coordinate | Version |
 | --- | --- | --- | --- |
-| Controller image | oci-image | `ghcr.io/trianalab/pacto-operator/pacto-controller` | `5.0.0` |
-| Helm chart | helm-chart | `ghcr.io/trianalab/pacto-operator/charts/pacto-operator` | `5.0.0` |
+| Controller image | oci-image | `ghcr.io/trianalab/pacto/operator` | `5.0.0` |
+| Helm chart | helm-chart | `ghcr.io/trianalab/pacto/charts/pacto-operator` | `5.0.0` |
 | Go module | go-module | `github.com/trianalab/pacto/integrations/kubernetes/v5` | `5.0.0` |
 | Documentation | docs | `mkdocs:integrations/kubernetes` | `5.0.0` |
 
@@ -24,14 +24,14 @@ Published artifact coordinates for the Kubernetes integration. All coordinates a
 
 ```yaml
 - name: pacto-controller
-  image: ghcr.io/trianalab/pacto-operator/pacto-controller:5.0.0
+  image: ghcr.io/trianalab/pacto/operator:5.0.0
 ```
 
 ## Install from the published chart
 
 ```bash
 helm install pacto-operator \
-  oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
+  oci://ghcr.io/trianalab/pacto/charts/pacto-operator \
   --version 5.0.0 \
   --namespace pacto-operator-system --create-namespace
 ```

--- a/integrations/kubernetes/docs/generated/helm-reference.md
+++ b/integrations/kubernetes/docs/generated/helm-reference.md
@@ -37,7 +37,7 @@ Values are generated from `charts/pacto-operator/values.yaml`. Descriptions come
 | `dashboard.service.type` | `ClusterIP` | Dashboard exposure Service type (ClusterIP, NodePort, LoadBalancer). The operator manages an internal ClusterIP Service (pacto-dashboard) for pod-to-pod communication. This chart-managed Service provides configurable external access and serves as the backend for Ingress/HTTPRoute resources. Selects dashboard pods via operator-defined labels. |
 | `fullnameOverride` | `""` | Override the full release name |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |
-| `image.repository` | `ghcr.io/trianalab/pacto-operator/pacto-controller` | Controller image repository |
+| `image.repository` | `ghcr.io/trianalab/pacto/operator` | Controller image repository |
 | `image.tag` | `""` | Overrides the image tag (default is the chart appVersion) |
 | `imagePullSecrets` | `[]` | Image pull secrets for private registries |
 | `leaderElection.enabled` | `true` | Enable leader election for HA deployments |

--- a/integrations/kubernetes/docs/installation.md
+++ b/integrations/kubernetes/docs/installation.md
@@ -19,7 +19,7 @@ dashboard.
 
 ```bash
 helm install pacto-operator \
-  oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
+  oci://ghcr.io/trianalab/pacto/charts/pacto-operator \
   --namespace pacto-operator-system --create-namespace
 ```
 
@@ -28,7 +28,7 @@ installs; see the [compatibility table](upgrade.md#version-compatibility)):
 
 ```bash
 helm install pacto-operator \
-  oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
+  oci://ghcr.io/trianalab/pacto/charts/pacto-operator \
   --version 4.7.0 \
   --namespace pacto-operator-system --create-namespace
 ```
@@ -37,7 +37,7 @@ helm install pacto-operator \
 
 ```bash
 helm install pacto-operator \
-  oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
+  oci://ghcr.io/trianalab/pacto/charts/pacto-operator \
   --namespace pacto-operator-system --create-namespace \
   --set controller.watchNamespace=my-namespace \
   --set metrics.serviceMonitor.enabled=true \

--- a/integrations/kubernetes/docs/upgrade.md
+++ b/integrations/kubernetes/docs/upgrade.md
@@ -11,7 +11,7 @@ enough:
 
 ```bash
 helm upgrade pacto-operator \
-  oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
+  oci://ghcr.io/trianalab/pacto/charts/pacto-operator \
   --version 4.7.0 \
   --namespace pacto-operator-system
 ```
@@ -35,7 +35,7 @@ kubectl apply --server-side --force-conflicts \
 
 # 2. Upgrade the release to the new chart version.
 helm upgrade pacto-operator \
-  oci://ghcr.io/trianalab/pacto-operator/charts/pacto-operator \
+  oci://ghcr.io/trianalab/pacto/charts/pacto-operator \
   --version 5.0.0 \
   --namespace pacto-operator-system
 ```

--- a/integrations/kubernetes/integration.yaml
+++ b/integrations/kubernetes/integration.yaml
@@ -23,10 +23,10 @@ releaseUnits:
     tagPrefix: integrations/kubernetes/
   - id: operator-image
     kind: oci-image
-    coordinate: ghcr.io/trianalab/pacto-operator/pacto-controller
+    coordinate: ghcr.io/trianalab/pacto/operator
   - id: operator-chart
     kind: helm-chart
-    coordinate: ghcr.io/trianalab/pacto-operator/charts/pacto-operator
+    coordinate: ghcr.io/trianalab/pacto/charts/pacto-operator
     chartName: pacto-operator
   - id: k8s-docs
     kind: docs

--- a/integrations/kubernetes/internal/dashboard/config_test.go
+++ b/integrations/kubernetes/internal/dashboard/config_test.go
@@ -36,19 +36,19 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			name:    "enabled without namespace fails",
-			cfg:     Config{Enabled: true, Image: "ghcr.io/trianalab/pacto-dashboard:0.24.2"},
+			cfg:     Config{Enabled: true, Image: "ghcr.io/trianalab/pacto/dashboard:0.24.2"},
 			wantErr: true,
 			errMsg:  "dashboard namespace must be set",
 		},
 		{
 			name:    "enabled with latest tag fails",
-			cfg:     Config{Enabled: true, Image: "ghcr.io/trianalab/pacto-dashboard:latest", Namespace: "ns"},
+			cfg:     Config{Enabled: true, Image: "ghcr.io/trianalab/pacto/dashboard:latest", Namespace: "ns"},
 			wantErr: true,
 			errMsg:  "must not use 'latest'",
 		},
 		{
 			name:    "enabled with no tag fails (implicit latest)",
-			cfg:     Config{Enabled: true, Image: "ghcr.io/trianalab/pacto-dashboard", Namespace: "ns"},
+			cfg:     Config{Enabled: true, Image: "ghcr.io/trianalab/pacto/dashboard", Namespace: "ns"},
 			wantErr: true,
 			errMsg:  "must not use 'latest'",
 		},
@@ -56,7 +56,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "enabled with valid config succeeds",
 			cfg: Config{
 				Enabled:   true,
-				Image:     "ghcr.io/trianalab/pacto-dashboard:0.24.2",
+				Image:     "ghcr.io/trianalab/pacto/dashboard:0.24.2",
 				Namespace: "pacto-system",
 			},
 			wantErr: false,
@@ -65,7 +65,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "enabled with OCI secret is valid",
 			cfg: Config{
 				Enabled:   true,
-				Image:     "ghcr.io/trianalab/pacto-dashboard:1.0.0",
+				Image:     "ghcr.io/trianalab/pacto/dashboard:1.0.0",
 				Namespace: "pacto-system",
 				OCISecret: "registry-creds",
 			},
@@ -75,7 +75,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "enabled with invalid resource quantity fails",
 			cfg: Config{
 				Enabled:   true,
-				Image:     "ghcr.io/trianalab/pacto-dashboard:1.0.0",
+				Image:     "ghcr.io/trianalab/pacto/dashboard:1.0.0",
 				Namespace: "pacto-system",
 				Resources: ResourcesConfig{MemoryRequest: "not-a-quantity"},
 			},
@@ -86,7 +86,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "enabled with valid resource overrides succeeds",
 			cfg: Config{
 				Enabled:   true,
-				Image:     "ghcr.io/trianalab/pacto-dashboard:1.0.0",
+				Image:     "ghcr.io/trianalab/pacto/dashboard:1.0.0",
 				Namespace: "pacto-system",
 				Resources: ResourcesConfig{CPURequest: "100m", CPULimit: "1", MemoryRequest: "256Mi", MemoryLimit: "1Gi"},
 			},
@@ -116,9 +116,9 @@ func TestHasLatestTag(t *testing.T) {
 		image string
 		want  bool
 	}{
-		{"ghcr.io/trianalab/pacto-dashboard:0.24.2", false},
-		{"ghcr.io/trianalab/pacto-dashboard:latest", true},
-		{"ghcr.io/trianalab/pacto-dashboard", true},
+		{"ghcr.io/trianalab/pacto/dashboard:0.24.2", false},
+		{"ghcr.io/trianalab/pacto/dashboard:latest", true},
+		{"ghcr.io/trianalab/pacto/dashboard", true},
 		{"my-registry.com/dashboard:v1.2.3", false},
 		{"dashboard:1.0", false},
 		{"dashboard:latest", true},

--- a/integrations/kubernetes/internal/dashboard/reconciler_test.go
+++ b/integrations/kubernetes/internal/dashboard/reconciler_test.go
@@ -66,7 +66,7 @@ func TestReconcile_Disabled_NoResources(t *testing.T) {
 func TestReconcile_Enabled_CreatesResources(t *testing.T) {
 	cfg := Config{
 		Enabled:   true,
-		Image:     "ghcr.io/trianalab/pacto-dashboard:0.24.2",
+		Image:     "ghcr.io/trianalab/pacto/dashboard:0.24.2",
 		Namespace: "test-ns",
 	}
 
@@ -100,14 +100,14 @@ func TestReconcile_Enabled_CreatesResources(t *testing.T) {
 func TestReconcile_Enabled_UpdatesExistingResources(t *testing.T) {
 	cfg := Config{
 		Enabled:   true,
-		Image:     "ghcr.io/trianalab/pacto-dashboard:0.25.0",
+		Image:     "ghcr.io/trianalab/pacto/dashboard:0.25.0",
 		Namespace: "test-ns",
 	}
 
 	// Pre-create a deployment with an old image
 	oldDeploy := BuildDeployment(Config{
 		Enabled:   true,
-		Image:     "ghcr.io/trianalab/pacto-dashboard:0.24.0",
+		Image:     "ghcr.io/trianalab/pacto/dashboard:0.24.0",
 		Namespace: "test-ns",
 	})
 
@@ -136,7 +136,7 @@ func TestReconcile_Enabled_UpdatesExistingResources(t *testing.T) {
 func TestReconcile_DisabledAfterEnabled_CleansUp(t *testing.T) {
 	cfg := Config{
 		Enabled:   true,
-		Image:     "ghcr.io/trianalab/pacto-dashboard:0.24.2",
+		Image:     "ghcr.io/trianalab/pacto/dashboard:0.24.2",
 		Namespace: "test-ns",
 	}
 
@@ -213,7 +213,7 @@ func TestReconcile_Cleanup_NoErrorWhenNoResources(t *testing.T) {
 func TestReconcile_PreservesExternalLabelsAndAnnotations(t *testing.T) {
 	cfg := Config{
 		Enabled:   true,
-		Image:     "ghcr.io/trianalab/pacto-dashboard:0.25.0",
+		Image:     "ghcr.io/trianalab/pacto/dashboard:0.25.0",
 		Namespace: "test-ns",
 	}
 
@@ -268,7 +268,7 @@ func TestReconcile_PreservesExternalLabelsAndAnnotations(t *testing.T) {
 func TestReconcile_Idempotent(t *testing.T) {
 	cfg := Config{
 		Enabled:   true,
-		Image:     "ghcr.io/trianalab/pacto-dashboard:0.24.2",
+		Image:     "ghcr.io/trianalab/pacto/dashboard:0.24.2",
 		Namespace: "test-ns",
 	}
 
@@ -331,7 +331,7 @@ func assertClusterResourceNotFound(t *testing.T, c client.Client, ctx context.Co
 func TestReconcile_OCISecret_CreatesManagedSecret(t *testing.T) {
 	cfg := Config{
 		Enabled:   true,
-		Image:     "ghcr.io/trianalab/pacto-dashboard:0.24.2",
+		Image:     "ghcr.io/trianalab/pacto/dashboard:0.24.2",
 		Namespace: "test-ns",
 		OCISecret: "my-creds",
 	}
@@ -364,7 +364,7 @@ func TestReconcile_OCISecret_CreatesManagedSecret(t *testing.T) {
 func TestReconcile_OCISecrets_CreatesManagedSecret(t *testing.T) {
 	cfg := Config{
 		Enabled:    true,
-		Image:      "ghcr.io/trianalab/pacto-dashboard:0.24.2",
+		Image:      "ghcr.io/trianalab/pacto/dashboard:0.24.2",
 		Namespace:  "test-ns",
 		OCISecrets: []string{"creds-1", "creds-2"},
 	}
@@ -396,7 +396,7 @@ func TestReconcile_OCISecrets_CreatesManagedSecret(t *testing.T) {
 func TestReconcile_NoOCISecrets_NoManagedSecret(t *testing.T) {
 	cfg := Config{
 		Enabled:   true,
-		Image:     "ghcr.io/trianalab/pacto-dashboard:0.24.2",
+		Image:     "ghcr.io/trianalab/pacto/dashboard:0.24.2",
 		Namespace: "test-ns",
 	}
 	r := newReconciler(cfg)
@@ -417,7 +417,7 @@ func TestReconcile_NoOCISecrets_NoManagedSecret(t *testing.T) {
 func TestReconcile_NoOCISecrets_CleansUpManagedSecret(t *testing.T) {
 	cfg := Config{
 		Enabled:   true,
-		Image:     "ghcr.io/trianalab/pacto-dashboard:0.24.2",
+		Image:     "ghcr.io/trianalab/pacto/dashboard:0.24.2",
 		Namespace: "test-ns",
 	}
 	// Pre-create a managed secret from a previous run
@@ -448,7 +448,7 @@ func TestReconcile_NoOCISecrets_CleansUpManagedSecret(t *testing.T) {
 func TestReconcile_OCISecret_MissingSourceSecret(t *testing.T) {
 	cfg := Config{
 		Enabled:   true,
-		Image:     "ghcr.io/trianalab/pacto-dashboard:0.24.2",
+		Image:     "ghcr.io/trianalab/pacto/dashboard:0.24.2",
 		Namespace: "test-ns",
 		OCISecret: "nonexistent",
 	}
@@ -464,7 +464,7 @@ func TestReconcile_OCISecret_MissingSourceSecret(t *testing.T) {
 func TestReconcile_OCICredentials_CleanupGetError(t *testing.T) {
 	cfg := Config{
 		Enabled:   true,
-		Image:     "ghcr.io/trianalab/pacto-dashboard:0.24.2",
+		Image:     "ghcr.io/trianalab/pacto/dashboard:0.24.2",
 		Namespace: "test-ns",
 		// No OCISecret/OCISecrets → triggers cleanup path
 	}
@@ -495,7 +495,7 @@ func TestReconcile_OCICredentials_CleanupGetError(t *testing.T) {
 func TestReconcile_OCICredentials_MergeError(t *testing.T) {
 	cfg := Config{
 		Enabled:   true,
-		Image:     "ghcr.io/trianalab/pacto-dashboard:0.24.2",
+		Image:     "ghcr.io/trianalab/pacto/dashboard:0.24.2",
 		Namespace: "test-ns",
 		OCISecret: "bad-secret",
 	}
@@ -519,7 +519,7 @@ func TestReconcile_OCICredentials_MergeError(t *testing.T) {
 func TestReconcile_Cleanup_IncludesManagedSecret(t *testing.T) {
 	cfg := Config{
 		Enabled:   true,
-		Image:     "ghcr.io/trianalab/pacto-dashboard:0.24.2",
+		Image:     "ghcr.io/trianalab/pacto/dashboard:0.24.2",
 		Namespace: "test-ns",
 	}
 	managedSecret := &corev1.Secret{

--- a/integrations/kubernetes/internal/dashboard/resources_test.go
+++ b/integrations/kubernetes/internal/dashboard/resources_test.go
@@ -14,7 +14,7 @@ import (
 
 var testConfig = Config{
 	Enabled:   true,
-	Image:     "ghcr.io/trianalab/pacto-dashboard:0.24.2",
+	Image:     "ghcr.io/trianalab/pacto/dashboard:0.24.2",
 	Namespace: "pacto-system",
 }
 
@@ -198,7 +198,7 @@ func TestBuildDeployment(t *testing.T) {
 func TestBuildDeploymentWithWatchNamespace(t *testing.T) {
 	cfg := Config{
 		Enabled:        true,
-		Image:          "ghcr.io/trianalab/pacto-dashboard:0.24.2",
+		Image:          "ghcr.io/trianalab/pacto/dashboard:0.24.2",
 		Namespace:      "pacto-system",
 		WatchNamespace: "production",
 	}
@@ -230,7 +230,7 @@ func TestBuildDeploymentWithoutWatchNamespace(t *testing.T) {
 func TestBuildDeploymentWithOCISecret(t *testing.T) {
 	cfg := Config{
 		Enabled:   true,
-		Image:     "ghcr.io/trianalab/pacto-dashboard:0.24.2",
+		Image:     "ghcr.io/trianalab/pacto/dashboard:0.24.2",
 		Namespace: "pacto-system",
 		OCISecret: "registry-creds",
 	}
@@ -285,7 +285,7 @@ func TestBuildDeploymentWithOCISecret(t *testing.T) {
 func TestBuildDeploymentWithOCISecrets(t *testing.T) {
 	cfg := Config{
 		Enabled:    true,
-		Image:      "ghcr.io/trianalab/pacto-dashboard:0.24.2",
+		Image:      "ghcr.io/trianalab/pacto/dashboard:0.24.2",
 		Namespace:  "pacto-system",
 		OCISecrets: []string{"ghcr-creds", "ecr-creds"},
 	}

--- a/release/release-manifest.json
+++ b/release/release-manifest.json
@@ -15,13 +15,13 @@
     },
     "dashboard-contract-bundle": {
       "artifactKind": "oci-image",
-      "coordinate": "ghcr.io/trianalab/pactos/pacto-dashboard",
+      "coordinate": "ghcr.io/trianalab/pacto/dashboard-contract",
       "tag": "3.0.1",
       "version": "3.0.1"
     },
     "dashboard-image": {
       "artifactKind": "oci-image",
-      "coordinate": "ghcr.io/trianalab/pacto-dashboard",
+      "coordinate": "ghcr.io/trianalab/pacto/dashboard",
       "tag": "3.0.1",
       "version": "3.0.1"
     },
@@ -45,13 +45,13 @@
     },
     "operator-chart": {
       "artifactKind": "helm-chart",
-      "coordinate": "ghcr.io/trianalab/pacto-operator/charts/pacto-operator",
+      "coordinate": "ghcr.io/trianalab/pacto/charts/pacto-operator",
       "tag": "5.0.0",
       "version": "5.0.0"
     },
     "operator-image": {
       "artifactKind": "oci-image",
-      "coordinate": "ghcr.io/trianalab/pacto-operator/pacto-controller",
+      "coordinate": "ghcr.io/trianalab/pacto/operator",
       "tag": "5.0.0",
       "version": "5.0.0"
     }

--- a/release/release-plan.json
+++ b/release/release-plan.json
@@ -14,13 +14,13 @@
           "unit": "cli"
         },
         {
-          "coordinate": "ghcr.io/trianalab/pacto-dashboard",
+          "coordinate": "ghcr.io/trianalab/pacto/dashboard",
           "kind": "oci-image",
           "tag": "3.0.1",
           "unit": "dashboard-image"
         },
         {
-          "coordinate": "ghcr.io/trianalab/pactos/pacto-dashboard",
+          "coordinate": "ghcr.io/trianalab/pacto/dashboard-contract",
           "kind": "oci-image",
           "tag": "3.0.1",
           "unit": "dashboard-contract-bundle"
@@ -46,7 +46,7 @@
           "unit": "k8s-module"
         },
         {
-          "coordinate": "ghcr.io/trianalab/pacto-operator/pacto-controller",
+          "coordinate": "ghcr.io/trianalab/pacto/operator",
           "kind": "oci-image",
           "tag": "5.0.0",
           "unit": "operator-image"
@@ -54,7 +54,7 @@
         {
           "appVersion": "5.0.0",
           "chartVersion": "5.0.0",
-          "coordinate": "ghcr.io/trianalab/pacto-operator/charts/pacto-operator",
+          "coordinate": "ghcr.io/trianalab/pacto/charts/pacto-operator",
           "defaultImageTag": "5.0.0",
           "kind": "helm-chart",
           "unit": "operator-chart"

--- a/release/units/dashboard-contract-bundle/package.json
+++ b/release/units/dashboard-contract-bundle/package.json
@@ -5,6 +5,6 @@
   "pacto": {
     "releaseUnit": "dashboard-contract-bundle",
     "kind": "oci-image",
-    "coordinate": "ghcr.io/trianalab/pactos/pacto-dashboard"
+    "coordinate": "ghcr.io/trianalab/pacto/dashboard-contract"
   }
 }

--- a/release/units/operator-chart/package.json
+++ b/release/units/operator-chart/package.json
@@ -5,6 +5,6 @@
   "pacto": {
     "releaseUnit": "operator-chart",
     "kind": "helm-chart",
-    "coordinate": "ghcr.io/trianalab/pacto-operator/charts/pacto-operator"
+    "coordinate": "ghcr.io/trianalab/pacto/charts/pacto-operator"
   }
 }

--- a/release/units/operator-image/package.json
+++ b/release/units/operator-image/package.json
@@ -5,6 +5,6 @@
   "pacto": {
     "releaseUnit": "operator-image",
     "kind": "oci-image",
-    "coordinate": "ghcr.io/trianalab/pacto-operator/pacto-controller"
+    "coordinate": "ghcr.io/trianalab/pacto/operator"
   }
 }

--- a/release/units/pacto-dashboard-image/package.json
+++ b/release/units/pacto-dashboard-image/package.json
@@ -5,6 +5,6 @@
   "pacto": {
     "releaseUnit": "dashboard-image",
     "kind": "oci-image",
-    "coordinate": "ghcr.io/trianalab/pacto-dashboard"
+    "coordinate": "ghcr.io/trianalab/pacto/dashboard"
   }
 }

--- a/tests/e2e/kind/v4-to-v5-upgrade.sh
+++ b/tests/e2e/kind/v4-to-v5-upgrade.sh
@@ -37,7 +37,7 @@ V4_TAG="4.7.0"
 # silently change what this cross-major migration test installs. Verified in
 # SOURCE.md; the guard below fails closed if the live tag no longer resolves here.
 V4_DIGEST="sha256:a2e8e27dd8b080e797436ab376cef3f95467c7f91c9408bacc09aad8ff769e7d"
-V5_REPO="pacto-operator/pacto-controller"
+V5_REPO="pacto/operator"
 V5_TAG="5.0.0-e2e"
 V5_IMG="${V5_REPO}:${V5_TAG}"
 CRD_PACTOS=pactos.pacto.trianalab.io

--- a/tests/release/stale_links_test.go
+++ b/tests/release/stale_links_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 )
 
-// staleOperatorRepoRE matches the archived operator GitHub REPO url. It does not
-// match the preserved public coordinates that keep the `pacto-operator` name —
-// the image/chart registry path (ghcr.io/trianalab/pacto-operator/…) and the
-// Artifact Hub repository (artifacthub.io/…/pacto-operator) — which are correct.
+// staleOperatorRepoRE matches the archived operator GitHub REPO url. Active
+// source/support links must point at the monorepo, never the archived repo. The
+// chart NAME `pacto-operator` is still used (Chart.yaml + the Artifact Hub
+// listing), but the ghcr registry path now lives under the `pacto` namespace.
 var staleOperatorRepoRE = regexp.MustCompile(`github\.com/[Tt]riana[Ll]ab/pacto-operator`)
 
 // isHistoricalRef lists the paths permitted to reference the old repo for


### PR DESCRIPTION
Moves every published package into the monorepo-owned `ghcr.io/trianalab/pacto/*` namespace so nothing depends on the archived `pacto-operator` repo.

| Artifact | New coordinate |
|---|---|
| operator image | `ghcr.io/trianalab/pacto/operator` |
| operator chart | `ghcr.io/trianalab/pacto/charts/pacto-operator` |
| dashboard image | `ghcr.io/trianalab/pacto/dashboard` |
| dashboard contract bundle | `ghcr.io/trianalab/pacto/dashboard-contract` |
| demo bundles | `ghcr.io/trianalab/pacto/*` (already) |

Rewrites every coordinate (release.yml, Chart.yaml, values.yaml, integration.yaml, manifest/plan, docs, chart README) + regenerated generated docs. **Chart name `pacto-operator` and the Artifact Hub repository are preserved** — after release, re-point the AH repository URL to `oci://ghcr.io/trianalab/pacto/charts/pacto-operator` (repositoryID unchanged). Go module paths (`/v3`, `/v5`) unchanged; minor group bump (v3.1.0 / v5.1.0). Old coords + the v4 upgrade fixture left as historical.