### PR TITLE
chore(release): patch to ship + validate the native per-arch image pipeline

### DIFF
--- a/.changeset/validate-per-arch-builds.md
+++ b/.changeset/validate-per-arch-builds.md
@@ -1,0 +1,9 @@
+---
+"@pacto/core": patch
+"@pacto/k8s-module": patch
+---
+
+Rebuild the operator and dashboard container images through the new native per-arch
+build pipeline: each architecture builds on its own runner (no QEMU emulation) and is
+merged into the multi-arch manifest. No functional change to the engine, operator, or
+dashboard — this release ships and validates the faster image pipeline.


### PR DESCRIPTION
Coordinated core + k8s **patch** (v3.1.2 / v5.1.2) that rebuilds the operator and dashboard images through the new native per-arch build pipeline (#282 $BUILDPLATFORM pin + #283 per-arch runner matrix). No functional change to the engine, operator, or dashboard — this validates the multi-arch build+merge jobs end-to-end in a real release. Both groups bump so both `operator-image` and `dashboard-image` per-arch builds are exercised.