### PR TITLE
fix(demo): smoke asserts the breaking step by behaviour, and gate it on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
               - 'go.work'
             dashboard:
               - 'pkg/dashboard/**'
+              # dashboard-e2e builds the WASM demo and now smokes its engine, so
+              # the fixtures and the host that serve it are inputs to this leg. A
+              # demo-only PR used to skip it entirely and land untested.
+              - 'examples/demo/**'
             kubernetes:
               - 'integrations/kubernetes/**'
               - 'go.work'
@@ -420,6 +424,11 @@ jobs:
       - release-dry-run
       - release-version-test
       - demo-bundle-immutability
+      # dashboard-e2e was the one leg nothing aggregated, so it could go red on a
+      # PR and still report mergeable. It carries the browser acceptance suite and
+      # now the demo engine smoke, which is the check whose absence let a fixture
+      # rename turn main red.
+      - dashboard-e2e
     runs-on: ubuntu-latest
     steps:
       - name: Verify no required leg failed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -899,6 +899,12 @@ jobs:
           node-version: '22'
       - name: Build the WASM dashboard demo
         run: make -C examples/demo build
+      # The publisher checks what the validator checks. docs.yml smokes the engine
+      # before it builds the site; this job is the only thing that actually ships
+      # the demo, so without this it could publish a demo whose engine docs.yml
+      # would have rejected.
+      - name: Smoke test the wasm engine
+        run: make -C examples/demo smoke
       # Fold the demo into the docs tree so mike's internal `mkdocs build` copies it
       # into the released version deploy at /demo/ (mirrors docs.yml). Without this
       # the demo is built but never lands in the version slot, so /latest/demo/ 404s.

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,13 @@ e2e-otel: test-acceptance-local
 # and liveness are different properties and a merged suite proves neither.
 test-browser:
 	$(MAKE) -C examples/demo build
+# The engine smoke rides the build this target already paid for. Until now it ran
+# only in the post-merge docs workflow: source_embed_test.go covers the same
+# fixtures under a required job, but nothing on a PR ran smoke.mjs itself, so a
+# fixture republish that updated the Go test and missed the smoke went green and
+# turned main red on the way out. Before Playwright, because a broken engine makes
+# the browser failures downstream noise.
+	$(MAKE) -C examples/demo smoke
 	cd pkg/dashboard/frontend && npm ci --ignore-scripts && npx playwright install chromium && npm run test:e2e
 e2e-dashboard-wasm: test-browser
 

--- a/docs/examples/dashboard-demo.md
+++ b/docs/examples/dashboard-demo.md
@@ -41,7 +41,7 @@ It showcases the full UI against a realistic set of services:
 - **Dependency graph** — resolved from each contract's declared dependencies,
   with blast-radius highlighting.
 - **Change analysis** — `payments-service` spans six versions; the
-  `v1.2.0 → v2.0.0` step is a breaking change that removes the `/charges` API,
+  `v1.2.1 → v2.0.1` step is a breaking change that removes the `/charges` API,
   and the same screen shows which consumers that break reaches.
 - **Readiness** — never a separate screen, because readiness is declared by a
   contract revision about itself. It is a *Needs attention* category, a

--- a/docs/javascripts/aria-labels.js
+++ b/docs/javascripts/aria-labels.js
@@ -35,10 +35,45 @@
     }
   }
 
+  // Material 9.7 wraps each code block's copy and select buttons in a bare <nav>
+  // (`md-code__nav`, built in the theme's bundle, not a partial). That makes every
+  // code block a navigation landmark with no name, so any page carrying two of
+  // them fails landmark-unique -- which is every page on this site.
+  //
+  // Naming them would satisfy the rule and make the page worse: a screen reader's
+  // landmark menu would grow one entry per code block. Two buttons are not a
+  // region to navigate to, so drop the landmark instead and leave the buttons
+  // themselves untouched.
+  function unlandmarkCodeNavs() {
+    var navs = document.querySelectorAll("nav.md-code__nav");
+    for (var i = 0; i < navs.length; i++) {
+      var nav = navs[i];
+      if (nav.getAttribute("role")) continue;
+      if (nav.getAttribute("aria-label") || nav.getAttribute("aria-labelledby")) continue;
+      nav.setAttribute("role", "presentation");
+    }
+  }
+
+  // The breadcrumb trail is the one place this file overwrites a name the theme
+  // set, because the name the theme set is the bug: partials/path.html labels it
+  // `lang.t('nav')`, the same string the primary navigation uses, so the two
+  // collide as landmark-unique on every page deep enough to have a trail. It is a
+  // breadcrumb, and "Breadcrumb" is what it should have been called.
+  function nameBreadcrumb() {
+    var path = document.querySelector("nav.md-path");
+    var primary = document.querySelector("nav.md-nav--primary");
+    if (!path || !primary) return;
+    if (path.getAttribute("aria-label") === primary.getAttribute("aria-label")) {
+      path.setAttribute("aria-label", "Breadcrumb");
+    }
+  }
+
   function apply() {
     name('[data-md-component="search"][role="dialog"]', "Search");
     name('[data-md-component="progress"][role="progressbar"]', "Page loading progress");
     nameSubNavs();
+    unlandmarkCodeNavs();
+    nameBreadcrumb();
   }
 
   // The header persists across instant navigation; the navigation drawer does

--- a/docs/maintainers/testing.md
+++ b/docs/maintainers/testing.md
@@ -459,6 +459,9 @@ the boundary between them is the artifact under test — never the subject matte
 **`pkg/dashboard/frontend/e2e/`** owns the dashboard bundle, run by
 `make test-browser`, gated by the `dashboard-e2e` job in CI. `e2e/mermaid.spec.ts`
 lives here and proves that *bundle documentation renders inside the dashboard*.
+`make test-browser` also runs the WASM demo's engine smoke (`examples/demo`)
+first, since it has already built that artifact and a broken engine would make
+the browser failures downstream noise.
 
 **`pkg/dashboard/frontend/e2e-docs-site/`** owns the MkDocs output, run by
 `make test-browser-docs-site`, gated by the Docs check workflow. It builds the

--- a/examples/demo/smoke.mjs
+++ b/examples/demo/smoke.mjs
@@ -37,12 +37,29 @@ check("GET /api/graph 200 with content", graphRes.status === 200 && graphRes.bod
 
 const versions = json(call("GET", "/api/services/payments-service/versions"));
 check("payments-service has 6 versions", Array.isArray(versions) && versions.length === 6, `${versions.length}`);
-const v200 = versions.find((v) => v.version === "2.0.0");
-check("2.0.0 classified BREAKING", v200 && v200.classification === "BREAKING", v200 && v200.classification);
-
-const diff = json(call("GET", "/api/diff?from_name=payments-service&from_version=1.2.0&to_name=payments-service&to_version=2.0.0"));
-check("diff 1.2.0->2.0.0 BREAKING", diff.classification === "BREAKING", `${diff.changes && diff.changes.length} changes`);
-check("diff includes /charges removal", (diff.changes || []).some((c) => c.path === "openapi.paths[/charges]"));
+// Find the breaking step by what it DOES, not by what it is numbered. A fixture
+// bundle whose bytes change has to republish under a NEW version, because the tag
+// it already published is immutable -- and when payments 1.2.0/2.0.0 became
+// 1.2.1/2.0.1 for exactly that reason, these assertions went on naming versions
+// the fixture no longer had. The list is newest-first and each entry is classified
+// against its predecessor, so every candidate step is (a BREAKING entry, the entry
+// after it); the one this asserts on is whichever of those drops /charges, which
+// also keeps a second breaking revision from stealing the match.
+let brk = null;
+let prev = null;
+let diff = {};
+for (let i = 0; i < versions.length - 1; i++) {
+  if (versions[i].classification !== "BREAKING") continue;
+  const d = json(call("GET", `/api/diff?from_name=payments-service&from_version=${versions[i + 1].version}&to_name=payments-service&to_version=${versions[i].version}`));
+  if (!(d.changes || []).some((c) => c.path === "openapi.paths[/charges]")) continue;
+  brk = versions[i];
+  prev = versions[i + 1];
+  diff = d;
+  break;
+}
+check("a payments step is BREAKING by removing /charges", !!brk, brk ? `${prev.version}->${brk.version}` : "no such step");
+check(`diff ${prev ? prev.version : "?"}->${brk ? brk.version : "?"} BREAKING`,
+  diff.classification === "BREAKING", `${diff.changes && diff.changes.length} changes`);
 
 // Every other GET endpoint the UI's api.ts calls must answer (no 500s), so no
 // dashboard view errors out in the browser.
@@ -105,27 +122,30 @@ const someTargetKey = Object.keys(snap.targets || {})[0];
 const tdetail = json(call("GET", `/api/fleet/target?key=${encodeURIComponent(someTargetKey)}`));
 check("fleet target detail resolves by key", tdetail.target && tdetail.target.key === someTargetKey, someTargetKey);
 
-// Impact: a preconfigured breaking scenario (payments-service 1.0.0 → 2.0.0)
-// resolved entirely from embedded bundles, no OCI. Uses the same published
-// snapshot the graph serves.
-const revs = json(call("GET", "/api/services/payments-service/versions")); // reuse for hashes? use fleet detail refs
+// Impact: payments-service's oldest revision against its newest, resolved
+// entirely from embedded bundles, no OCI. Uses the same published snapshot the
+// graph serves. The pair is named from what was actually diffed -- the label
+// used to read "1.0.0 → 2.0.0" while the code took the newest revision, so it
+// had been reporting a comparison it never ran.
 const payRevs = (detail.revisions || []).slice().sort((a, b) => (a.version < b.version ? -1 : 1));
-const oldRef = payRevs[0].resolvedRef;
-const newRef = payRevs[payRevs.length - 1].resolvedRef;
-const impRes = call("GET", `/api/fleet/impact?old=${encodeURIComponent(oldRef)}&new=${encodeURIComponent(newRef)}&includeObserved=false`);
+// Guarded so a detail response without revisions fails as this check rather than
+// as a TypeError that takes the rest of the run down with it.
+check("payments-service detail carries revisions to compare", payRevs.length >= 2, `${payRevs.length}`);
+const oldRev = payRevs[0] || {};
+const newRev = payRevs[payRevs.length - 1] || {};
+const impRes = call("GET", `/api/fleet/impact?old=${encodeURIComponent(oldRev.resolvedRef)}&new=${encodeURIComponent(newRev.resolvedRef)}&includeObserved=false`);
 check("impact 200", impRes.status === 200, `status ${impRes.status}`);
 const imp = json(impRes);
 check("impact result binds the published snapshot (section 2.2)", imp.snapshotId === snap.snapshotId, `${imp.snapshotId} vs ${snap.snapshotId}`);
-check("impact 1.0.0→2.0.0 is BREAKING", imp.classification === "BREAKING", imp.classification);
+check(`impact ${oldRev.version}→${newRev.version} is BREAKING`, imp.classification === "BREAKING", imp.classification);
 check("impact has affected consumers (direct + transitive)", (imp.consumers || []).length >= 1);
 
 // Observed: include-observed surfaces the audit-log shadow consumer that declares
 // no dependency on payments-service.
-const impObs = json(call("GET", `/api/fleet/impact?old=${encodeURIComponent(oldRef)}&new=${encodeURIComponent(newRef)}&includeObserved=true`));
+const impObs = json(call("GET", `/api/fleet/impact?old=${encodeURIComponent(oldRev.resolvedRef)}&new=${encodeURIComponent(newRev.resolvedRef)}&includeObserved=true`));
 check("include-observed surfaces the audit-log shadow consumer",
   (impObs.consumers || []).some((c) => c.service === "audit-log"),
   (impObs.consumers || []).map((c) => c.service).join(","));
-void revs;
 
 // ── Product API: the demo must be RICH through the paths the product UI uses ──
 // The product UI never reads the raw snapshot above; it reads these endpoints. A


### PR DESCRIPTION
Two separate breakages, both of which reached `main` the same way: a red check that nothing was aggregating.

## 1. `Docs (validate)` — stale fixture versions

Its **Smoke test the wasm engine** step asked for `payments-service` `1.2.0 → 2.0.0`, versions the demo fixture no longer has. A fixture bundle whose bytes change has to republish under a **new** version, because the tag it already published is immutable — that is why `1.2.0`/`2.0.0` became `1.2.1`/`2.0.1`. `source_embed_test.go` was updated in that rename; `smoke.mjs` was missed, and nothing on a PR ran it.

`smoke.mjs` no longer writes version numbers down. It scans the versions list for the BREAKING step that drops `/charges` and asserts on whichever pair that is. Verified by deleting `v2.0.1` outright: the smoke still found the equivalent step (`1.2.1 → 2.1.0`) and failed only on the version count — it tracks behaviour, not numbering.

The impact block is likewise named from the pair it actually diffed. Its label read `1.0.0 → 2.0.0` while the code took the *newest* revision, so it had been reporting a comparison it never ran. Both derivations are guarded, so a thinned fixture fails as a check rather than as a `TypeError`.

The public site was never affected: `release.yml` is the only job that publishes, and it built the demo without smoking it, so it succeeded while `docs.yml` failed.

## 2. `docs-check` — the mkdocs-material 9.7 upgrade

#351 (9.6.21 → 9.7.7) turned the axe suite red on **every** page, both colour schemes and mobile, and auto-merged anyway. Two upstream `landmark-unique` violations, both fixed in `aria-labels.js`, which exists for exactly this and explains why it patches landmarks in JS rather than vendoring a partial:

- **Code block navs** — 9.7 wraps each code block's copy/select buttons in a bare `<nav class="md-code__nav">`, so every code block became an unnamed navigation landmark. Naming them would satisfy axe and make the page *worse* (one landmark-menu entry per code block); two buttons are not a region to navigate to, so the landmark is dropped and the buttons are untouched.
- **Breadcrumb** — `partials/path.html` labels the trail `lang.t('nav')`, the same string the primary nav uses, so the two collide. Relabelled `Breadcrumb`.

## Closing the gaps

| Gap | Change |
|---|---|
| Smoke ran only post-merge | `test-browser` runs it on the demo build it already pays for |
| A demo-only PR skipped the leg that builds the demo | `ci.yml`'s `dashboard` filter includes `examples/demo/**` |
| `dashboard-e2e` was the one job nothing aggregated | it joins `required`'s `needs` |
| The publisher had no check the validator has | `release.yml`'s `docs` job smokes before it deploys |

The `required` change is the load-bearing one: branch protection requires only `validate` and `required`, so without it `dashboard-e2e` could go red and still merge, which makes the first two rows advisory.

**Still open, not fixed here:** `docs-check` is in neither list either — that is how #351 merged red. Adding it to the required contexts is a repo-settings change, so it is called out rather than done.

## Also

`docs/examples/dashboard-demo.md` still described the demo's breaking change as `v1.2.0 → v2.0.0`. Fixed. `examples/demo/README.md` and the demo `Makefile` keep `1.2.0`/`2.0.0` correctly — they resolve over OCI, where those immutable tags still exist.

**No changeset.** The substance is CI plumbing and a docs-site script, neither of which ships to users. That leaves the one-line `dashboard-demo.md` correction unpublished until the next release; add a `@pacto/core` patch changeset if it should go sooner.

## Verification

- `make -C examples/demo smoke` — all pass; negative run (fixture deleted) fails closed, no `TypeError`
- `make test-browser` — smoke passes, then 255 Playwright tests pass
- `make test-browser-docs-site` against **9.7.7** — 28 passed, 0 failed (was 15 failed)
- `docs_check.py` against **9.7.7** — 16/16
- `go test ./tests/release/...` — ok
- `required` now aggregates every `ci.yml` job