### PR TITLE
chore(deps): roll up the three open dependabot PRs

### DIFF
--- a/.changeset/k8s-libraries-0-36-4.md
+++ b/.changeset/k8s-libraries-0-36-4.md
@@ -1,0 +1,15 @@
+---
+"@pacto/core": patch
+"@pacto/k8s-module": patch
+---
+
+Move both Go modules onto the Kubernetes 0.36.4 library line.
+
+`k8s.io/client-go`, `k8s.io/api` and `k8s.io/apimachinery` are now v0.36.4 in
+`go.mod` and `integrations/kubernetes/go.mod`. The bumps landed on `main`
+without a changeset, so neither the core line nor the kubernetes line would
+have shipped them — this patch is what actually publishes a core module and an
+operator image built against 0.36.4.
+
+No API or behaviour change: the 0.36.4 patch releases only refresh the
+`golang.org/x` dependencies underneath.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
       # `changeset version` — no release plan, no transaction, no regenerated docs.
       # tests/release/changesets_action_contract_test.go is the standing proof.
       - name: Open or update the Version Packages PR
-        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
+        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version-script: npm run release:version:docs

--- a/tests/release/changesets_action_contract_test.go
+++ b/tests/release/changesets_action_contract_test.go
@@ -28,12 +28,12 @@ import (
 //
 // This gate is the substitute for the run that never happens. It reads the
 // contract off the workflow the way GitHub reads it — a parsed document, not text,
-// because the `uses:` line carries a trailing `# v2.1.0` comment a grep would
+// because the `uses:` line carries a trailing `# v2.1.1` comment a grep would
 // treat as part of the reference — and pairs it with the Changesets CLI major the
 // action drives, since the action and the CLI are two halves of one contract.
 
-// The accepted v2 pin: a full commit, never a tag. changesets/action v2.1.0.
-const changesetsActionPin = "changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a"
+// The accepted v2 pin: a full commit, never a tag. changesets/action v2.1.1.
+const changesetsActionPin = "changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1"
 
 // The canonical version command. It is not `changeset version`: the repository's
 // script chains the transaction builder, the plan applier and the version-derived
@@ -44,7 +44,7 @@ const changesetsVersionScript = "release:version:docs"
 // other half of a half-finished migration.
 const changesetsCLIMinMajor = 3
 
-// Every input changesets/action v2.1.0 declares at the pinned commit. A key
+// Every input changesets/action v2.1.1 declares at the pinned commit. A key
 // outside this set is a v1 leftover or a typo, and both are ignored at runtime.
 var changesetsV2Inputs = map[string]bool{
 	"github-token":           true,


### PR DESCRIPTION
Aggregates #321, #323 and #324, all of which were sitting there conflicted or unreleasable.

### k8s.io/api + k8s.io/apimachinery 0.36.4 (#323, #321)

Turns out there's nothing to apply. The client-go 0.36.4 bump that landed on `main` already pulled both to 0.36.4 in `go.mod` and `integrations/kubernetes/go.mod` — that's exactly why those two PRs went conflicted, they were replaying a bump main already had.

What *was* missing is the changeset. None of the k8s bumps carried one, so the 0.36.4 libraries would just sit on `main` and never get published. `.changeset/k8s-libraries-0-36-4.md` patches `@pacto/core` and `@pacto/k8s-module` so the next Version PR actually ships a core module and an operator image built against them.

### changesets/action 2.1.0 → 2.1.1 (#324)

Real diff, tiny one. 2.1.1 is a single message-only fix — `commit: "commit-mesage"` → `commit: "commit-message"` in `throwOnRenamedInputs`, i.e. the error text you get when you pass the v1 `commit` input. `action.yml` declares the identical input set at the new SHA, so nothing about our step changes; `changesetsActionPin` in `tests/release/changesets_action_contract_test.go` just follows the pin.

### Checks

`go test ./tests/release/...` green, `go build ./...` green in the kubernetes module. `go mod tidy` in both modules is a no-op.

Closing #321, #323 and #324 in favour of this.