### PR TITLE
fix(docs): reveal the version selector in the header + single-row README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,4 @@
-[![CI](https://github.com/TrianaLab/pacto/actions/workflows/ci.yml/badge.svg)](https://github.com/TrianaLab/pacto/actions/workflows/ci.yml)
-[![Docs](https://img.shields.io/badge/docs-pacto.run-blue)](https://pacto.run)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/trianalab/pacto/v3)](https://pkg.go.dev/github.com/trianalab/pacto/v3)
-[![codecov](https://codecov.io/github/TrianaLab/pacto/graph/badge.svg?token=p3AJpP3BbO)](https://codecov.io/github/TrianaLab/pacto)
-[![GitHub Release](https://img.shields.io/github/v/release/TrianaLab/pacto)](https://github.com/TrianaLab/pacto/releases/latest)
-[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/pacto-operator)](https://artifacthub.io/packages/search?repo=pacto-operator)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![CI](https://github.com/TrianaLab/pacto/actions/workflows/ci.yml/badge.svg)](https://github.com/TrianaLab/pacto/actions/workflows/ci.yml) [![Docs](https://img.shields.io/badge/docs-pacto.run-blue)](https://pacto.run) [![PkgGoDev](https://pkg.go.dev/badge/github.com/trianalab/pacto/v3)](https://pkg.go.dev/github.com/trianalab/pacto/v3) [![codecov](https://codecov.io/github/TrianaLab/pacto/graph/badge.svg?token=p3AJpP3BbO)](https://codecov.io/github/TrianaLab/pacto) [![GitHub Release](https://img.shields.io/github/v/release/TrianaLab/pacto)](https://github.com/TrianaLab/pacto/releases/latest) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/pacto-operator)](https://artifacthub.io/packages/search?repo=pacto-operator) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 # Pacto
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -375,3 +375,22 @@
   from { opacity: 0; transform: translateY(0.5rem); }
   to   { opacity: 1; transform: none; }
 }
+
+/* ---- Header: keep the mike version selector visible ------------------------
+   The mike version selector is injected into the header's site-name topic.
+   Material swaps that topic for the page-title topic on scroll (adds
+   .md-header__title--active), which hides the selector — and with the sticky
+   tabs header that active state is set even at the top, so the selector never
+   shows. Keep the site-name topic (and its version selector) visible and drop
+   the page-title-in-header swap; the page title still shows as the content H1. */
+.md-header__title--active .md-header__ellipsis > .md-header__topic:first-child {
+  z-index: 1;
+  opacity: 1;
+  pointer-events: auto;
+  transform: none;
+}
+.md-header__title--active .md-header__ellipsis > .md-header__topic[data-md-component="header-topic"] {
+  z-index: -1;
+  opacity: 0;
+  pointer-events: none;
+}


### PR DESCRIPTION
Two docs/README fixes.

**Version selector not showing.** The mike version selector renders correctly but lives in the header's site-name topic. Material swaps that topic for the page title on scroll (adds `.md-header__title--active`), which hides the selector — and with the sticky-tabs header that active state is set even at the top, so the dropdown never appeared. The CSS keeps the site-name topic (and its selector) visible and drops the page-title-in-header swap.

Verified in a mike-style multi-version replica: the header shows `Pacto | <version> v`, `/latest/` displays the latest version by default, and selecting a version navigates to it and updates the displayed version.

**README badges.** They were each on their own line, which GitHub rendered as a vertical stack. Collapsed onto one line so they render as a horizontal row (added a `docs -> pacto.run` badge).

CSS + README only — no frontend/UI-bundle change.