### PR TITLE
docs: publish the pending documentation fixes

### DIFF
--- a/.changeset/publish-pending-docs.md
+++ b/.changeset/publish-pending-docs.md
@@ -1,0 +1,21 @@
+---
+"@pacto/core": patch
+---
+
+Publish four documentation fixes that have been correct on `main` but absent from
+the site.
+
+`docs/examples/dashboard-demo.md` named `v1.2.0 → v2.0.0` as the breaking step of
+the demo fleet. OCI tags are immutable, so republishing that fixture under changed
+bytes renumbered it to `v1.2.1 → v2.0.1` and left the page pointing at two tags
+that no longer exist. The same stale literals were what broke the WASM demo smoke
+test and turned the docs pipeline red; that test now finds the breaking step by
+behaviour rather than by version, and this ships the half a reader can see.
+
+The rest of the batch rides along because `release.yml`'s `docs` job is the only
+publisher and it builds the whole site: the mkdocs-material 9.6.21 → 9.7.7 bump,
+the two `aria-labels.js` fixes that keep it accessible and a testing note. 9.7
+wraps every code block's buttons in an unnamed `<nav>` and labels the breadcrumb
+with the same string the primary navigation uses, so every page carrying two code
+blocks fails landmark-unique. The theme bump has never been published without its
+fixes, and shipping them in one transaction keeps it that way.


### PR DESCRIPTION
## The problem

`https://pacto.run/latest/examples/dashboard-demo/` tells readers the breaking step
of the demo fleet is `v1.2.0 → v2.0.0`. Neither tag exists. The fixture was
republished under changed bytes, and because OCI tags are immutable that
republish renumbered it to `v1.2.1 → v2.0.1`.

Those same stale literals are what broke the docs pipeline: the WASM demo smoke
test looked the versions up by name. That half was fixed in #352 — the test now
finds the breaking step by behaviour, asserting that some payments step is
`BREAKING` *because* it removes `/charges`, so a future renumbering cannot break
it again. The page itself was corrected in the same PR.

The correction never reached anyone. `release.yml`'s `docs` job is the only thing
that publishes the site, it runs only inside a release transaction, and
`.changeset/` was empty. So the fix has been correct on `main` and wrong on the
website ever since.

Verified before opening this, rather than assumed:

```
main source:   v1.2.1 → v2.0.1     (correct)
pacto.run:     v1.2.0 → v2.0.0     (still live)
.changeset/:   empty
```

## The change

One changeset, `@pacto/core: patch`. That is the whole diff. `core` is in the
`docs` job's unit list, so the transaction it opens publishes the site.

## What ships with it

The `docs` job builds the whole site, so this releases every documentation change
sitting on `main` since `v3.2.8`:

| file | why it matters |
|---|---|
| `docs/examples/dashboard-demo.md` | the stale tags above |
| `docs/requirements.txt` | mkdocs-material 9.6.21 → 9.7.7 |
| `docs/javascripts/aria-labels.js` | the two fixes that keep 9.7 accessible |
| `docs/maintainers/testing.md` | note covering the browser gate |

The theme bump and its fixes landing together is the point, not a coincidence.
9.7 wraps each code block's buttons in an unnamed `<nav>` and labels the
breadcrumb with the same string the primary navigation uses, so any page with two
code blocks fails `landmark-unique` — which is nearly every page here. I checked
the live site for `md-code__nav` and found none, so the regression has never
reached readers: the bump is unpublished too, and this transaction ships both
sides at once.

## Checks

`go test ./tests/release/...` passes. The frontmatter matches the accepted format
and `@pacto/core` resolves to `release/units/pacto-core/package.json`.

Worth stating plainly: this is the first PR since #353 made `docs-required` a
required context, and it touches no documentation source. So it is also the first
live exercise of the skip path — `docs-check` should skip while `docs-required`
reports green. If that reasoning is wrong this PR blocks instead of merging, which
is the safe direction to be wrong in, and removing the context reverses it.
