### PR TITLE
fix(demo): label the demo navbar with the core version, not the k8s submodule tag

### DIFF
--- a/examples/demo/Makefile
+++ b/examples/demo/Makefile
@@ -21,11 +21,14 @@ GOROOT      := $(shell go env GOROOT)
 SERVE_PORT  ?= 8088
 FRONTEND    := $(abspath ../../pkg/dashboard/frontend)
 UI_BUILD    := $(abspath .ui-build)
-# Pacto version this demo is built from — the latest release tag, surfaced in the
-# dashboard navbar via -ldflags into the wasm. Uses --abbrev=0 for a clean
-# "vX.Y.Z" label. Needs tags available (CI must checkout with fetch-depth: 0);
-# falls back to a short SHA, then "dev", when no tags are present.
-VERSION     ?= $(shell git describe --tags --abbrev=0 2>/dev/null || git rev-parse --short HEAD 2>/dev/null || echo dev)
+# Pacto CORE version this demo is built from — the latest core release tag,
+# surfaced in the dashboard navbar via -ldflags into the wasm. `--match 'v[0-9]*'`
+# restricts to core "vX.Y.Z" tags so the k8s submodule tag
+# (integrations/kubernetes/vX.Y.Z), which git describe would otherwise pick as the
+# most recent, never leaks into the navbar. Uses --abbrev=0 for a clean label.
+# Needs tags available (CI must checkout with fetch-depth: 0); falls back to a
+# short SHA, then "dev", when no tags are present.
+VERSION     ?= $(shell git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || git rev-parse --short HEAD 2>/dev/null || echo dev)
 
 .PHONY: build preflight ui wasm wasmexec inject serve test validate smoke clean diff breaking-change evolution explain demo-locks
 


### PR DESCRIPTION
The WASM demo navbar showed `integrations/kubernetes/v5.1.0`. The Makefile derives the label from `git describe --tags --abbrev=0`, which returns the most recent tag — and after a coordinated release that is the k8s submodule tag `integrations/kubernetes/vX.Y.Z`, not the core `vX.Y.Z`.

Fix: `--match 'v[0-9]*'` restricts the describe to core version tags, so it resolves to `v3.1.0`. Verified locally at the v3.1.0 commit: old → `integrations/kubernetes/v5.1.0`, new → `v3.1.0`.

The live `/latest/demo/` navbar updates on the next docs deploy of that version.