### PR TITLE
fix(release): fold the WASM demo into the released docs deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -610,6 +610,13 @@ jobs:
           node-version: '22'
       - name: Build the WASM dashboard demo
         run: make -C examples/demo build
+      # Fold the demo into the docs tree so mike's internal `mkdocs build` copies it
+      # into the released version deploy at /demo/ (mirrors docs.yml). Without this
+      # the demo is built but never lands in the version slot, so /latest/demo/ 404s.
+      - name: Fold the demo into the docs site
+        run: |
+          mkdir -p docs/demo
+          cp -r examples/demo/dist/. docs/demo/
       - name: Deploy versioned docs with mike (exact release versions)
         env:
           PACTO_DOCS_CORE_VERSION: ${{ needs.detect.outputs.core_version }}


### PR DESCRIPTION
The release docs job built the WASM dashboard demo into `examples/demo/dist` but never copied it into `docs/demo/`. mike deploys the mkdocs site (which reads `docs/`), so the released version slot shipped without `/demo/` and `pacto.run/latest/demo/` returned 404.

`docs.yml` (the dev `next` deploy) already has a "Fold the demo into the docs site" step that copies `examples/demo/dist/. -> docs/demo/` before deploying, which is why `next/demo/` exists but the released versions do not. This mirrors that exact step in `release.yml` so every released version publishes the demo.

The live site was restored separately by copying the already-published `next/demo/` assets into the `3.0.1/` version slot on `gh-pages`; this PR makes the fix durable for future releases.