### PR TITLE
perf(ci): native operator cross-compile + disk-guarded Go cache + sharded kind e2e

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -1,5 +1,5 @@
 name: CI
-description: Shared CI step — setup Go and run a make target
+description: Shared CI step — setup Go with disk-guarded caching and run a make target
 
 inputs:
   target:
@@ -20,6 +20,9 @@ runs:
     - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version-file: go.mod
+        # We manage the Go cache explicitly below (disk-guarded); disable setup-go's
+        # built-in cache so the two do not fight over the same paths.
+        cache: false
 
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       if: inputs.node == 'true'
@@ -28,12 +31,38 @@ runs:
         cache: 'npm'
         cache-dependency-path: pkg/dashboard/frontend/package-lock.json
 
+    # Best-effort caching: if the runner is low on disk, WARN and SKIP the cache for
+    # this run instead of risking a disk-full failure. Never exits non-zero.
+    - name: Cache disk guard
+      id: cacheguard
+      shell: bash
+      run: |
+        min_mb=5000
+        avail="$(df -Pm "$HOME" 2>/dev/null | awk 'NR==2{print $4}')"
+        if [ -n "$avail" ] && [ "$avail" -ge "$min_mb" ]; then
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::Go build/mod cache skipped — only ${avail:-unknown} MB free on \$HOME (need >= ${min_mb} MB)."
+        fi
+
+    - name: Resolve Go cache dirs
+      id: gocache
+      if: steps.cacheguard.outputs.enabled == 'true'
+      shell: bash
+      run: |
+        echo "build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
     - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      if: steps.cacheguard.outputs.enabled == 'true'
+      continue-on-error: true
       with:
         path: |
-          ~/.cache/go-build
-          ${{ env.GOPATH }}/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          ${{ steps.gocache.outputs.build }}
+          ${{ steps.gocache.outputs.mod }}
+        # Workspace-aware: bust on any module's go.sum OR the workspace go.work.sum.
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum', 'go.work.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,13 @@ jobs:
     needs: changes
     if: needs.changes.outputs.e2e == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    # Shard the three self-provisioning kind scenarios across parallel runners (each
+    # spins up its own cluster) instead of running them serially in one job. The
+    # `required` aggregate waits for all matrix legs, so coverage is unchanged.
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario: [reconcile, dashboard, upgrade]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -199,7 +206,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.30.0
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
-      - run: make ci-e2e-kind
+      - run: make ci-e2e-kind-${{ matrix.scenario }}
 
   release-dry-run:
     needs: changes

--- a/ci.mk
+++ b/ci.mk
@@ -8,7 +8,7 @@ BUNDLE_DIR := pactos/pacto-dashboard
 REPOWISE_VERSION ?= 0.36.0
 
 .PHONY: ci ci-static ci-static-engine ci-engine ci-dashboard ci-integration-kubernetes \
-       ci-e2e-envtest ci-e2e-kind ci-e2e-kind-dashboard ci-e2e-kind-upgrade ci-oci ci-gates docs-generate docs-check artifact-drift release-dry-run \
+       ci-e2e-envtest ci-e2e-kind ci-e2e-kind-dashboard ci-e2e-kind-upgrade ci-e2e-kind-reconcile ci-oci ci-gates docs-generate docs-check artifact-drift release-dry-run \
        verify-k8s-standalone ci-test ci-ui ui-build ci-ui-drift ci-fmt ci-vet ci-cyclo ci-lint ci-arch ci-docs \
        gen-openapi gen-config-schema gen-sbom gen-bundle
 
@@ -60,14 +60,19 @@ ci-e2e-envtest:
 # published v4 chart + its v4 CRDs, server-side apply the new CRDs, helm upgrade to
 # the v5 chart, prove existing resources survive). dashboard-modes + upgrade run
 # first (fast guards); run.sh then covers the full enabled reconcile cycle.
-ci-e2e-kind: ci-e2e-kind-dashboard ci-e2e-kind-upgrade
-	bash tests/e2e/kind/run.sh
+# CI shards these three self-provisioning scenarios across a matrix (each spins up
+# its own kind cluster, so they run independently in parallel); `make ci-e2e-kind`
+# still runs all three locally.
+ci-e2e-kind: ci-e2e-kind-dashboard ci-e2e-kind-upgrade ci-e2e-kind-reconcile
 
 ci-e2e-kind-dashboard:
 	bash tests/e2e/kind/dashboard-modes.sh
 
 ci-e2e-kind-upgrade:
 	bash tests/e2e/kind/v4-to-v5-upgrade.sh
+
+ci-e2e-kind-reconcile:
+	bash tests/e2e/kind/run.sh
 
 # OCI leg: the public oci package tests + the staging release-publisher tests.
 ci-oci:

--- a/integrations/kubernetes/Dockerfile
+++ b/integrations/kubernetes/Dockerfile
@@ -2,7 +2,12 @@
 # Monorepo-aware build: context is the repository ROOT so the operator module
 # resolves the engine (github.com/trianalab/pacto/v3) through the workspace
 # (go.work) instead of a published tag — no replace, no unreleased-tag dependency.
-FROM golang:1.26.5 AS builder
+# Pin the builder to the BUILD platform so `go build` runs NATIVELY and
+# cross-compiles to $TARGETARCH (CGO_ENABLED=0 below) instead of running under QEMU
+# emulation for the non-native arch — the arm64 build was the multi-arch release
+# pole. The distroless/static runtime stage has no RUN, so nothing executes under the
+# target platform. Matches the root Dockerfile's cross-compile pattern.
+FROM --platform=$BUILDPLATFORM golang:1.26.5 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION=dev


### PR DESCRIPTION
Speeds up CI + release without touching the release workflow, the OCI publish adapter, or runners. Highest-ROI change per dimension the analysis surfaced; the per-arch native-runner split is deferred (mostly unnecessary once the operator cross-compiles natively).

## Multi-arch (the ~15-20 min pole)
The operator Dockerfile builder wasn't pinned to `$BUILDPLATFORM`, so its arm64 `go build` ran under **QEMU emulation**. Pinning it cross-compiles arm64 **natively** (the build already sets `GOARCH=$TARGETARCH`, `CGO_ENABLED=0`); the distroless/static runtime stage has no `RUN`, so zero QEMU remains. Matches the root Dockerfile. The shared adapter still records the same index digest — verify/adopt/immutability/record semantics unchanged.

## Caching (disk-guarded, never fails the job)
The shared `ci` composite double-cached (setup-go built-in **and** an explicit `actions/cache`) and cached a bogus `/pkg/mod` (`${{ env.GOPATH }}` is empty in a composite). Now: disable setup-go's cache, cache the real `GOCACHE`+`GOMODCACHE`, key on every `go.sum` + `go.work.sum`. A **disk-guard** pre-step warns and skips caching when the runner is low on disk (< 5 GB free), and the cache step is `continue-on-error` — a full disk can never fail the job.

## Parallelization / matrix
`ci-e2e-kind` (the longest CI leg) ran three self-provisioning kind scenarios serially. Sharded into a parallel matrix (`reconcile` / `dashboard` / `upgrade`); the `required` aggregate waits for all legs, so coverage is unchanged.

## Deferred (follow-up)
Per-arch native-runner split + buildx GHA layer cache (release.yml) — measure post-merge; the operator QEMU cost is gone after the pin. Workspace-aware keys on the eight raw `setup-go` jobs, and splitting `ci-integration-kubernetes` (envtest vs helm).