### PR TITLE
chore(release): patch to deploy the docs version-selector fix

### DIFF
--- a/.changeset/deploy-docs-version-selector-fix.md
+++ b/.changeset/deploy-docs-version-selector-fix.md
@@ -1,0 +1,8 @@
+---
+"@pacto/core": patch
+---
+
+Deploy the docs version-selector fix to the live site: the mike version dropdown
+now opens on click, not hover, so it no longer pops over the nav tabs and swallows
+their clicks. Docs-only change (PR #286); no functional change to the engine, CLI,
+or dashboard. This core patch is the release that redeploys pacto.run/latest.


### PR DESCRIPTION
Cut a core patch (v3.1.3) whose sole purpose is to redeploy the versioned docs site with the version-selector fix from #286.

## Why a release
`docs.yml` is validation-only; the live `pacto.run/latest` site is redeployed only by the release pipeline's docs unit (`mike deploy --update-aliases <core> latest`), and the release policy reserves touching a stable version or `latest` to a release transaction. Merging #286 landed the fix on `main` but did not deploy it. This changeset is the release that ships it.

## Scope
- Core-only patch changeset. The docs job triggers on `core` in the release units, so no k8s bump is needed (k8s stays at v5.1.2).
- Docs-only content change (#286): the mike version dropdown opens on click instead of hover, so it no longer overlaps the nav tabs or swallows their clicks. No functional change to the engine, CLI, or dashboard.

## Flow
Merging this opens the changesets "Version Packages" PR; merging that publishes v3.1.3 and the docs unit redeploys `latest` with the fix.