### PR TITLE
fix(docs): make the version dropdown open on click (specificity fix)

### DIFF
--- a/.changeset/version-selector-click-fix.md
+++ b/.changeset/version-selector-click-fix.md
@@ -1,0 +1,9 @@
+---
+"@pacto/core": patch
+---
+
+Fix the docs version selector so it opens on click. After the previous fix it no
+longer opened on hover (intended) but a `:focus-within` rule out-ranked the open
+class on click, so the dropdown stayed collapsed. Gated the hover/focus suppress
+rules with `:not(.md-version--open)` and raised the open rule's specificity.
+Docs-only; this core patch is the release that redeploys pacto.run/latest.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -400,17 +400,20 @@
    absolutely positioned directly over the nav tabs below it, so it popped open when
    the mouse merely passed over the header and swallowed the tabs' clicks. Neutralise
    the hover/focus open triggers and drive visibility from the .md-version--open class.
+   The suppress rules are gated with :not(.md-version--open) because clicking the
+   trigger FOCUSES it, and an un-gated .md-version:focus-within rule (specificity 0,3,0)
+   would out-rank the .md-version--open show rule and keep the list collapsed on click.
    Keep Material's collapsed default (max-height:0) so the closed list never overlays
    the tabs; cap the OPEN height so a long version list scrolls instead of running
    off-screen (.md-version__list already has overflow:auto). */
-.md-version:hover .md-version__list,
-.md-version:focus-within .md-version__list {
+.md-version:not(.md-version--open):hover .md-version__list,
+.md-version:not(.md-version--open):focus-within .md-version__list {
   max-height: 0;
   opacity: 0;
   pointer-events: none;
   animation: none;
 }
-.md-version--open .md-version__list {
+.md-version.md-version--open .md-version__list {
   max-height: 75vh;
   opacity: 1;
   pointer-events: auto;


### PR DESCRIPTION
## Problem
After #286 the version selector no longer opened on hover (good) but no longer opened on **click** either — clicking the trigger did nothing.

## Root cause
`extra.css` neutralised Material's hover/focus auto-open and drove visibility from a `.md-version--open` class toggled by `version-selector.js`. But clicking the trigger (`<button class="md-version__current">`) **focuses** it, so Material's/our `.md-version:focus-within .md-version__list` rule — specificity **(0,3,0)** — out-ranked the `.md-version--open .md-version__list` show rule at **(0,2,0)** and forced `max-height:0`. The class toggled, but the list stayed collapsed.

## Fix
- Gate the hover/focus suppress rules with `:not(.md-version--open)` so they stop applying once the list is explicitly opened.
- Raise the open rule to `.md-version.md-version--open .md-version__list` (0,3,0) so it decisively beats Material's collapsed default.

CSS-only; `version-selector.js` is unchanged.

## Verification
Rendered the real Material version-selector DOM with the real compiled `main.css` + the patched `extra.css`/JS in headless Chromium and asserted each state:
- initial: closed
- hover: does not open
- click: opens (computed max-height 675px, opacity 1, visible)
- Escape and outside-click: close
- closed selector does not overlay the nav tabs

The same test run against the pre-fix CSS fails the "click opens" assertions (class toggles, list stays collapsed) — i.e. it reproduces the reported bug and confirms the fix resolves it.