### PR TITLE
docs: version selector — remove 'next' + scrollable list

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Deploy docs
+name: Docs (validate)
 
 on:
   push:
@@ -27,24 +27,16 @@ on:
       # The demo embeds the dashboard UI + engine, so redeploy when they change.
       - 'pkg/dashboard/**'
       - '.github/workflows/docs.yml'
-  # Release-time docs are deployed by the release transaction (release.yml, unit
-  # k8s-docs), which owns the versioned site deploy with the exact core + k8s
-  # versions. This workflow only redeploys the CURRENT version's docs on a
-  # doc-only change to main (no release), plus manual runs. It no longer
-  # self-triggers on release/workflow_run (that was a duplicate deploy that read
-  # the "latest release" and raced the release job).
+  # The versioned public site is deployed ONLY by the release transaction
+  # (release.yml, unit k8s-docs), which owns the exact core + k8s versions and the
+  # `latest` alias. This workflow does NOT deploy: on a doc-only change to main it
+  # just runs a strict build to validate the docs (a post-merge safety net on top
+  # of the PR docs-check). It no longer publishes an unreleased `next` snapshot.
   workflow_dispatch:
 
-# mike commits the built site to the gh-pages branch and pushes it, so the deploy
-# needs write access to repository contents (not the Pages upload API).
+# Validation only — no deploy — so read access is enough.
 permissions:
-  contents: write
-
-# Serialize deploys: two concurrent `mike deploy --push` runs would race on the
-# gh-pages branch.
-concurrency:
-  group: docs-deploy
-  cancel-in-progress: false
+  contents: read
 
 jobs:
   # Non-release doc refresh. The release UNIT k8s-docs (the versioned site deploy
@@ -83,15 +75,14 @@ jobs:
         run: |
           mkdir -p docs/demo
           cp -r examples/demo/dist/. docs/demo/
-      # Strict gate before publishing: mike's internal build is not --strict, so run
-      # the same strict build the PR "Docs check" enforces against a throwaway dir.
+      # Strict gate: mike's internal build is not --strict, so run the same strict
+      # build the PR "Docs check" enforces, against a throwaway dir. This is a
+      # main-push validation net; it does NOT deploy.
+      #
+      # The versioned public site is deployed only by the release transaction
+      # (release.yml, unit k8s-docs). We intentionally do NOT publish an
+      # unreleased `next` snapshot: it cluttered the public version selector (and
+      # was the fallback the selector landed on). Preview unreleased docs locally
+      # with `make docs` / `mkdocs serve`.
       - name: Strict docs build gate
         run: mkdocs build --strict --site-dir "$(mktemp -d)"
-      # Publish ONLY the unreleased `next` snapshot to gh-pages. This non-release
-      # path must never move `latest` or write a released version slot — that is the
-      # release transaction's job (release.yml, unit k8s-docs, `make docs-deploy`).
-      - name: Deploy the dev (next) docs snapshot with mike
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          make docs-deploy-dev

--- a/ci.mk
+++ b/ci.mk
@@ -117,14 +117,6 @@ docs-deploy: docs-generate
 	mike deploy --push --update-aliases "$$ver" latest; \
 	mike set-default --push latest
 
-# DEV docs deploy (docs.yml, non-release main-push): publish an unreleased `next`
-# snapshot ONLY. It must NEVER move `latest` or write into a released version slot,
-# so merging a breaking PR before its version PR releases cannot mislabel the stable
-# docs. The Material version selector shows `next` alongside the released versions.
-docs-deploy-dev: docs-generate
-	@echo "==> mike deploy --push next (unreleased dev snapshot; no alias move, no released slot)"; \
-	mike deploy --push --title "next (unreleased)" next
-
 # Full documentation gate: regenerate from scratch, prove zero drift and zero
 # second-run diff, strict build, and validate every fenced contract / CR example /
 # flag / chart / artifact coordinate against the real sources. See docs_check.py.

--- a/docs/maintainers/releases.md
+++ b/docs/maintainers/releases.md
@@ -115,11 +115,12 @@ Artifact Hub failure never leaves a published-but-unrecorded chart or wedges a r
 
 ## Docs versioning
 
-`mike` publishes to `gh-pages`. A **release** deploys the exact released core version
-and moves the `latest` alias + default (`make docs-deploy`). A **non-release**
-main-push publishes only an unreleased `next` snapshot and never touches `latest` or a
-released slot (`make docs-deploy-dev`). So merging a breaking PR before its Version PR
-releases cannot mislabel the stable docs.
+`mike` publishes to `gh-pages`. Only a **release** deploys the docs: it publishes the
+exact released core version and moves the `latest` alias + default (`make docs-deploy`).
+A **non-release** main-push does NOT deploy — `docs.yml` runs a strict build only, to
+validate the docs. So merging a breaking PR before its Version PR releases can never
+mislabel the stable docs or move `latest`. There is no published `next` snapshot in the
+version selector; preview unreleased docs locally with `make docs` / `mkdocs serve`.
 
 ## Demo bundle immutability
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -394,3 +394,10 @@
   opacity: 0;
   pointer-events: none;
 }
+
+/* Version selector: cap the dropdown height and scroll once the released versions
+   outgrow the viewport, so a long list never runs off-screen. */
+.md-version__list {
+  max-height: 75vh;
+  overflow-y: auto;
+}

--- a/tests/release/docs_versioning_test.go
+++ b/tests/release/docs_versioning_test.go
@@ -8,12 +8,14 @@ import (
 	"testing"
 )
 
-// Release-safety item 6: dev docs (a non-release main-push) must publish only an
-// unreleased `next` snapshot — never move `latest` and never write a released
-// version slot. Only the release transaction (release.yml unit k8s-docs) deploys
-// the exact released version + moves latest. This gate encodes the scenario of
-// merging this breaking PR while the manifest still names the old stable version:
-// with it green, that merge (docs.yml) cannot alter stable docs or the latest alias.
+// Release-safety item 6: a non-release main-push (docs.yml) must NEVER deploy the
+// versioned public site. It only validates the docs (strict build); the release
+// transaction (release.yml unit k8s-docs) is the sole publisher of the versioned
+// site and the only thing that moves the `latest` alias. docs.yml no longer
+// publishes an unreleased `next` snapshot: that cluttered the public version
+// selector (and was the fallback the selector landed on). With this gate green,
+// merging a breaking PR before its Version PR releases cannot alter stable docs,
+// move latest, or add a `next` entry to the version dropdown.
 
 // makeRecipe returns the recipe lines of a make target from a Makefile-like text.
 func makeRecipe(text, target string) string {
@@ -50,27 +52,25 @@ func TestDocsDevDeployNeverMovesLatest(t *testing.T) {
 	}
 	ci := read("ci.mk")
 
-	dev := makeRecipe(ci, "docs-deploy-dev")
-	if dev == "" {
-		t.Fatal("ci.mk has no docs-deploy-dev target")
-	}
-	if strings.Contains(dev, "latest") || strings.Contains(dev, "update-aliases") {
-		t.Errorf("docs-deploy-dev must NOT move latest or use --update-aliases; recipe:\n%s", dev)
-	}
-	if !strings.Contains(dev, "next") {
-		t.Errorf("docs-deploy-dev must deploy the `next` snapshot; recipe:\n%s", dev)
-	}
-
+	// The RELEASE docs-deploy target is the only one that moves the latest alias.
 	rel := makeRecipe(ci, "docs-deploy")
 	if !strings.Contains(rel, "latest") {
 		t.Errorf("the RELEASE docs-deploy target must move the latest alias; recipe:\n%s", rel)
 	}
 
-	// The non-release workflow must call the dev target; the release workflow the
-	// release target.
+	// The unreleased `next` preview was removed, so its deploy target must be gone.
+	if makeRecipe(ci, "docs-deploy-dev") != "" {
+		t.Error("ci.mk must no longer define docs-deploy-dev (the `next` preview was removed)")
+	}
+
+	// The non-release workflow must NOT deploy the site at all: no `mike deploy`,
+	// no release docs-deploy, and no leftover dev-deploy call. It only validates.
 	docs := read(".github/workflows/docs.yml")
-	if !strings.Contains(docs, "make docs-deploy-dev") {
-		t.Error("docs.yml (non-release) must call `make docs-deploy-dev`")
+	if strings.Contains(docs, "mike deploy") {
+		t.Error("docs.yml (non-release) must not run `mike deploy` (deploys are release-only)")
+	}
+	if strings.Contains(docs, "docs-deploy-dev") {
+		t.Error("docs.yml must not call docs-deploy-dev (the `next` preview was removed)")
 	}
 	if regexp.MustCompile(`make docs-deploy(\s|$)`).MatchString(docs) {
 		t.Error("docs.yml (non-release) must NOT call the release `make docs-deploy` (it moves latest)")


### PR DESCRIPTION
The docs version dropdown showed **"next (unreleased)"** — undesirable, and because `next` is the first `versions.json` entry it was the fallback the selector displayed as the current version on `/latest/`.

`next` was published by `docs.yml` on every docs-affecting main push (`make docs-deploy-dev`). This removes that:
- `docs.yml` now runs a **strict build only** (validation, no deploy) on main pushes; renamed accordingly, downgraded to `contents: read`.
- Removed the dead `docs-deploy-dev` target from `ci.mk`.
- Updated the release-safety gate test (`docs_versioning_test.go`) to assert docs.yml never deploys, and the maintainer docs.

The versioned public site is deployed **only** by the release transaction (unit `k8s-docs`), which still owns the `latest` alias. Preview unreleased docs locally with `make docs` / `mkdocs serve`.

After merge I will delete the existing `next` version from `gh-pages` so it leaves the live dropdown.