### PR TITLE
fix(release): supersede the half-shipped 3.2.0 with 3.2.1 and gate both causes

### DIFF
--- a/.changeset/quiet-pugs-shave.md
+++ b/.changeset/quiet-pugs-shave.md
@@ -1,0 +1,29 @@
+---
+"@pacto/core": patch
+"@pacto/k8s-module": patch
+---
+
+Make a demo-fixture edit unable to half-ship a release.
+
+Release run 32560058692 published four irreversible units and then died. Two
+independent defects had to line up for that, and both are closed here.
+
+The demo bundles publish to immutable tags. `payments-service` 2.1.0 was edited
+in place — a mermaid diagram added to a version already published — so the
+byte-exact gate correctly refused the tag, but it refused it mid-release,
+because nothing ran that gate before the release. The fixture is restored to its
+published bytes and the diagram ships as a new `payments-service` 2.1.1, and
+`publish-demo-bundles.sh --check` now runs the identical gate read-only at PR
+time as the `demo-bundle-immutability` CI leg.
+
+Separately, the `demo-compose` job lost its ORAS install when the unit moved to
+`docker compose publish`, on the reasoning that ORAS stayed where the ledger
+used it — while that job still read and wrote the ledger, which *is* the ORAS
+user. `ledger.sh` returned the empty string for a missing binary, the empty
+string means "nothing recorded", and the unit failed closed. `ledger.sh` now
+refuses to run without its tools and distinguishes a 404 from an unreadable
+registry; the two `if [ "$(ledger.sh …)" ]` call sites that discarded its exit
+status now assign first; and a new gate walks every job's shell through its make
+targets and scripts and fails when a job can reach a CLI it never installed.
+That gate found a second, quieter instance: the release dry run was rehearsing
+without `syft`, silently skipping the SBOM the real release produces.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,51 @@ jobs:
           version: v5.5.0
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
+      - name: Install syft
+        # build-cli.sh SKIPS the SBOM when syft is absent, so without this the
+        # dry run rehearses a release the real one does not perform.
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       - run: make release-dry-run
+
+  # The demo bundles are published to IMMUTABLE tags. Editing a fixture under a
+  # version that is already published makes that tag unpublishable, and until now
+  # the only thing that noticed was the release itself — mid-flight, after
+  # irreversible units had shipped (run 32560058692). This runs the identical
+  # byte-exact gate at PR time, READ-ONLY: it computes each bundle's deterministic
+  # OCI digest locally and compares it to the published one. It never pushes, and
+  # it names no coordinate — the script owns that.
+  demo-bundle-immutability:
+    needs: changes
+    if: needs.changes.outputs.release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+      - name: Install crane (the byte-exact comparison IS crane)
+        run: go install github.com/google/go-containerregistry/cmd/crane@v0.20.2
+      - name: Log in to GHCR (read-only, for the published-digest lookup)
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check demo bundles against their published digests
+        run: |
+          # 75 is EX_TEMPFAIL: the registry could not be read, so the check proved
+          # nothing. That is not a conflict and must not block a PR on someone
+          # else's outage — but it must not read as a pass either, hence the warning.
+          rc=0
+          release/scripts/publish-demo-bundles.sh --check || rc=$?
+          case "$rc" in
+            0) ;;
+            75) echo "::warning::the demo-bundle immutability check could not read the registry — it compared nothing this run, which is not evidence that there is no conflict" ;;
+            *) exit "$rc" ;;
+          esac
 
   # Cross-cutting architecture + release gates (tests/architecture + tests/release).
   # These live under /tests/ which the ci-engine coverage run EXCLUDES, so without
@@ -375,6 +419,7 @@ jobs:
       - ci-e2e-compose
       - release-dry-run
       - release-version-test
+      - demo-bundle-immutability
     runs-on: ubuntu-latest
     steps:
       - name: Verify no required leg failed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,7 +229,12 @@ jobs:
           # formula as release/orchestrator/detect.mjs and dry-run.sh, expressed in
           # jq: sorted-key compact JSON of {unit: version}, hashed with no newline.
           MSHA="$(jq -cS '.units | map_values(.version)' release/release-manifest.json | tr -d '\n' | sha256sum | cut -d' ' -f1)"
-          if [ -n "$(bash release/orchestrator/ledger.sh get "$TXN")" ]; then
+          # Assigned first, deliberately: a command substitution inside `[ ... ]`
+          # discards its exit status, so a FAILED ledger read would be
+          # indistinguishable from an ABSENT one and would take the init branch —
+          # re-initializing a live transaction is exactly what must never be silent.
+          META="$(bash release/orchestrator/ledger.sh get "$TXN")"
+          if [ -n "$META" ]; then
             # Resume: the existing ledger must describe THIS exact transaction —
             # matching transactionId + sourceSha + manifestSha — else fail closed.
             # (manifest read from the source_sha checkout, so MSHA is the source's.)
@@ -472,7 +477,11 @@ jobs:
       - name: Resume check (ledger)
         id: v
         run: |
-          if [ "$(bash release/orchestrator/ledger.sh status "$PACTO_RELEASE_TXN" demo-bundles)" = complete ]; then
+          # Assigned first so a failed ledger read aborts the step: inside
+          # `[ ... ]` the exit status is discarded, an unreadable ledger reads as
+          # "not complete", and the step republishes to a production coordinate.
+          STATE="$(bash release/orchestrator/ledger.sh status "$PACTO_RELEASE_TXN" demo-bundles)"
+          if [ "$STATE" = complete ]; then
             echo "state=identical" >> "$GITHUB_OUTPUT"
           else
             echo "state=absent" >> "$GITHUB_OUTPUT"
@@ -494,7 +503,10 @@ jobs:
   # scenario) projected into ONE compose file and published by Docker Compose
   # itself, because Compose owns this OCI artifact type — `docker compose publish`
   # writes it and `docker compose -f oci://…@sha256:…` runs it, with no generic OCI
-  # tool and no install step in between. The demo runs the dashboard image THIS
+  # tool in between. (ORAS is still installed below: this job READS the release
+  # ledger, which is an OCI artifact, to pin the dashboard image by digest, and
+  # WRITES it through publish-oci-unit.sh. Removing that install is what half-shipped
+  # release run 32560058692.) The demo runs the dashboard image THIS
   # transaction published, which is why the job depends on it; `always()` keeps a
   # single-unit recovery runnable on its own, exactly as the final `release` job does.
   #
@@ -534,6 +546,11 @@ jobs:
         run: |
           go install github.com/google/go-containerregistry/cmd/crane@v0.20.2
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: Install ORAS
+        # NOT for the Compose artifact — Compose publishes that (see the job
+        # comment). For the release LEDGER, which this job reads below and writes
+        # through publish-oci-unit.sh, and which ledger.sh pulls with oras.
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
       - name: Log in to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:

--- a/docs/examples/dashboard-demo.md
+++ b/docs/examples/dashboard-demo.md
@@ -14,14 +14,14 @@ It showcases the full UI against a realistic set of services:
   infra and external tiers.
 - **Dependency graph** — resolved from each contract's declared dependencies,
   with blast-radius highlighting.
-- **Change analysis** — `payments-service` spans five versions; the
+- **Change analysis** — `payments-service` spans six versions; the
   `v1.2.0 → v2.0.0` step is a breaking change that removes the `/charges` API,
   and the same screen shows which consumers that break reaches.
 - **Readiness** — never a separate screen, because readiness is declared by a
   contract revision about itself. It is a *Needs attention* category, a
   distribution over every revision in the snapshot on the **Contract revisions**
   inventory (with a filter for each of its buckets) and a section on the revision
-  itself. `payments-service` 2.1.0 declares a readiness gate that fails: a
+  itself. `payments-service` 2.1.1 declares a readiness gate that fails: a
   required check (the LLM-safety eval suite) is `not-done`, dropping its score to
   70, below the required 80 — while `orders-service` 1.2.0 passes, and still runs
   on a target observed to be non-compliant, which is the difference between

--- a/docs/maintainers/releases.md
+++ b/docs/maintainers/releases.md
@@ -143,6 +143,47 @@ rule. A changed bundle needs a new contract version; replacing content under an
 existing tag is refused unless the deliberate one-time migration is explicitly
 authorized.
 
+Because that refusal happens *during* the release — after other units have already
+published irreversibly — the same gate runs read-only at PR time as CI's
+`demo-bundle-immutability` leg (`publish-demo-bundles.sh --check`). It compares each
+bundle's locally computed OCI digest against the published one and never pushes.
+Exit 75 means the registry could not be read: the check compared nothing, so CI warns
+rather than blocking, and that is not evidence there is no conflict.
+
+## Every job installs the CLIs its scripts reach
+
+A job's shell runs scripts, and those scripts run `oras`, `crane`, `cosign`, `syft`
+and `helm`, none of which the runner image provides. Nothing in the YAML declares
+that dependency — the install step and the script that needs the tool sit in
+different files. `tests/release/workflow_tooling_test.go` walks each job's shell
+through its `make` targets and the transitive closure of the scripts it invokes, and
+fails when a job can reach a gated CLI it never installed. It is one-directional: an
+unused install is not an error, an uninstalled use is.
+
+This matters more than a missing binary usually would, because the release scripts
+answer questions with strings. `ledger.sh` returning `""` means "nothing recorded" —
+which is also what it returned when `oras` was absent. It now refuses to run without
+its tools, and distinguishes a genuine 404 from a registry it could not read at all.
+Callers must assign its output to a variable before testing it: inside `[ "$(…)" ]`
+the exit status is discarded, so a failed read reads as an empty one.
+
+## Abandoned transaction `522e9507410f16fc` (3.2.0 / 5.2.0)
+
+Run [32560058692](https://github.com/TrianaLab/pacto/actions/runs/32560058692) published
+four units and then failed on the two defects above. Its versions were **tagged and
+resolvable through the Go module proxy but never released**: v3.2.0 and v5.2.0 have no
+GitHub Release, and `releases/latest` — which the CLI's update check and
+`scripts/get-pacto.sh` both read — correctly skips them. Do **not** create a back-dated
+Release for either; GitHub picks `latest` by creation time, so it would advertise them
+as newer than whatever has shipped since.
+
+The transaction is not resumable: every publisher checks out `ref: source_sha`, which
+is the commit whose demo fixture cannot be published. It was superseded by 3.2.1 / 5.2.1
+rather than recovered. Its ledger entries stay in
+`ghcr.io/trianalab/pacto-release-ledger` permanently, so a recovery dispatch for that
+transaction id remains armed and would still refuse to double-publish the four units
+that did complete.
+
 ## Manual maintainer actions (post-merge, not automated)
 
 - First production publish + Artifact Hub listing.

--- a/examples/demo/bundles/api-gateway/v1.0.0/pacto.lock
+++ b/examples/demo/bundles/api-gateway/v1.0.0/pacto.lock
@@ -17,8 +17,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/email-provider
       constraint: ^1.0.0
-      version: 1.0.0
-      digest: sha256:31f12d0ba035a93bb4551c96ad606194b96f7b9ca6456f0df2c017c48eb4cb2a
+      version: 1.0.1
+      digest: sha256:11006ec73f4decd917adc0cc61558489a399262ebc007238a4c216fb608f0fdb
     - name: fraud-service
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/fraud-service
@@ -49,8 +49,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/payments-service
       constraint: ^1.0.0
-      version: 2.1.0
-      digest: sha256:4f5b3e6ef65bbf3ef2843d25c5a107df8e94632c60addca0303dd76100e5b08a
+      version: 2.1.1
+      digest: sha256:8e5dce7b472ff36abb06b00285debbad32c0d5c51ca2b98399dd060bd35bf224
       dependsOn:
         - fraud-service
         - postgresql
@@ -65,8 +65,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/redis
       constraint: ^7.0.0
-      version: 7.2.0
-      digest: sha256:f9485712de500349ab7afcd16927535963e69c1499ecb0482f3f5af3b207034a
+      version: 7.2.1
+      digest: sha256:788937240da84877a0287261b33ece86378393855e6e317c1e317ba02bb86768
     - name: stripe-api
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/stripe-api

--- a/examples/demo/bundles/api-gateway/v1.1.0/pacto.lock
+++ b/examples/demo/bundles/api-gateway/v1.1.0/pacto.lock
@@ -17,8 +17,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/email-provider
       constraint: ^1.0.0
-      version: 1.0.0
-      digest: sha256:31f12d0ba035a93bb4551c96ad606194b96f7b9ca6456f0df2c017c48eb4cb2a
+      version: 1.0.1
+      digest: sha256:11006ec73f4decd917adc0cc61558489a399262ebc007238a4c216fb608f0fdb
     - name: fraud-service
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/fraud-service
@@ -49,8 +49,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/payments-service
       constraint: ^1.0.0
-      version: 2.1.0
-      digest: sha256:4f5b3e6ef65bbf3ef2843d25c5a107df8e94632c60addca0303dd76100e5b08a
+      version: 2.1.1
+      digest: sha256:8e5dce7b472ff36abb06b00285debbad32c0d5c51ca2b98399dd060bd35bf224
       dependsOn:
         - fraud-service
         - postgresql
@@ -65,8 +65,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/redis
       constraint: ^7.0.0
-      version: 7.2.0
-      digest: sha256:f9485712de500349ab7afcd16927535963e69c1499ecb0482f3f5af3b207034a
+      version: 7.2.1
+      digest: sha256:788937240da84877a0287261b33ece86378393855e6e317c1e317ba02bb86768
     - name: stripe-api
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/stripe-api

--- a/examples/demo/bundles/api-gateway/v1.2.0/pacto.lock
+++ b/examples/demo/bundles/api-gateway/v1.2.0/pacto.lock
@@ -17,8 +17,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/email-provider
       constraint: ^1.0.0
-      version: 1.0.0
-      digest: sha256:31f12d0ba035a93bb4551c96ad606194b96f7b9ca6456f0df2c017c48eb4cb2a
+      version: 1.0.1
+      digest: sha256:11006ec73f4decd917adc0cc61558489a399262ebc007238a4c216fb608f0fdb
     - name: fraud-service
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/fraud-service
@@ -49,8 +49,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/payments-service
       constraint: ^1.0.0
-      version: 2.1.0
-      digest: sha256:4f5b3e6ef65bbf3ef2843d25c5a107df8e94632c60addca0303dd76100e5b08a
+      version: 2.1.1
+      digest: sha256:8e5dce7b472ff36abb06b00285debbad32c0d5c51ca2b98399dd060bd35bf224
       dependsOn:
         - fraud-service
         - postgresql
@@ -65,8 +65,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/redis
       constraint: ^7.0.0
-      version: 7.2.0
-      digest: sha256:f9485712de500349ab7afcd16927535963e69c1499ecb0482f3f5af3b207034a
+      version: 7.2.1
+      digest: sha256:788937240da84877a0287261b33ece86378393855e6e317c1e317ba02bb86768
     - name: stripe-api
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/stripe-api

--- a/examples/demo/bundles/auth-service/pacto.lock
+++ b/examples/demo/bundles/auth-service/pacto.lock
@@ -9,8 +9,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/redis
       constraint: ^7.0.0
-      version: 7.2.0
-      digest: sha256:f9485712de500349ab7afcd16927535963e69c1499ecb0482f3f5af3b207034a
+      version: 7.2.1
+      digest: sha256:788937240da84877a0287261b33ece86378393855e6e317c1e317ba02bb86768
 references:
     - kind: config
       name: platform

--- a/examples/demo/bundles/email-provider/pacto.yaml
+++ b/examples/demo/bundles/email-provider/pacto.yaml
@@ -1,7 +1,7 @@
 pactoVersion: '2.0'
 service:
   name: email-provider
-  version: 1.0.0
+  version: 1.0.1
   owner:
     contacts:
     - type: url

--- a/examples/demo/bundles/fraud-service/pacto.lock
+++ b/examples/demo/bundles/fraud-service/pacto.lock
@@ -9,8 +9,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/redis
       constraint: ^7.0.0
-      version: 7.2.0
-      digest: sha256:f9485712de500349ab7afcd16927535963e69c1499ecb0482f3f5af3b207034a
+      version: 7.2.1
+      digest: sha256:788937240da84877a0287261b33ece86378393855e6e317c1e317ba02bb86768
 references:
     - kind: config
       name: platform

--- a/examples/demo/bundles/frontend/pacto.lock
+++ b/examples/demo/bundles/frontend/pacto.lock
@@ -27,8 +27,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/email-provider
       constraint: ^1.0.0
-      version: 1.0.0
-      digest: sha256:31f12d0ba035a93bb4551c96ad606194b96f7b9ca6456f0df2c017c48eb4cb2a
+      version: 1.0.1
+      digest: sha256:11006ec73f4decd917adc0cc61558489a399262ebc007238a4c216fb608f0fdb
     - name: fraud-service
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/fraud-service
@@ -59,8 +59,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/payments-service
       constraint: ^1.0.0
-      version: 2.1.0
-      digest: sha256:4f5b3e6ef65bbf3ef2843d25c5a107df8e94632c60addca0303dd76100e5b08a
+      version: 2.1.1
+      digest: sha256:8e5dce7b472ff36abb06b00285debbad32c0d5c51ca2b98399dd060bd35bf224
       dependsOn:
         - fraud-service
         - postgresql
@@ -75,8 +75,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/redis
       constraint: ^7.0.0
-      version: 7.2.0
-      digest: sha256:f9485712de500349ab7afcd16927535963e69c1499ecb0482f3f5af3b207034a
+      version: 7.2.1
+      digest: sha256:788937240da84877a0287261b33ece86378393855e6e317c1e317ba02bb86768
     - name: stripe-api
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/stripe-api

--- a/examples/demo/bundles/notification-worker/pacto.lock
+++ b/examples/demo/bundles/notification-worker/pacto.lock
@@ -9,8 +9,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/email-provider
       constraint: ^1.0.0
-      version: 1.0.0
-      digest: sha256:31f12d0ba035a93bb4551c96ad606194b96f7b9ca6456f0df2c017c48eb4cb2a
+      version: 1.0.1
+      digest: sha256:11006ec73f4decd917adc0cc61558489a399262ebc007238a4c216fb608f0fdb
 references:
     - kind: config
       name: platform

--- a/examples/demo/bundles/orders-service/v1.0.0/pacto.lock
+++ b/examples/demo/bundles/orders-service/v1.0.0/pacto.lock
@@ -9,8 +9,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/email-provider
       constraint: ^1.0.0
-      version: 1.0.0
-      digest: sha256:31f12d0ba035a93bb4551c96ad606194b96f7b9ca6456f0df2c017c48eb4cb2a
+      version: 1.0.1
+      digest: sha256:11006ec73f4decd917adc0cc61558489a399262ebc007238a4c216fb608f0fdb
     - name: fraud-service
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/fraud-service
@@ -31,8 +31,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/payments-service
       constraint: ^1.0.0
-      version: 2.1.0
-      digest: sha256:4f5b3e6ef65bbf3ef2843d25c5a107df8e94632c60addca0303dd76100e5b08a
+      version: 2.1.1
+      digest: sha256:8e5dce7b472ff36abb06b00285debbad32c0d5c51ca2b98399dd060bd35bf224
       dependsOn:
         - fraud-service
         - postgresql
@@ -47,8 +47,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/redis
       constraint: ^7.0.0
-      version: 7.2.0
-      digest: sha256:f9485712de500349ab7afcd16927535963e69c1499ecb0482f3f5af3b207034a
+      version: 7.2.1
+      digest: sha256:788937240da84877a0287261b33ece86378393855e6e317c1e317ba02bb86768
     - name: stripe-api
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/stripe-api

--- a/examples/demo/bundles/orders-service/v1.1.0/pacto.lock
+++ b/examples/demo/bundles/orders-service/v1.1.0/pacto.lock
@@ -9,8 +9,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/email-provider
       constraint: ^1.0.0
-      version: 1.0.0
-      digest: sha256:31f12d0ba035a93bb4551c96ad606194b96f7b9ca6456f0df2c017c48eb4cb2a
+      version: 1.0.1
+      digest: sha256:11006ec73f4decd917adc0cc61558489a399262ebc007238a4c216fb608f0fdb
     - name: fraud-service
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/fraud-service
@@ -31,8 +31,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/payments-service
       constraint: ^1.0.0
-      version: 2.1.0
-      digest: sha256:4f5b3e6ef65bbf3ef2843d25c5a107df8e94632c60addca0303dd76100e5b08a
+      version: 2.1.1
+      digest: sha256:8e5dce7b472ff36abb06b00285debbad32c0d5c51ca2b98399dd060bd35bf224
       dependsOn:
         - fraud-service
         - postgresql
@@ -47,8 +47,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/redis
       constraint: ^7.0.0
-      version: 7.2.0
-      digest: sha256:f9485712de500349ab7afcd16927535963e69c1499ecb0482f3f5af3b207034a
+      version: 7.2.1
+      digest: sha256:788937240da84877a0287261b33ece86378393855e6e317c1e317ba02bb86768
     - name: stripe-api
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/stripe-api

--- a/examples/demo/bundles/orders-service/v1.2.0/pacto.lock
+++ b/examples/demo/bundles/orders-service/v1.2.0/pacto.lock
@@ -9,8 +9,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/email-provider
       constraint: ^1.0.0
-      version: 1.0.0
-      digest: sha256:31f12d0ba035a93bb4551c96ad606194b96f7b9ca6456f0df2c017c48eb4cb2a
+      version: 1.0.1
+      digest: sha256:11006ec73f4decd917adc0cc61558489a399262ebc007238a4c216fb608f0fdb
     - name: fraud-service
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/fraud-service
@@ -31,8 +31,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/payments-service
       constraint: ^1.0.0
-      version: 2.1.0
-      digest: sha256:4f5b3e6ef65bbf3ef2843d25c5a107df8e94632c60addca0303dd76100e5b08a
+      version: 2.1.1
+      digest: sha256:8e5dce7b472ff36abb06b00285debbad32c0d5c51ca2b98399dd060bd35bf224
       dependsOn:
         - fraud-service
         - postgresql
@@ -47,8 +47,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/redis
       constraint: ^7.0.0
-      version: 7.2.0
-      digest: sha256:f9485712de500349ab7afcd16927535963e69c1499ecb0482f3f5af3b207034a
+      version: 7.2.1
+      digest: sha256:788937240da84877a0287261b33ece86378393855e6e317c1e317ba02bb86768
     - name: stripe-api
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/stripe-api

--- a/examples/demo/bundles/pacto-demo/pacto.lock
+++ b/examples/demo/bundles/pacto-demo/pacto.lock
@@ -27,8 +27,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/email-provider
       constraint: ^1.0.0
-      version: 1.0.0
-      digest: sha256:31f12d0ba035a93bb4551c96ad606194b96f7b9ca6456f0df2c017c48eb4cb2a
+      version: 1.0.1
+      digest: sha256:11006ec73f4decd917adc0cc61558489a399262ebc007238a4c216fb608f0fdb
     - name: fraud-service
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/fraud-service
@@ -67,8 +67,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/payments-service
       constraint: ^1.0.0
-      version: 2.1.0
-      digest: sha256:4f5b3e6ef65bbf3ef2843d25c5a107df8e94632c60addca0303dd76100e5b08a
+      version: 2.1.1
+      digest: sha256:8e5dce7b472ff36abb06b00285debbad32c0d5c51ca2b98399dd060bd35bf224
       dependsOn:
         - fraud-service
         - postgresql
@@ -83,8 +83,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/redis
       constraint: ^7.0.0
-      version: 7.2.0
-      digest: sha256:f9485712de500349ab7afcd16927535963e69c1499ecb0482f3f5af3b207034a
+      version: 7.2.1
+      digest: sha256:788937240da84877a0287261b33ece86378393855e6e317c1e317ba02bb86768
     - name: stripe-api
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/stripe-api

--- a/examples/demo/bundles/payments-service/v1.2.0/pacto.lock
+++ b/examples/demo/bundles/payments-service/v1.2.0/pacto.lock
@@ -23,8 +23,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/redis
       constraint: ^7.0.0
-      version: 7.2.0
-      digest: sha256:f9485712de500349ab7afcd16927535963e69c1499ecb0482f3f5af3b207034a
+      version: 7.2.1
+      digest: sha256:788937240da84877a0287261b33ece86378393855e6e317c1e317ba02bb86768
     - name: stripe-api
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/stripe-api

--- a/examples/demo/bundles/payments-service/v2.1.0/docs/overview.md
+++ b/examples/demo/bundles/payments-service/v2.1.0/docs/overview.md
@@ -5,14 +5,3 @@ Introduces structured ownership metadata with team, DRI, and contact information
 ## Changes from v2.0.0
 - Migrated `owner` from simple string to structured ownership model
 - Added team, DRI, and contact channels (email, chat, oncall)
-
-## Request flow
-
-The gateway authenticates, then payments settles and records to the ledger:
-
-```mermaid
-flowchart LR
-  gw[api-gateway] --> auth[auth-service]
-  gw --> pay[payments-service]
-  pay --> ledger[ledger]
-```

--- a/examples/demo/bundles/payments-service/v2.1.0/pacto.lock
+++ b/examples/demo/bundles/payments-service/v2.1.0/pacto.lock
@@ -23,8 +23,8 @@ dependencies:
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/redis
       constraint: ^7.0.0
-      version: 7.2.0
-      digest: sha256:f9485712de500349ab7afcd16927535963e69c1499ecb0482f3f5af3b207034a
+      version: 7.2.1
+      digest: sha256:788937240da84877a0287261b33ece86378393855e6e317c1e317ba02bb86768
     - name: stripe-api
       source: oci
       ref: oci://ghcr.io/trianalab/pacto/stripe-api

--- a/examples/demo/bundles/payments-service/v2.1.1/configuration/schema.json
+++ b/examples/demo/bundles/payments-service/v2.1.1/configuration/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Payments Service Config",
+  "type": "object",
+  "properties": {
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": ["debug", "info", "warn", "error"],
+      "default": "info"
+    },
+    "STRIPE_SECRET_KEY": {
+      "type": "string",
+      "description": "Stripe secret key (renamed from STRIPE_API_KEY)"
+    },
+    "PAYMENTS_DB_URL": {
+      "type": "string",
+      "format": "uri",
+      "description": "PostgreSQL connection string for payments database"
+    },
+    "WEBHOOK_SECRET": {
+      "type": "string",
+      "description": "Stripe webhook signing secret (now required)"
+    },
+    "FRAUD_CHECK_ENABLED": {
+      "type": "boolean",
+      "default": true,
+      "description": "Fraud detection is now enabled by default and required"
+    }
+  },
+  "required": ["STRIPE_SECRET_KEY", "PAYMENTS_DB_URL", "WEBHOOK_SECRET"]
+}

--- a/examples/demo/bundles/payments-service/v2.1.1/docs/overview.md
+++ b/examples/demo/bundles/payments-service/v2.1.1/docs/overview.md
@@ -1,0 +1,17 @@
+# Payments Service v2.1.1
+
+Documentation-only release: the request flow is now drawn, not described.
+
+## Changes from v2.1.0
+- Documented the settlement path as a diagram
+
+## Request flow
+
+The gateway authenticates, then payments settles and records to the ledger:
+
+```mermaid
+flowchart LR
+  gw[api-gateway] --> auth[auth-service]
+  gw --> pay[payments-service]
+  pay --> ledger[ledger]
+```

--- a/examples/demo/bundles/payments-service/v2.1.1/docs/runbooks/payments-service.md
+++ b/examples/demo/bundles/payments-service/v2.1.1/docs/runbooks/payments-service.md
@@ -1,0 +1,15 @@
+# Payments Service — On-Call Runbook
+
+## Overview
+The payments-service exposes the Payment Intents API and processes charges via
+Stripe with mandatory fraud detection.
+
+## Common incidents
+- **Stripe webhook backlog** — check the webhook consumer lag and the
+  `WEBHOOK_SECRET` rotation status.
+- **Fraud-service unavailable** — payments fail closed; verify fraud-service
+  health and Redis connectivity.
+- **Database connection saturation** — inspect the PostgreSQL connection pool.
+
+## Escalation
+Page `payments-oncall`; escalate to the payments-team DRI for sustained outages.

--- a/examples/demo/bundles/payments-service/v2.1.1/interfaces/events.json
+++ b/examples/demo/bundles/payments-service/v2.1.1/interfaces/events.json
@@ -1,0 +1,87 @@
+{
+  "asyncapi": "2.6.0",
+  "info": {
+    "title": "Payments Service Events",
+    "version": "2.0.0"
+  },
+  "channels": {
+    "payment.intent.created": {
+      "publish": {
+        "operationId": "paymentIntentCreated",
+        "summary": "Payment intent has been created",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "payment_intent_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "currency": { "type": "string" },
+              "customer_id": { "type": "string" },
+              "risk_score": { "type": "number" },
+              "created_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["payment_intent_id", "amount", "currency", "customer_id"]
+          }
+        }
+      }
+    },
+    "payment.intent.succeeded": {
+      "publish": {
+        "operationId": "paymentIntentSucceeded",
+        "summary": "Payment intent has been confirmed and succeeded",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "payment_intent_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "currency": { "type": "string" },
+              "customer_id": { "type": "string" },
+              "succeeded_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["payment_intent_id", "amount", "currency", "customer_id"]
+          }
+        }
+      }
+    },
+    "payment.intent.failed": {
+      "publish": {
+        "operationId": "paymentIntentFailed",
+        "summary": "Payment intent has failed",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "payment_intent_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "currency": { "type": "string" },
+              "error_code": { "type": "string" },
+              "error_message": { "type": "string" },
+              "failed_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["payment_intent_id", "amount", "currency", "error_code"]
+          }
+        }
+      }
+    },
+    "payment.refunded": {
+      "publish": {
+        "operationId": "paymentRefunded",
+        "summary": "Payment has been refunded",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "payment_intent_id": { "type": "string" },
+              "refund_id": { "type": "string" },
+              "amount": { "type": "integer" },
+              "reason": { "type": "string" },
+              "refunded_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["payment_intent_id", "refund_id", "amount"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/payments-service/v2.1.1/interfaces/openapi.json
+++ b/examples/demo/bundles/payments-service/v2.1.1/interfaces/openapi.json
@@ -1,0 +1,157 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Payments Service API",
+    "version": "2.0.0"
+  },
+  "paths": {
+    "/payment-intents": {
+      "post": {
+        "operationId": "createPaymentIntent",
+        "summary": "Create a new payment intent",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "amount": { "type": "integer", "description": "Amount in cents" },
+                  "currency": { "type": "string" },
+                  "customer_id": { "type": "string" },
+                  "payment_method": { "type": "string" },
+                  "description": { "type": "string" },
+                  "metadata": { "type": "object", "additionalProperties": { "type": "string" } }
+                },
+                "required": ["amount", "currency", "customer_id", "payment_method"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Payment intent created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "payment_intent_id": { "type": "string" },
+                    "amount": { "type": "integer" },
+                    "currency": { "type": "string" },
+                    "status": { "type": "string", "enum": ["requires_confirmation", "processing", "succeeded", "failed"] },
+                    "risk_score": { "type": "number" },
+                    "risk_signals": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid request" },
+          "402": { "description": "Payment failed" },
+          "422": { "description": "Fraud check rejected" }
+        }
+      },
+      "get": {
+        "operationId": "listPaymentIntents",
+        "summary": "List payment intents",
+        "parameters": [
+          { "name": "customer_id", "in": "query", "schema": { "type": "string" } },
+          { "name": "status", "in": "query", "schema": { "type": "string" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" } },
+          { "name": "cursor", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "List of payment intents" }
+        }
+      }
+    },
+    "/payment-intents/{id}": {
+      "get": {
+        "operationId": "getPaymentIntent",
+        "summary": "Get payment intent by ID",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Payment intent details" },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/payment-intents/{id}/confirm": {
+      "post": {
+        "operationId": "confirmPaymentIntent",
+        "summary": "Confirm a payment intent",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Payment intent confirmed" },
+          "400": { "description": "Cannot confirm" },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/payment-intents/{id}/cancel": {
+      "post": {
+        "operationId": "cancelPaymentIntent",
+        "summary": "Cancel a payment intent",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Payment intent cancelled" },
+          "400": { "description": "Cannot cancel" },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/refunds": {
+      "post": {
+        "operationId": "createRefund",
+        "summary": "Create a refund for a payment intent",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "payment_intent_id": { "type": "string" },
+                  "amount": { "type": "integer" },
+                  "reason": { "type": "string", "enum": ["duplicate", "fraudulent", "requested_by_customer"] }
+                },
+                "required": ["payment_intent_id"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Refund created" },
+          "400": { "description": "Invalid request" },
+          "404": { "description": "Payment intent not found" }
+        }
+      }
+    },
+    "/webhooks/stripe": {
+      "post": {
+        "operationId": "handleStripeWebhook",
+        "summary": "Handle Stripe webhook events",
+        "responses": {
+          "200": { "description": "Webhook processed" },
+          "400": { "description": "Invalid signature" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "healthCheck",
+        "summary": "Health check",
+        "responses": {
+          "200": { "description": "Service healthy" }
+        }
+      }
+    }
+  }
+}

--- a/examples/demo/bundles/payments-service/v2.1.1/pacto.lock
+++ b/examples/demo/bundles/payments-service/v2.1.1/pacto.lock
@@ -3,7 +3,7 @@ pacto:
     version: 0.0.0
 root:
     name: payments-service
-    version: 2.0.0
+    version: 2.1.1
 dependencies:
     - name: fraud-service
       source: oci

--- a/examples/demo/bundles/payments-service/v2.1.1/pacto.yaml
+++ b/examples/demo/bundles/payments-service/v2.1.1/pacto.yaml
@@ -1,0 +1,116 @@
+pactoVersion: '2.0'
+service:
+  name: payments-service
+  version: 2.1.1
+  owner:
+    team: payments-team
+    dri: james.wilson
+    contacts:
+    - type: email
+      value: payments-team@acme.com
+      purpose: escalation
+    - type: chat
+      value: '#payments-team'
+      purpose: support
+    - type: oncall
+      value: payments-oncall
+      purpose: oncall
+interfaces:
+- name: http
+  type: openapi
+  ref: interfaces/openapi.json
+  visibility: internal
+- name: events
+  type: asyncapi
+  ref: interfaces/events.json
+  visibility: internal
+configurations:
+- name: platform
+  ref: oci://ghcr.io/trianalab/pacto/platform-app-config
+  required: true
+- name: app
+  schema: configuration/schema.json
+  values:
+    LOG_LEVEL: info
+    STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY}
+    PAYMENTS_DB_URL: postgresql://postgres:5432/payments
+    WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET}
+    FRAUD_CHECK_ENABLED: true
+  required: true
+policies:
+- name: http-security
+  ref: oci://ghcr.io/trianalab/pacto/platform-http-policy
+dependencies:
+- name: postgresql
+  ref: oci://ghcr.io/trianalab/pacto/postgresql
+  required: true
+  compatibility: ^16.0.0
+- name: stripe-api
+  ref: oci://ghcr.io/trianalab/pacto/stripe-api
+  required: true
+  compatibility: ^2024.01.01
+- name: fraud-service
+  ref: oci://ghcr.io/trianalab/pacto/fraud-service
+  required: true
+  compatibility: ^1.0.0
+workload: service
+state:
+  type: stateful
+  persistence:
+    scope: shared
+    durability: persistent
+  dataCriticality: high
+readiness:
+  minScore: 80
+  expires: '2099-12-31'
+  partialCredit: 0.5
+  history:
+  - date: '2026-02-15'
+    version: 2.1.0
+    author: james.wilson
+    description: Added structured ownership metadata and fraud detection readiness
+      tracking
+  claims:
+  - id: dashboard
+    type: url
+    category: observability
+    status: done
+    evidence: https://grafana.acme.com/d/payments-service
+    weight: 30
+    description: Production Grafana dashboard
+  - id: runbook
+    type: document
+    category: documentation
+    status: done
+    evidence: docs/runbooks/payments-service.md
+    weight: 20
+    description: On-call runbook for payment incidents
+  - id: security-review
+    type: ticket
+    category: security
+    status: done
+    evidence: SEC-2087
+    weight: 20
+    description: Annual security review
+  - id: ai-evals
+    type: report
+    category: testing
+    status: not-done
+    evidence: https://evals.acme.com/payments-service
+    weight: 30
+    description: LLM safety evaluation suite (stale — needs refresh)
+metadata:
+  tier: domain
+  category: payments
+  criticality: high
+  summary: Payment Intents API with structured ownership metadata and mandatory fraud
+    detection
+  language: go
+  repo: github.com/trianalab/pacto-demo/payments-service
+  tags:
+  - payments
+  - stripe
+  - payment-intents
+  - fraud-detection
+  - webhooks
+  - ownership

--- a/examples/demo/bundles/payments-service/v2.1.1/skills/refund_customer.md
+++ b/examples/demo/bundles/payments-service/v2.1.1/skills/refund_customer.md
@@ -1,0 +1,26 @@
+# Refund a customer
+
+Domain workflow for issuing a refund. The `createRefund` tool wraps the raw
+`POST /refunds` operation, but the business rules below are not expressed by the
+OpenAPI contract and must be followed.
+
+## Steps
+
+1. Confirm the payment is refundable — call `getPaymentIntent` with the customer's
+   `payment_intent_id`. Only intents in the `succeeded` state can be refunded.
+2. Decide the amount:
+   - **Full refund** — omit `amount`; the whole captured amount is returned.
+   - **Partial refund** — set `amount` in the smallest currency unit (cents), never
+     more than the captured amount.
+3. Set `reason` to one of `duplicate`, `fraudulent`, or `requested_by_customer`.
+   Use `fraudulent` only when fraud has been confirmed by the fraud-service — it
+   affects the customer's risk profile.
+4. Call `createRefund`. Refunds are idempotent per `payment_intent_id` + `amount`;
+   do not blindly retry on timeout — re-check with `getPaymentIntent` first.
+
+## Guardrails
+
+- Never refund more than the original captured amount.
+- A refund cannot be reversed once issued.
+- Refunds are money-movement: prefer a partial refund you can repeat over a full
+  refund you cannot undo.

--- a/examples/demo/bundles/redis/pacto.yaml
+++ b/examples/demo/bundles/redis/pacto.yaml
@@ -1,7 +1,7 @@
 pactoVersion: '2.0'
 service:
   name: redis
-  version: 7.2.0
+  version: 7.2.1
   owner:
     team: infra-data
     dri: priya.raman

--- a/examples/demo/smoke.mjs
+++ b/examples/demo/smoke.mjs
@@ -29,14 +29,14 @@ check("GET /health 200", call("GET", "/health").status === 200);
 
 const services = json(call("GET", "/api/services"));
 check("GET /api/services returns fleet", Array.isArray(services) && services.length >= 10, `${services.length} services`);
-check("fleet includes payments-service@2.1.0",
-  services.some((s) => s.name === "payments-service" && s.version === "2.1.0"));
+check("fleet includes payments-service@2.1.1",
+  services.some((s) => s.name === "payments-service" && s.version === "2.1.1"));
 
 const graphRes = call("GET", "/api/graph");
 check("GET /api/graph 200 with content", graphRes.status === 200 && graphRes.body.length > 100, `${graphRes.body.length} bytes`);
 
 const versions = json(call("GET", "/api/services/payments-service/versions"));
-check("payments-service has 5 versions", Array.isArray(versions) && versions.length === 5, `${versions.length}`);
+check("payments-service has 6 versions", Array.isArray(versions) && versions.length === 6, `${versions.length}`);
 const v200 = versions.find((v) => v.version === "2.0.0");
 check("2.0.0 classified BREAKING", v200 && v200.classification === "BREAKING", v200 && v200.classification);
 
@@ -58,11 +58,11 @@ for (const [name, path] of [
   check(`GET ${path} ok`, res.status === 200, `${name} status ${res.status}`);
 }
 
-// Readiness showcase: payments-service 2.1.0 declares a readiness block that
+// Readiness showcase: payments-service 2.1.1 declares a readiness block that
 // fails its gate (an expired ai-evals check drops the score to 70 < 80);
 // orders-service 1.2.0 declares an all-current block that passes.
 const pay = json(call("GET", "/api/services/payments-service"));
-check("payments 2.1.0 exposes readiness", pay.readiness != null);
+check("payments 2.1.1 exposes readiness", pay.readiness != null);
 check("payments readiness Score 70", pay.readiness && pay.readiness.score === 70, pay.readiness && `score ${pay.readiness.score}`);
 check("payments readiness gate FAIL", pay.readiness && pay.readiness.passing === false);
 

--- a/examples/demo/source_embed_test.go
+++ b/examples/demo/source_embed_test.go
@@ -48,8 +48,8 @@ func TestGetServiceReturnsLatest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetService: %v", err)
 	}
-	if d.Version != "2.1.0" {
-		t.Errorf("payments-service current version = %q, want 2.1.0", d.Version)
+	if d.Version != "2.1.1" {
+		t.Errorf("payments-service current version = %q, want 2.1.1", d.Version)
 	}
 }
 
@@ -59,7 +59,7 @@ func TestGetVersionsDescendingWithClassification(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetVersions: %v", err)
 	}
-	wantOrder := []string{"2.1.0", "2.0.0", "1.2.0", "1.1.0", "1.0.0"}
+	wantOrder := []string{"2.1.1", "2.1.0", "2.0.0", "1.2.0", "1.1.0", "1.0.0"}
 	if len(vs) != len(wantOrder) {
 		t.Fatalf("got %d versions, want %d", len(vs), len(wantOrder))
 	}
@@ -108,12 +108,12 @@ func TestGetDiffDefaultsToLatest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetDiff: %v", err)
 	}
-	if d.To.Version != "2.1.0" {
-		t.Errorf("to version = %q, want resolved latest 2.1.0", d.To.Version)
+	if d.To.Version != "2.1.1" {
+		t.Errorf("to version = %q, want resolved latest 2.1.1", d.To.Version)
 	}
 }
 
-// TestReadinessShowcase pins the two readiness fixtures: payments-service 2.1.0
+// TestReadinessShowcase pins the two readiness fixtures: payments-service 2.1.1
 // fails its gate (Score 70 < minScore 80) and orders-service 1.2.0 passes. Dates
 // are durable sentinels, so these hold regardless of when the test runs.
 func TestReadinessShowcase(t *testing.T) {
@@ -124,7 +124,7 @@ func TestReadinessShowcase(t *testing.T) {
 		t.Fatalf("GetService(payments-service): %v", err)
 	}
 	if pay.Readiness == nil {
-		t.Fatal("payments-service 2.1.0 should expose readiness")
+		t.Fatal("payments-service 2.1.1 should expose readiness")
 	}
 	if pay.Readiness.MinScore != 80 {
 		t.Errorf("payments minScore = %d, want 80", pay.Readiness.MinScore)

--- a/pkg/dashboard/frontend/e2e/mermaid.spec.ts
+++ b/pkg/dashboard/frontend/e2e/mermaid.spec.ts
@@ -18,7 +18,7 @@ async function waitReady(page: Page) {
   await expect(page.getByRole('link', { name: 'Operational Graph' })).toBeVisible({ timeout: T });
 }
 
-// The demo's payments-service v2.1.0 overview carries a flowchart fence.
+// The demo's payments-service v2.1.1 overview carries a flowchart fence.
 //
 // The row is picked by canonical key, never by label: the demo publishes same-named
 // services in two domains, so matching on the visible name alone can silently open
@@ -28,7 +28,16 @@ async function openMermaidDoc(page: Page) {
   await expect(page.getByRole('heading', { name: 'Services' })).toBeVisible({ timeout: T });
   await page.locator('.sv-item a.entity-link[href$="/fleet/services/payments-service"]').first().click();
   await expect(page).toHaveURL(/#\/fleet\/services\/payments-service$/);
-  await page.locator('a.entity-link[href*="/fleet/revisions/"]', { hasText: '2.1.0' }).first().click();
+  // 2.1.1 is published but not deployed, so it is not in the in-use list the page
+  // opens with -- it is in the exhaustive "All revisions" disclosure, which is
+  // collapsed. A revision nobody runs still has documentation worth reading.
+  await page
+    .locator('details.ps-collapsible')
+    .filter({ has: page.getByRole('heading', { name: 'All revisions' }) })
+    .locator('summary')
+    .first()
+    .click();
+  await page.locator('a.entity-link[href*="/fleet/revisions/"]', { hasText: '2.1.1' }).first().click();
   await expect(page).toHaveURL(/#\/fleet\/revisions\//);
 
   const doc = page.locator('details.rd-doc', { hasText: 'overview' }).first();

--- a/release/orchestrator/ledger.sh
+++ b/release/orchestrator/ledger.sh
@@ -33,17 +33,43 @@ REPO="${PACTO_LEDGER_REPO:?PACTO_LEDGER_REPO required}"
 case "$REPO" in
   *ghcr.io*|*trianalab*) [ "${PACTO_ALLOW_PROD:-}" = "1" ] || { echo "refusing prod ledger repo '$REPO' without PACTO_ALLOW_PROD=1" >&2; exit 1; } ;;
 esac
+# Fail-closed on a MISSING TOOL, not just a missing tag. The ledger is an OCI
+# artifact read and written with oras|jq; when a job forgets to install one, every
+# read returns the empty string, the empty string is indistinguishable from "this
+# transaction recorded nothing", and a release half-ships. That is release run
+# 32560058692. An absent tool is a job misconfiguration, so say which job and how.
+for tool in oras jq; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "::error::ledger.sh $CMD: '$tool' is not installed, but the release ledger ($REPO) is an OCI artifact read and written with it. Install it in this job (ORAS: oras-project/setup-oras) — an uninstalled tool reads as an empty ledger, which is how a release half-ships." >&2
+    exit 1
+  }
+done
 orasFlags() { case "$REPO" in localhost*|127.0.0.1*) printf -- '--plain-http';; esac; }
 # OCI tags allow [A-Za-z0-9_.-]; sanitize txn/unit-derived tags defensively.
 tagsan() { printf '%s' "$1" | tr -c 'A-Za-z0-9_.-' '_'; }
 ref() { printf '%s:%s' "$REPO" "$(tagsan "$1")"; }
 
-# pull <tag> -> ledger.json content on stdout ("" if the tag is absent). A fresh
+# pull <tag> -> ledger.json content on stdout ("" if the tag is ABSENT). A fresh
 # temp dir per call so concurrent/repeated pulls never collide on the filename.
+#
+# Only a genuine 404 yields "". Any other failure — auth, TLS, DNS, rate limit,
+# a registry outage — is fatal, because "" is load-bearing everywhere upstream
+# (it means "not yet recorded" and unlocks the write path), and reporting an
+# UNREADABLE ledger as an EMPTY one is precisely how a resumed release both
+# re-initializes a live transaction and republishes a completed unit. Callers
+# assign the result to a variable first, so `set -e` propagates this exit.
 pull() {
-  local d; d="$(mktemp -d)"
+  local d out rc=0
+  d="$(mktemp -d)"
   # shellcheck disable=SC2046  # $(orasFlags) is intentionally unquoted: empty => no arg.
-  if oras pull $(orasFlags) "$(ref "$1")" -o "$d" >/dev/null 2>&1; then cat "$d/ledger.json" 2>/dev/null || true; fi
+  out="$(oras pull $(orasFlags) "$(ref "$1")" -o "$d" 2>&1)" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    cat "$d/ledger.json" 2>/dev/null || true
+  elif ! printf '%s' "$out" | grep -qiE 'not found|NAME_UNKNOWN|MANIFEST_UNKNOWN|404'; then
+    rm -rf "$d"
+    echo "::error::ledger read failed for $(ref "$1") (exit $rc) — refusing to report an unreadable ledger as an empty one: $out" >&2
+    exit 1
+  fi
   rm -rf "$d"
 }
 # push_immutable <tag> <json>: write the doc to an immutable tag. If the tag

--- a/release/scripts/publish-demo-bundles.sh
+++ b/release/scripts/publish-demo-bundles.sh
@@ -31,9 +31,18 @@
 # In production mode (PACTO_ALLOW_PROD=1) it only performs step 2 against the
 # production coordinate; the offline-lock regen and live proof are dev/PR concerns.
 #
+# --check is the PR-time half of this script: it runs step 2's byte-exact
+# immutability gate against the OWNED production coordinate, READ-ONLY, and stops
+# before the push. It is the only way to learn on a pull request that a demo
+# fixture edit has made a published immutable tag unpublishable — a fact that
+# otherwise surfaces mid-release, after irreversible units have shipped.
+# Exit: 0 clean, 1 conflict, 75 (EX_TEMPFAIL) the registry could not be read, so
+# the gate proved nothing and the caller should warn rather than block.
+#
 # Usage:
 #   release/scripts/publish-demo-bundles.sh            # staging + proof
 #   release/scripts/publish-demo-bundles.sh --push     # same (explicit)
+#   release/scripts/publish-demo-bundles.sh --check    # read-only gate, no push
 #   PACTO_DEMO_REGISTRY=127.0.0.1:5002/pacto-demo release/scripts/publish-demo-bundles.sh
 set -euo pipefail
 
@@ -43,11 +52,26 @@ COORD="${PACTO_DEMO_REGISTRY:-localhost:5001/pacto-demo}"
 BUNDLES="$ROOT/examples/demo/bundles"
 OWNED="ghcr.io/trianalab/pacto"   # committed refs' coordinate (== demo-bundles unit coordinate)
 PROOF="$ROOT/release/proofs/demo-artifacts.txt"
+EX_TEMPFAIL=75
+
+CHECK=0
+case "${1:-}" in
+  --check) CHECK=1 ;;
+  --push|"") ;;
+  *) echo "usage: $(basename "$0") [--push|--check]" >&2; exit 2 ;;
+esac
+if [ "$CHECK" = "1" ]; then
+  # The coordinate whose immutability is actually at stake is the owned one, and
+  # checking it needs no permission to write it.
+  COORD="${PACTO_DEMO_REGISTRY:-$OWNED}"
+fi
 
 # ---- production guard (refuse a production-looking target unless PACTO_ALLOW_PROD) ----
 host_path="${COORD#*/}"
 if { printf '%s' "$COORD" | grep -qi 'ghcr\.io'; } || { printf '%s' "$host_path" | grep -qi 'trianalab'; }; then
-  if [ "${PACTO_ALLOW_PROD:-}" != "1" ]; then
+  # --check is exempt: it is a read, and requiring the production opt-in to READ
+  # would mean the gate could only ever run in the job that also publishes.
+  if [ "${PACTO_ALLOW_PROD:-}" != "1" ] && [ "$CHECK" = "0" ]; then
     echo "REFUSED: production-looking target '$COORD' — point PACTO_DEMO_REGISTRY at a disposable local registry (or set PACTO_ALLOW_PROD=1 in the canonical publisher)" >&2
     exit 1
   fi
@@ -59,7 +83,8 @@ fi
 # The pacto binary is only used by the staging proof (offline-lock regen + live
 # resolution checks). Production mode pushes via `go run ./publishbundles` and
 # never touches it, so only require it in staging.
-if [ "$PROD" = "0" ]; then
+# --check never resolves anything either: it reads digests and stops.
+if [ "$PROD" = "0" ] && [ "$CHECK" = "0" ]; then
   command -v "$PACTO_BIN" >/dev/null 2>&1 || { echo "pacto binary not found at $PACTO_BIN (build: go build -o /tmp/pacto ./cmd/pacto)" >&2; exit 1; }
 fi
 
@@ -71,7 +96,7 @@ cleanup() { rm -rf "$WORK" "$XDG_CACHE_HOME"; }
 trap cleanup EXIT
 
 # ---- step 1: regenerate committed offline locks (deterministic) ----
-if [ "$PROD" = "0" ]; then
+if [ "$PROD" = "0" ] && [ "$CHECK" = "0" ]; then
   echo "==> genlocks: regenerate committed offline demo locks"
   ( cd "$ROOT/examples/demo" && go run ./genlocks >/dev/null )
 fi
@@ -96,13 +121,35 @@ find "$WORK/bundles" -name pacto.lock -delete   # regenerated fresh against the 
 # This is byte-exact, not a semantic `pacto diff`: a change to any auxiliary,
 # interface or unreferenced file moves the digest and is caught.
 MIGRATE="${PACTO_DEMO_MIGRATE:-0}"
+if [ "$CHECK" = "1" ]; then
+  MIGRATE=0   # a read-only check must never be waved through by the migration escape hatch
+fi
 if command -v crane >/dev/null 2>&1; then
-  CONFLICTS=() ; MIGRATED=()
-  rdig() { crane digest "$1" 2>/dev/null || crane digest --insecure "$1" 2>/dev/null || true; }
+  CONFLICTS=() ; MIGRATED=() ; READABLE=0 ; UNREADABLE=()
+  # rdig <ref>: prints the remote digest, prints nothing when the tag is genuinely
+  # ABSENT, and exits non-zero when the registry could not be read at all. The old
+  # `|| true` conflated the last two, so an outage, an expired token or a rate
+  # limit read as "nothing published yet" and the byte-exact gate waved every
+  # bundle straight through to an overwrite.
+  rdig() {
+    local out
+    if out="$(crane digest "$1" 2>&1)" || out="$(crane digest --insecure "$1" 2>&1)"; then
+      printf '%s' "$out"; return 0
+    fi
+    case "$out" in
+      *MANIFEST_UNKNOWN*|*NAME_UNKNOWN*|*[Nn]ot" "found*|*404*) return 0 ;;   # absent
+    esac
+    printf '%s' "$out" >&2
+    return 1
+  }
   while read -r tag local_d; do
     [ -n "$tag" ] && [ -n "$local_d" ] || continue
-    remote_d="$(rdig "$COORD/$tag")"
+    if ! remote_d="$(rdig "$COORD/$tag")"; then
+      UNREADABLE+=("$COORD/$tag")
+      continue
+    fi
     [ -z "$remote_d" ] && continue                     # absent -> will publish
+    READABLE=$((READABLE+1))
     [ "$remote_d" = "$local_d" ] && continue            # identical digest -> no-op
     if [ "$MIGRATE" = "1" ]; then
       MIGRATED+=("$COORD/$tag: $remote_d -> $local_d")
@@ -115,7 +162,30 @@ if command -v crane >/dev/null 2>&1; then
     printf '    %s\n' "${CONFLICTS[@]}" >&2
     exit 1
   fi
+  if [ "${#UNREADABLE[@]}" -gt 0 ]; then
+    # Not "no conflict": no answer. Pushing on no answer is the overwrite this
+    # gate exists to prevent, so the push path fails hard and --check reports
+    # EX_TEMPFAIL so its caller can warn instead of blocking on someone else's outage.
+    echo "could not read ${#UNREADABLE[@]} tag(s) from $COORD — the immutability gate proved nothing:" >&2
+    printf '    %s\n' "${UNREADABLE[@]}" >&2
+    [ "$CHECK" = "1" ] && exit "$EX_TEMPFAIL"
+    exit 1
+  fi
+  if [ "$CHECK" = "1" ] && [ "$READABLE" = "0" ]; then
+    # Every tag came back absent. Either this is a fresh coordinate or the check is
+    # pointed somewhere it cannot see the published set — in both cases it compared
+    # nothing, and a gate that compares nothing must not report success.
+    echo "no published demo tag was found at $COORD — nothing was compared, so this check is not evidence of immutability" >&2
+    exit "$EX_TEMPFAIL"
+  fi
   [ "${#MIGRATED[@]}" -gt 0 ] && { echo "==> MIGRATION: replacing ${#MIGRATED[@]} tag(s) (audit inventory old->new):"; printf '    %s\n' "${MIGRATED[@]}"; }
+  if [ "$CHECK" = "1" ]; then
+    echo "==> immutability OK: $READABLE published demo tag(s) at $COORD are byte-identical to this tree; the rest are new"
+    exit 0
+  fi
+elif [ "$CHECK" = "1" ]; then
+  echo "REFUSED: crane is required for the byte-exact immutability check. Install it: go install github.com/google/go-containerregistry/cmd/crane@latest" >&2
+  exit 1
 elif [ "$PROD" = "1" ]; then
   # Never publish to a production coordinate without the byte-exact immutability gate:
   # a missing crane would otherwise let changed content overwrite an immutable tag.

--- a/tests/release/compose_native_test.go
+++ b/tests/release/compose_native_test.go
@@ -145,8 +145,12 @@ func TestNothingOnTheComposeDemoPathTouchesOras(t *testing.T) {
 		"tests/acceptance/local/compose-demo.sh": readFile(t, root, "tests", "acceptance", "local", "compose-demo.sh"),
 		"docs/examples/compose-demo.md":          readFile(t, root, "docs", "examples", "compose-demo.md"),
 	}
-	// The two jobs that run that harness / that publish the unit, in full: an
-	// `uses:` line installing ORAS is as much a regression as a call to it.
+	// The SHELL of the two jobs that run that harness / publish the unit. The ban
+	// is on ORAS touching THIS ARTIFACT, not on the job having ORAS installed:
+	// demo-compose installs it to read and write the release ledger, which is a
+	// generic OCI artifact and nothing to do with the Compose application. Banning
+	// the `uses:` line too is what deleted that install in 45abda33 and half-shipped
+	// release run 32560058692. What must never appear here is a CALL.
 	for file, jobs := range map[string]map[string]wfJob{
 		"ci.yml":      workflowJobs(t, root, "ci.yml"),
 		"release.yml": workflowJobs(t, root, "release.yml"),
@@ -156,11 +160,7 @@ func TestNothingOnTheComposeDemoPathTouchesOras(t *testing.T) {
 			if !ok {
 				continue
 			}
-			b, err := yaml.Marshal(job)
-			if err != nil {
-				t.Fatalf("re-encode %s job %s: %v", file, name, err)
-			}
-			subjects[file+" job "+name] = string(b)
+			subjects[file+" job "+name] = job.runs()
 		}
 	}
 	for name, text := range subjects {

--- a/tests/release/workflow_tooling_test.go
+++ b/tests/release/workflow_tooling_test.go
@@ -1,0 +1,343 @@
+package release
+
+import (
+	"maps"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// A release job runs shell, that shell runs scripts, and those scripts run
+// external CLIs — oras, crane, cosign, syft, helm — that the GitHub runner image
+// does not provide. Every job therefore has to install the ones it will reach,
+// and nothing in the workflow declares that: the install step and the script
+// that needs the tool sit hundreds of lines apart, in different files, connected
+// only in a maintainer's head.
+//
+// That is how release run 32560058692 half-shipped. Commit 45abda33 moved the
+// demo-compose unit to `docker compose publish` and deleted the job's ORAS
+// install, reasoning that "ORAS stays where the ledger uses it" — while the job
+// kept reading the ledger (`ledger.sh digest …`, to pin the dashboard image by
+// digest) and kept publishing through publish-oci-unit.sh, which records into
+// the ledger. ledger.sh IS the ORAS user. On the runner `oras` was not found,
+// ledger.sh returned the empty string, the empty string is indistinguishable
+// from "this transaction recorded no digest", the fail-closed guard fired and
+// the unit died — after four irreversible publishes had already happened. Every
+// existing gate was green, because not one of them runs a job with the runner's
+// PATH.
+//
+// So this gate reads the dependency the way the runner experiences it: for each
+// job it walks the shell that job runs — through `make` targets and through the
+// transitive closure of the scripts those shells invoke — collects the gated
+// CLIs that appear as commands, and requires the job to install every one of
+// them. It is deliberately one-directional. A job that installs a tool it never
+// uses wastes twenty seconds; a job that uses a tool it never installed loses a
+// release. Only the second is an error here.
+//
+// Known ceilings, so nobody trusts this further than it reaches: a make target
+// assembled from a matrix expression (`make test-acceptance-kind-${{ matrix.x }}`)
+// does not resolve to a rule, so its tools are invisible; `if:` on an install
+// step is not modelled; and a tool used only inside a container image is not a
+// PATH dependency at all. Under-detection is the safe direction, and it is the
+// price of having no second declaration to keep in sync.
+//
+// One consequence worth stating: a script that degrades when a tool is absent
+// (build-cli.sh prints "syft not found — SBOM skipped") is still treated as
+// needing it. A rehearsal that silently skips the SBOM the real release produces
+// is not rehearsing the release, so the fix is to install the tool, not to
+// exempt the script.
+
+// toolInstaller maps each gated CLI to the single installer this repository uses
+// for it. The key is the command name as it appears on a command line. The value
+// is the installer's identity WITHOUT its pin — the pin is checked separately,
+// and by consistency, so bumping it stays a one-line change.
+var toolInstaller = map[string]string{
+	"oras":   "oras-project/setup-oras",
+	"crane":  "github.com/google/go-containerregistry/cmd/crane",
+	"cosign": "sigstore/cosign-installer",
+	"syft":   "anchore/sbom-action/download-syft",
+	"helm":   "azure/setup-helm",
+}
+
+// toolCallRE matches the CLI being run, not the word: `oras.land/oras-go` is a Go
+// import, and comments are already gone by the time commandLines is done.
+func toolCallRE(tool string) *regexp.Regexp {
+	return regexp.MustCompile(`(?:^|[\s;|&(]|\$\()` + regexp.QuoteMeta(tool) + `\s`)
+}
+
+// shScriptRE finds, by basename, the shell scripts a command line runs.
+var shScriptRE = regexp.MustCompile(`([A-Za-z0-9_.-]+)\.sh\b`)
+
+// gateScripts is every shell script a workflow job can reach, basename -> path.
+func gateScripts(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, pat := range [][]string{
+		{"release", "orchestrator", "*.sh"},
+		{"release", "scripts", "*.sh"},
+		{"tests", "acceptance", "kind", "*.sh"},
+		{"tests", "acceptance", "local", "*.sh"},
+	} {
+		matches, err := filepath.Glob(filepath.Join(append([]string{root}, pat...)...))
+		if err != nil {
+			t.Fatalf("glob %v: %v", pat, err)
+		}
+		for _, m := range matches {
+			out[filepath.Base(m)] = m
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no release scripts found — the closure below would silently pass")
+	}
+	return out
+}
+
+// toolsIn reduces any shell text to the gated CLIs it invokes and the scripts it
+// runs, both by name.
+func toolsIn(text string) (tools, scripts map[string]bool) {
+	tools, scripts = map[string]bool{}, map[string]bool{}
+	for _, l := range commandLines(text) {
+		for tool := range toolInstaller {
+			if toolCallRE(tool).MatchString(l) {
+				tools[tool] = true
+			}
+		}
+		for _, m := range shScriptRE.FindAllStringSubmatch(l, -1) {
+			scripts[m[1]+".sh"] = true
+		}
+	}
+	return tools, scripts
+}
+
+// scriptTools is the transitive tool closure of one script: tool -> the script in
+// the chain that actually runs it, which is what the failure message needs to say.
+func scriptTools(t *testing.T, name string, files map[string]string, seen map[string]bool) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	if seen[name] {
+		return out
+	}
+	seen[name] = true
+	path, ok := files[name]
+	if !ok {
+		return out // not one of ours: a vendored helper, or a name that only appears in prose.
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	tools, scripts := toolsIn(string(b))
+	for tool := range tools {
+		out[tool] = name
+	}
+	for _, s := range slices.Sorted(maps.Keys(scripts)) {
+		for tool, via := range scriptTools(t, s, files, seen) {
+			if _, dup := out[tool]; !dup {
+				out[tool] = via
+			}
+		}
+	}
+	return out
+}
+
+// recipeClosure is all the recipe text running target can execute: its own, its
+// prerequisites', and that of the targets it calls back into make for.
+func recipeClosure(rules map[string]makeRule, target string, seen map[string]bool) string {
+	if seen[target] {
+		return ""
+	}
+	seen[target] = true
+	r, ok := rules[target]
+	if !ok {
+		return ""
+	}
+	out := r.recipe
+	next := slices.Clone(r.prereqs)
+	for _, m := range subMakeRE.FindAllStringSubmatch(r.recipe, -1) {
+		next = append(next, m[1])
+	}
+	for _, m := range makeCallRE.FindAllStringSubmatch(r.recipe, -1) {
+		next = append(next, m[1])
+	}
+	for _, p := range next {
+		out += recipeClosure(rules, p, seen)
+	}
+	return out
+}
+
+// jobNeeds is every gated CLI the job's shell can reach, mapped to the reason —
+// the sentence a maintainer reads when the gate fires.
+func jobNeeds(t *testing.T, job wfJob, files map[string]string, rules map[string]makeRule) map[string]string {
+	t.Helper()
+	need := map[string]string{}
+	add := func(tool, why string) {
+		if _, ok := need[tool]; !ok {
+			need[tool] = why
+		}
+	}
+	via := func(entry, runner string) string {
+		if entry == runner {
+			return entry + " runs it"
+		}
+		return entry + " -> " + runner + " runs it"
+	}
+
+	shell := job.runs()
+	tools, scripts := toolsIn(shell)
+	for tool := range tools {
+		add(tool, "the job runs it directly")
+	}
+	for _, s := range slices.Sorted(maps.Keys(scripts)) {
+		for tool, runner := range scriptTools(t, s, files, map[string]bool{}) {
+			add(tool, via(s, runner))
+		}
+	}
+	// The same walk again for anything reached through make, because a job that
+	// runs one `make` line runs everything that target expands to.
+	for _, l := range commandLines(shell) {
+		for _, m := range makeCallRE.FindAllStringSubmatch(l, -1) {
+			recipe := recipeClosure(rules, m[1], map[string]bool{})
+			mTools, mScripts := toolsIn(recipe)
+			for tool := range mTools {
+				add(tool, "make "+m[1]+" runs it")
+			}
+			for _, s := range slices.Sorted(maps.Keys(mScripts)) {
+				for tool, runner := range scriptTools(t, s, files, map[string]bool{}) {
+					add(tool, "make "+m[1]+" -> "+via(s, runner))
+				}
+			}
+		}
+	}
+	return need
+}
+
+// jobInstalls is the set of gated CLIs the job puts on the runner's PATH.
+func jobInstalls(job wfJob) map[string]bool {
+	out := map[string]bool{}
+	for _, s := range job.Steps {
+		for tool, installer := range toolInstaller {
+			if strings.Contains(s.Uses, installer) || strings.Contains(s.Run, installer) {
+				out[tool] = true
+			}
+		}
+	}
+	return out
+}
+
+// TestEveryJobInstallsTheCLIsItsScriptsRun is the gate: no job may reach a gated
+// CLI it did not install.
+func TestEveryJobInstallsTheCLIsItsScriptsRun(t *testing.T) {
+	root := repoRoot(t)
+	files := gateScripts(t, root)
+	rules := makeRules(t, root)
+
+	for _, w := range loadWorkflows(t, root) {
+		jobs := workflowJobs(t, root, w.name)
+		for _, name := range slices.Sorted(maps.Keys(jobs)) {
+			job := jobs[name]
+			need := jobNeeds(t, job, files, rules)
+			installed := jobInstalls(job)
+			for _, tool := range slices.Sorted(maps.Keys(need)) {
+				if installed[tool] {
+					continue
+				}
+				t.Errorf("%s job %q reaches %s (%s) but no step installs it — add the %s install step. "+
+					"On a runner without %s the command is `%s: command not found`, and the release scripts read that as an empty answer rather than as a failure.",
+					w.name, name, tool, need[tool], toolInstaller[tool], tool, tool)
+			}
+		}
+	}
+}
+
+// installerPinRE finds every pinned reference to one installer, wherever a
+// workflow spells it: an `uses:` line (whose trailing `# v2` comment is not part
+// of the reference) or a `go install` line.
+func installerPinRE(installer string) *regexp.Regexp {
+	return regexp.MustCompile(regexp.QuoteMeta(installer) + `@(\S+)`)
+}
+
+var (
+	commitPinRE = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	semverPinRE = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+)
+
+// TestToolInstallersArePinnedAndIdentical: two workflows install these five CLIs
+// from a couple of dozen steps between them. A bump that reaches all but one of
+// them is a release where two jobs disagree about what "the tool" is, and the one
+// that matters is whichever job publishes something irreversible. The expected pin
+// is not written down here — it is whatever the workflows already agree on — so a
+// genuine bump stays a find-and-replace and only a PARTIAL bump fails.
+func TestToolInstallersArePinnedAndIdentical(t *testing.T) {
+	root := repoRoot(t)
+	workflows := loadWorkflows(t, root)
+
+	for _, tool := range slices.Sorted(maps.Keys(toolInstaller)) {
+		installer := toolInstaller[tool]
+		seen := map[string][]string{} // pin -> where
+		for _, w := range workflows {
+			for i, line := range strings.Split(w.text, "\n") {
+				for _, m := range installerPinRE(installer).FindAllStringSubmatch(line, -1) {
+					pin := strings.TrimRight(m[1], `"'`)
+					seen[pin] = append(seen[pin], w.name+":"+strconv.Itoa(i+1))
+				}
+			}
+		}
+		if len(seen) == 0 {
+			t.Errorf("no workflow installs %s via %s — either the installer changed or the tool is gone; update toolInstaller so the closure gate keeps meaning something", tool, installer)
+			continue
+		}
+		if len(seen) > 1 {
+			var detail []string
+			for _, pin := range slices.Sorted(maps.Keys(seen)) {
+				detail = append(detail, pin+" ("+strings.Join(seen[pin], ", ")+")")
+			}
+			t.Errorf("%s is installed from %d different pins of %s — a partial bump: %s", tool, len(seen), installer, strings.Join(detail, " vs "))
+		}
+		shape, label := commitPinRE, "commit SHA"
+		if strings.HasPrefix(installer, "github.com/") {
+			shape, label = semverPinRE, "released version"
+		}
+		for _, pin := range slices.Sorted(maps.Keys(seen)) {
+			if !shape.MatchString(pin) {
+				t.Errorf("%s is installed from %s@%s (%s) — a release must not resolve its tooling through a movable reference; pin a %s", tool, installer, pin, strings.Join(seen[pin], ", "), label)
+			}
+		}
+	}
+}
+
+// TestTheToolingGateBitesWhenAnInstallStepIsDeleted proves the rule above can
+// actually fail, on the exact edit that caused the incident: delete demo-compose's
+// ORAS install and the job still reads the ledger, so ORAS must still be reported
+// missing. Without this, a closure that quietly resolved to nothing would leave
+// the gate green forever.
+func TestTheToolingGateBitesWhenAnInstallStepIsDeleted(t *testing.T) {
+	root := repoRoot(t)
+	files := gateScripts(t, root)
+	rules := makeRules(t, root)
+
+	job, ok := workflowJobs(t, root, "release.yml")["demo-compose"]
+	if !ok {
+		t.Fatal("release.yml has no demo-compose job — the unit was renamed; move this proof with it")
+	}
+	stripped := wfJob{}
+	for _, s := range job.Steps {
+		if strings.Contains(s.Uses, toolInstaller["oras"]) || strings.Contains(s.Run, toolInstaller["oras"]) {
+			continue
+		}
+		stripped.Steps = append(stripped.Steps, s)
+	}
+	if jobInstalls(stripped)["oras"] {
+		t.Fatal("stripping the ORAS install left one behind — the proof below would be vacuous")
+	}
+	why, needed := jobNeeds(t, stripped, files, rules)["oras"]
+	if !needed {
+		t.Error("demo-compose without an ORAS install is not reported as needing ORAS — but the job reads the release ledger, and the ledger is an OCI artifact ORAS pulls. This is commit 45abda33 and release run 32560058692, unnoticed a second time.")
+	}
+	if needed && !strings.Contains(why, "ledger.sh") {
+		t.Errorf("the reason given for demo-compose needing ORAS is %q — it should name ledger.sh, which is the script that actually runs it", why)
+	}
+}


### PR DESCRIPTION
## Summary

Release run [32560058692](https://github.com/TrianaLab/pacto/actions/runs/32560058692) (transaction `522e9507410f16fc`) published four irreversible units and then died. `v3.2.0` and `v5.2.0` are on the Go module proxy with no GitHub Release behind them, and the transaction cannot be resumed: the publishers check out `ref: source_sha`, and that commit is precisely the one whose demo fixture cannot be published.

This PR abandons that transaction, supersedes it with **3.2.1 / 5.2.1** and closes the two independent defects that had to line up for a release to half-ship.

> `522e9507410f16fc` must never receive a back-dated GitHub Release. GitHub resolves `releases/latest` by creation time, and both `internal/update/check.go` and `scripts/get-pacto.sh` read it — a back-dated release would hand every updating client a version with no artifacts.

### Defect 1 — a job lost the CLI its scripts run

`45abda33` removed the ORAS install from `demo-compose` ("ORAS stays where the ledger uses it"), but that job still reads and writes the release ledger, and `ledger.sh` *is* the ORAS user. With the binary gone `ledger.sh` printed nothing, and nothing is exactly what an empty ledger prints — so the orchestrator resumed into a transaction it believed had recorded no units.

### Defect 2 — an immutable demo tag was edited in place

`payments-service` 2.1.0 gained a Mermaid diagram under a tag that was already published. The byte-exact immutability gate only runs during a release, so the conflict surfaced after four units were already irreversible.

## Changes

**Fix the fixture** — the diagram ships as a new `payments-service` 2.1.1 instead of an edit to 2.1.0. `email-provider` and `redis` get matching patch bumps, and the 18 affected `pacto.lock` files are regenerated.

**Make an absent tool fatal, not empty** — `ledger.sh` preflights `oras` and `jq` and refuses to run without them, and `pull()` now distinguishes a genuine 404 from an unreadable registry rather than reporting both as an empty ledger.

**Make the guard load-bearing** — `[ "$(ledger.sh …)" ]` discards the exit status of the command inside it, so `set -e` could never see the new failure. Both call sites in `release.yml` now assign first.

**Restore the missing install** — `demo-compose` installs ORAS again, with a comment naming the ledger as the consumer so the next reader does not remove it for the same reason.

**Gate the class, not the instance** — `tests/release/workflow_tooling_test.go` walks every workflow job's shell through its make targets and the transitive script closure, and fails when a job reaches a CLI no step installs. It found a second live under-install on its first run: `release-dry-run` reaches `syft` through `build-cli.sh` and never installed it. A third test strips an install step and asserts the gate still bites.

**Move the immutability check to PR time** — `publish-demo-bundles.sh` grows a `--check` mode and a new `demo-bundle-immutability` CI job runs it on every release-touching PR. An unreadable registry exits 75 and warns rather than passing silently, because "compared nothing" is not evidence of no conflict.

**Write it down** — `docs/maintainers/releases.md` records the abandoned transaction, the standing rule against a back-dated release and the two new gates.

## Related Issues

None.

## Checklist

- [x] Code compiles without errors
- [x] All tests pass (`make test && make e2e`)
- [x] Linter passes (`make lint`)
- [x] Tests added/updated for new functionality or bug fixes
- [x] Documentation updated (if applicable)
- [x] Commit messages follow the `<type>: <description>` convention

## Testing

- `make ci-gates`, `make ci-static` (0 issues, no UI bundle drift), `make artifact-drift`, `make ci-release-version`, `shellcheck`
- `go test ./tests/release/...` — including the three new tooling gates
- `publish-demo-bundles.sh --check` against live GHCR: **21 match, 4 new, 0 conflict** on this branch, and **exit 1 with the exact conflicting digest pair** when run against the offending commit, which reproduces the release failure at PR time
- WASM demo smoke: 46/46
- Playwright: the Mermaid revision-doc specs pass against 2.1.1. They needed a real fix — 2.1.1 is published but not deployed, so it lives in the collapsed "All revisions" disclosure rather than the in-use list the page opens with
- `npx changeset status` — all ten units bump patch to 3.2.1 / 5.2.1

Not merged and not released: merging this cuts 3.2.1 / 5.2.1.
