### PR TITLE
fix(docs): open the version selector on click, not hover

### DIFF
--- a/docs/javascripts/version-selector.js
+++ b/docs/javascripts/version-selector.js
@@ -1,0 +1,24 @@
+// Open the mike version dropdown on CLICK, not hover. Material opens
+// .md-version__list on :hover, but that list sits directly over the nav tabs below
+// it — so it pops open when the mouse merely passes over and, worse, swallows the
+// tabs' clicks. Toggle an .md-version--open class from the trigger instead; close on
+// an outside click or Escape. Delegated on document so it survives Material's instant
+// navigation (the header, and its version selector, persist across page swaps).
+document.addEventListener("click", function (e) {
+  var version = document.querySelector(".md-version");
+  if (!version) return;
+  if (e.target.closest(".md-version__current")) {
+    e.preventDefault();
+    version.classList.toggle("md-version--open");
+  } else if (!e.target.closest(".md-version__list")) {
+    // A click anywhere outside the trigger and the open list closes it. Clicks on a
+    // version link inside the list fall through so the navigation proceeds.
+    version.classList.remove("md-version--open");
+  }
+});
+
+document.addEventListener("keydown", function (e) {
+  if (e.key !== "Escape") return;
+  var version = document.querySelector(".md-version");
+  if (version) version.classList.remove("md-version--open");
+});

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -395,9 +395,24 @@
   pointer-events: none;
 }
 
-/* Version selector: cap the dropdown height and scroll once the released versions
-   outgrow the viewport, so a long list never runs off-screen. */
-.md-version__list {
+/* Version selector: open on CLICK only (toggled by javascripts/version-selector.js),
+   never on hover/focus. Material opens .md-version__list on :hover — but that list is
+   absolutely positioned directly over the nav tabs below it, so it popped open when
+   the mouse merely passed over the header and swallowed the tabs' clicks. Neutralise
+   the hover/focus open triggers and drive visibility from the .md-version--open class.
+   Keep Material's collapsed default (max-height:0) so the closed list never overlays
+   the tabs; cap the OPEN height so a long version list scrolls instead of running
+   off-screen (.md-version__list already has overflow:auto). */
+.md-version:hover .md-version__list,
+.md-version:focus-within .md-version__list {
+  max-height: 0;
+  opacity: 0;
+  pointer-events: none;
+  animation: none;
+}
+.md-version--open .md-version__list {
   max-height: 75vh;
-  overflow-y: auto;
+  opacity: 1;
+  pointer-events: auto;
+  animation: none;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,6 +139,7 @@ extra_css:
 
 extra_javascript:
   - javascripts/logo-spin.js
+  - javascripts/version-selector.js
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Bug
On the docs site, the mike version dropdown opened on **hover** and its list sat directly over the nav tabs below the header — so it popped open when the mouse passed over and **swallowed the tabs' clicks** (e.g. `Manifesto` was unclickable), and looked misaligned/overlapping.

## Cause
Material opens `.md-version__list` on `:hover`, and an earlier override (`docs/stylesheets/extra.css`) set its `max-height: 75vh` **unconditionally** — defeating Material's collapsed `max-height: 0` default. The `opacity:0` list therefore stayed full-height, overlaid the tabs, and captured their pointer events even when 'closed'.

## Fix
- Open on **click** via an `.md-version--open` class toggled by `docs/javascripts/version-selector.js` (delegated on `document` so it survives `navigation.instant`; closes on outside-click or Escape).
- Neutralise Material's `:hover`/`:focus-within` open triggers; keep the list collapsed (`max-height:0`) when closed so it never overlays the tabs.
- Apply the 75vh scroll cap only when open.

Alignment is restored as a result — Material aligns the items under the trigger once the list collapses correctly. `mkdocs build --strict` passes.

## Deploy note
`docs.yml` is validation-only; the live `latest` site is redeployed by the release (k8s-docs unit). Getting this onto `pacto.run/latest/` needs a docs redeploy of the current version (see PR discussion).