### PR TITLE
docs: mark the newest release as 'latest' in the version selector

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,9 @@ extra:
       link: https://github.com/TrianaLab/pacto
   version:
     provider: mike
+    # Show the alias (e.g. "latest") next to the current version in the selector,
+    # so the newest release is clearly marked as latest.
+    alias: true
 
 markdown_extensions:
   - abbr


### PR DESCRIPTION
Adds `extra.version.alias: true` so the mike version dropdown shows the `latest` alias tag on the current release (e.g. "3.1.0 · latest"), making it clear which version is latest.

Already applied to the live gh-pages slots; this makes it durable for future deploys.