### PR TITLE
feat(operator): make the contract verdict a GitOps promotion gate

### DIFF
--- a/.changeset/gitops-promotion-gate.md
+++ b/.changeset/gitops-promotion-gate.md
@@ -21,14 +21,28 @@ verdict holds the deploy instead of going falsely green. The Argo one is a Lua
 health customization written for the sandbox Argo actually runs it in, which has
 the string library disabled.
 
-The Flux snippet is not an illustration. It lives at
-`tests/acceptance/kind/fixtures/gitops/flux-kustomization.yaml`, the page includes
-that file rather than a copy of it, and a new kind acceptance shard applies the
-same file to a real cluster running Flux: a contract that contradicts the workload
-that ships must leave the dependent Kustomization's manifest out of the cluster
-entirely, and correcting the contract must let it through. The shard runs at the
-operator's default stabilization window on purpose, because the page claims a
+Neither snippet is an illustration. Both live under
+`tests/acceptance/kind/fixtures/gitops/`, the page includes those files rather
+than copies of them, and each has a kind acceptance shard that applies it to a
+real cluster running the tool it targets.
+
+`gitops-flux.sh` proves the Flux gate changes what ships: a contract that
+contradicts the workload must leave the dependent Kustomization's manifest out of
+the cluster entirely, and correcting the contract must let it through. It runs at
+the operator's default stabilization window on purpose, because the page claims a
 mismatch does not wait one out.
+
+`gitops-argocd.sh` runs in two passes, because the Argo snippet's failure mode is
+silence — a `data` key Argo does not recognise is ignored, and an ignored key
+looks exactly like having configured nothing. The first pass needs no cluster:
+the `argocd` CLI evaluates the customization in the same Lua sandbox the
+controller uses, which is what gives every contract status an assertion,
+including the states a running cluster passes through too quickly to catch — no
+status yet, a verdict behind the contract, a status added in some future release.
+The second pass serves an Application from an OCI source in kind and requires it
+to go `Degraded` naming the finding, then `Healthy` once the contract is
+corrected. The page's read-back recipe is that same CLI command, and the shard
+runs it against the live cluster rather than only publishing it.
 
 `ContractRecovered` is new. The three contract warnings — `ValidationFailed`,
 `ContractInvalid`, `ContractUnavailable` — are transition-gated, so a contract

--- a/.changeset/gitops-promotion-gate.md
+++ b/.changeset/gitops-promotion-gate.md
@@ -1,0 +1,46 @@
+---
+"@pacto/k8s-module": minor
+---
+
+Make the contract verdict usable as a GitOps promotion gate, and emit the event
+that says a contract recovered.
+
+The operator has always reached a verdict and written it to
+`status.contractStatus`. Neither Flux nor Argo CD reads that field. Flux decides
+health with kstatus, which recognises `Ready`, `Reconciling` and `Stalled` and
+discards every condition Pacto publishes, so a Kustomization holding a
+`NonCompliant` Pacto reports healthy. Argo picks health checks from a closed list
+of built-in kinds and returns nothing for the rest, and the roll-up ignores
+nothing — a violated contract is not unhealthy to Argo, it is invisible. Both
+tools have an extension point for this; neither ships one for Pacto.
+
+The new [GitOps promotion gates](integrations/kubernetes/gitops.md) page is those
+two snippets, plus the timing they depend on. The Flux one is a
+`spec.healthCheckExprs` entry with no `inProgress` expression, so an unrecognised
+verdict holds the deploy instead of going falsely green. The Argo one is a Lua
+health customization written for the sandbox Argo actually runs it in, which has
+the string library disabled.
+
+The Flux snippet is not an illustration. It lives at
+`tests/acceptance/kind/fixtures/gitops/flux-kustomization.yaml`, the page includes
+that file rather than a copy of it, and a new kind acceptance shard applies the
+same file to a real cluster running Flux: a contract that contradicts the workload
+that ships must leave the dependent Kustomization's manifest out of the cluster
+entirely, and correcting the contract must let it through. The shard runs at the
+operator's default stabilization window on purpose, because the page claims a
+mismatch does not wait one out.
+
+`ContractRecovered` is new. The three contract warnings — `ValidationFailed`,
+`ContractInvalid`, `ContractUnavailable` — are transition-gated, so a contract
+that goes back to `Compliant` used to fall silent with no event marking the
+recovery. It now has one, matching the pair that `ReadinessGateUnmet` and
+`ReadinessRecovered` already formed. `ValidationFailed` also fired only when
+`status.summary` happened to be set; it now fires on the transition itself.
+
+Two documentation corrections ride along, both load-bearing for the timing advice
+on the new page. The stabilization window applies to **absences only** —
+`INTERFACE_ABSENT`, `DEPENDENCY_UNREACHABLE`, `CAPABILITY_ABSENT` and
+`CONFIGURATION_ABSENT`. A **mismatch** — `WORKLOAD_MISMATCH`,
+`PERSISTENCE_MISMATCH`, `CONFIGURATION_MISMATCH` — is `NonCompliant` on the first
+reconcile that observes it. The events table said seven events and listed seven;
+there are eight.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,13 +228,13 @@ jobs:
     needs: changes
     if: needs.changes.outputs.e2e == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    # Shard the three self-provisioning kind scenarios across parallel runners (each
+    # Shard the self-provisioning kind scenarios across parallel runners (each
     # spins up its own cluster) instead of running them serially in one job. The
     # `required` aggregate waits for all matrix legs, so coverage is unchanged.
     strategy:
       fail-fast: false
       matrix:
-        scenario: [reconcile, dashboard, upgrade, evidence, operational-graph, observation]
+        scenario: [reconcile, dashboard, upgrade, evidence, operational-graph, observation, gitops-flux]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -249,7 +249,9 @@ jobs:
       # The evidence scenario's store is the OCI registry itself, so it needs an
       # INDEPENDENT OCI client: ORAS is the observer that proves a third party
       # discovers what Pacto published, and publishes evidence Pacto reads back.
-      - if: matrix.scenario == 'evidence'
+      # gitops-flux needs the same client for a different reason: it publishes the
+      # manifest artifact that Flux's OCIRepository pulls the promotion from.
+      - if: matrix.scenario == 'evidence' || matrix.scenario == 'gitops-flux'
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
       - name: Install kind (checksum-verified via GOSUMDB)
         run: go install sigs.k8s.io/kind@v0.30.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scenario: [reconcile, dashboard, upgrade, evidence, operational-graph, observation, gitops-flux]
+        scenario: [reconcile, dashboard, upgrade, evidence, operational-graph, observation, gitops-flux, gitops-argocd]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -249,9 +249,10 @@ jobs:
       # The evidence scenario's store is the OCI registry itself, so it needs an
       # INDEPENDENT OCI client: ORAS is the observer that proves a third party
       # discovers what Pacto published, and publishes evidence Pacto reads back.
-      # gitops-flux needs the same client for a different reason: it publishes the
-      # manifest artifact that Flux's OCIRepository pulls the promotion from.
-      - if: matrix.scenario == 'evidence' || matrix.scenario == 'gitops-flux'
+      # The gitops scenarios need the same client for a different reason: they
+      # publish the manifest artifact the delivery tool pulls the promotion from —
+      # Flux's OCIRepository in one, Argo's OCI application source in the other.
+      - if: matrix.scenario == 'evidence' || startsWith(matrix.scenario, 'gitops-')
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
       - name: Install kind (checksum-verified via GOSUMDB)
         run: go install sigs.k8s.io/kind@v0.30.0

--- a/ci.mk
+++ b/ci.mk
@@ -12,6 +12,7 @@ REPOWISE_VERSION ?= 0.36.0
        ci-e2e-compose test-acceptance-compose test-browser-compose \
        test-acceptance-kind test-acceptance-kind-dashboard test-acceptance-kind-upgrade test-acceptance-kind-reconcile \
        test-acceptance-kind-evidence test-acceptance-kind-operational-graph test-acceptance-kind-observation \
+       test-acceptance-kind-gitops-flux \
        ci-oci ci-gates docs-generate docs-check docs-build-strict artifact-drift release-dry-run \
        verify-k8s-standalone ci-test ci-ui ui-build ci-ui-drift ci-fmt ci-vet ci-cyclo ci-lint ci-arch ci-docs \
        gen-openapi gen-config-schema gen-sbom gen-bundle mermaid-check gen-demo-transcripts
@@ -102,7 +103,8 @@ ci-e2e-envtest:
 # Each scenario is ONE boundary. They are not merged: a merged cluster run cannot
 # say which boundary broke, and cannot be sharded.
 test-acceptance-kind: test-acceptance-kind-dashboard test-acceptance-kind-upgrade test-acceptance-kind-reconcile \
-	test-acceptance-kind-evidence test-acceptance-kind-operational-graph test-acceptance-kind-observation
+	test-acceptance-kind-evidence test-acceptance-kind-operational-graph test-acceptance-kind-observation \
+	test-acceptance-kind-gitops-flux
 
 test-acceptance-kind-dashboard:
 	bash tests/acceptance/kind/dashboard-modes.sh
@@ -133,6 +135,13 @@ test-acceptance-kind-reconcile:
 
 test-acceptance-kind-evidence:
 	bash tests/acceptance/kind/evidence.sh
+
+# The contract verdict as a DEPLOYMENT GATE: real Flux, real OCIRepository, the
+# two Kustomizations exactly as integrations/kubernetes/docs/gitops.md publishes
+# them. Proves the promotion does not run while the contract is violated and does
+# run once it is satisfied — the claim the docs make, on the surface that makes it.
+test-acceptance-kind-gitops-flux:
+	bash tests/acceptance/kind/gitops-flux.sh
 
 # Compatibility aliases for the older names. Temporary.
 ci-e2e-kind:                    test-acceptance-kind

--- a/ci.mk
+++ b/ci.mk
@@ -12,7 +12,7 @@ REPOWISE_VERSION ?= 0.36.0
        ci-e2e-compose test-acceptance-compose test-browser-compose \
        test-acceptance-kind test-acceptance-kind-dashboard test-acceptance-kind-upgrade test-acceptance-kind-reconcile \
        test-acceptance-kind-evidence test-acceptance-kind-operational-graph test-acceptance-kind-observation \
-       test-acceptance-kind-gitops-flux \
+       test-acceptance-kind-gitops-flux test-acceptance-kind-gitops-argocd \
        ci-oci ci-gates docs-generate docs-check docs-build-strict artifact-drift release-dry-run \
        verify-k8s-standalone ci-test ci-ui ui-build ci-ui-drift ci-fmt ci-vet ci-cyclo ci-lint ci-arch ci-docs \
        gen-openapi gen-config-schema gen-sbom gen-bundle mermaid-check gen-demo-transcripts
@@ -104,7 +104,7 @@ ci-e2e-envtest:
 # say which boundary broke, and cannot be sharded.
 test-acceptance-kind: test-acceptance-kind-dashboard test-acceptance-kind-upgrade test-acceptance-kind-reconcile \
 	test-acceptance-kind-evidence test-acceptance-kind-operational-graph test-acceptance-kind-observation \
-	test-acceptance-kind-gitops-flux
+	test-acceptance-kind-gitops-flux test-acceptance-kind-gitops-argocd
 
 test-acceptance-kind-dashboard:
 	bash tests/acceptance/kind/dashboard-modes.sh
@@ -142,6 +142,14 @@ test-acceptance-kind-evidence:
 # run once it is satisfied — the claim the docs make, on the surface that makes it.
 test-acceptance-kind-gitops-flux:
 	bash tests/acceptance/kind/gitops-flux.sh
+
+# The same verdict on Argo CD's surface: the health customization the same page
+# publishes, judged first offline against every contract status (the argocd CLI's
+# own Lua sandbox, no cluster) and then inside a real Argo CD serving an
+# Application from an OCI source. Both halves run the documented file itself,
+# because a customization Argo does not recognise leaves the Application green.
+test-acceptance-kind-gitops-argocd:
+	bash tests/acceptance/kind/gitops-argocd.sh
 
 # Compatibility aliases for the older names. Temporary.
 ci-e2e-kind:                    test-acceptance-kind

--- a/integrations/kubernetes/api/v1alpha1/conditions.go
+++ b/integrations/kubernetes/api/v1alpha1/conditions.go
@@ -69,11 +69,25 @@ const (
 	ReasonReadinessExpired       = "Expired"
 )
 
-// Event reasons (free-form, emitted via the recorder). Readiness events are
-// emitted on gate transitions only to avoid per-reconcile spam.
+// Event reasons (free-form, emitted via the recorder). Readiness and contract-status
+// events are emitted on transitions only to avoid per-reconcile spam: a Pacto is
+// re-reconciled on every write to the workloads it watches, so an unguarded event
+// fires once per step of a rolling update.
 const (
 	EventReadinessGateUnmet = "ReadinessGateUnmet"
 	EventReadinessRecovered = "ReadinessRecovered"
+
+	// EventValidationFailed is the warning reason for a degraded contract status
+	// reached through a completed evaluation (Warning, NonCompliant, Unknown).
+	EventValidationFailed = "ValidationFailed"
+	// EventContractInvalid is the warning reason when the contract itself is Invalid.
+	EventContractInvalid = "ContractInvalid"
+	// EventContractUnavailable is the warning reason when the contract could not be
+	// obtained (registry/auth/not-found), so validity is undetermined.
+	EventContractUnavailable = "ContractUnavailable"
+	// EventContractRecovered is the normal reason emitted when the contract status
+	// returns to Compliant or Reference from any degraded value.
+	EventContractRecovered = "ContractRecovered"
 )
 
 // Severity levels for runtime reconciliation checks.

--- a/integrations/kubernetes/docs/gitops.md
+++ b/integrations/kubernetes/docs/gitops.md
@@ -106,25 +106,43 @@ kubectl -n argocd patch configmap argocd-cm --type merge \
   `ipairs` and `tostring()` are available; `string.format`, `s:gsub()` and the
   rest are not, and reaching for one fails at runtime rather than at load.
 
+That snippet is not an illustration either. `tests/acceptance/kind/gitops-argocd.sh`
+runs **that exact file** twice. Once with no cluster at all, through
+`argocd admin settings resource-overrides health`, which puts every contract
+status through Argo's own Lua sandbox — including the states a running cluster
+passes through too quickly to catch, like a verdict that has not caught up with
+the contract yet. Then inside a kind cluster running Argo CD, where an
+Application must go `Degraded` naming the finding while the contract is violated
+and back to `Healthy` once it is corrected.
+
 ### Check that it took
 
 Argo ignores a `data` key it does not recognise, and an ignored key looks exactly
-like having configured nothing. Unlike the Flux snippet, this one has no live
-acceptance test standing behind it, which is why the read-back matters. Confirm
-the customization is live before you rely on it:
+like having configured nothing. Confirm the customization is live before you rely
+on it:
 
 ```bash
 # The key must read back exactly, group and kind included.
 kubectl -n argocd get cm argocd-cm \
   -o jsonpath='{.data.resource\.customizations\.health\.pacto\.trianalab\.io_Pacto}'
-
-# Then read the health Argo assigns a real object.
-argocd app resources <app> | grep Pacto
 ```
 
-A Pacto whose `status.contractStatus` is `Compliant` should read `Healthy` with
-the message `contract satisfied`. If it reads `Healthy` with an empty message,
-the key did not take.
+Then ask Argo what it makes of a real object. `argocd admin settings` evaluates
+the customization against files on disk, in the same Lua sandbox the controller
+uses, so it answers without waiting for a sync:
+
+```bash
+kubectl -n argocd get cm argocd-cm -o yaml > /tmp/argocd-cm.yaml
+kubectl -n <namespace> get pacto <name> -o yaml > /tmp/pacto.yaml
+
+argocd admin settings resource-overrides health /tmp/pacto.yaml \
+  --argocd-cm-path /tmp/argocd-cm.yaml
+```
+
+A `Compliant` Pacto prints `STATUS: Healthy` and `MESSAGE: contract satisfied`.
+A key that did not take prints `Health script is not configured for
+'pacto.trianalab.io/Pacto'` instead — and prints it while **exiting 0**, so read
+the output rather than the exit code if you wire this into a check.
 
 ## Timing
 

--- a/integrations/kubernetes/docs/gitops.md
+++ b/integrations/kubernetes/docs/gitops.md
@@ -1,0 +1,174 @@
+# GitOps promotion gates
+
+The operator reaches a verdict on every reconcile and writes it to
+`status.contractStatus`. Neither Flux nor Argo CD reads that field on its own, so
+a Kustomization holding a `NonCompliant` Pacto reports healthy and a violated
+contract cannot turn an Argo Application red. Both tools have an extension point
+for exactly this. This page is the two snippets that close the gap.
+
+Nothing here changes the operator, the CRD or your contracts. It is configuration
+you add to the delivery tool you already run.
+
+## What the gate buys you
+
+The operator observes; it never writes to your workloads. By the time a verdict
+exists the pods are already serving. What these snippets buy is that **the next
+step stops**: the Kustomization goes unready, the dependent one never starts, the
+Argo Application goes Degraded and whatever alerting you already point at
+unhealthy resources picks it up.
+
+For catching a breaking change *before* it lands, the tool is
+[`pacto impact`](../../cli-reference.md) in the pull request. A promotion gate is
+the second line, not the first.
+
+## Flux
+
+Flux decides whether a resource is healthy using kstatus, which recognises three
+condition names: `Ready`, `Reconciling` and `Stalled`. Pacto publishes
+`ContractValid`, `RuntimeObserved` and `ReadinessSatisfied`, so kstatus discards
+all three unread and the object falls through to `Current`. The gate looks
+configured and gates nothing.
+
+`spec.healthCheckExprs` (kustomize-controller v1.5.0, flux2 v2.5.0 and later)
+replaces the guess with a CEL expression:
+
+```yaml
+--8<-- "tests/acceptance/kind/fixtures/gitops/flux-kustomization.yaml"
+```
+
+`sourceRef` is whatever you already use — `GitRepository`, `OCIRepository` or
+`Bucket`. The gate does not care where the manifests came from, only what the
+operator says about them once they are applied.
+
+Four things about that snippet are worth knowing, each checked against
+`fluxcd/pkg` `runtime/cel/status_evaluator.go`:
+
+- **There is no `inProgress` expression, deliberately.** When no expression
+  matches, Flux falls through to in-progress. So `Unknown`, `NotEvaluated` and
+  any verdict added in a later release hold the deploy and time out rather than
+  going falsely green. The gate fails closed.
+- **There is no hand-written generation guard, deliberately.** Flux already
+  compares `status.observedGeneration` to `metadata.generation` before any
+  expression runs. Writing your own is redundant, and it throws on an object that
+  has no status yet.
+- **`Warning` sits in the passing set.** Move that one word to `failed` if you
+  want contract warnings to block promotions. That is the whole knob.
+- **`timeout` must exceed the operator's stabilization window.** Set it lower and
+  a real violation reaches you as an ambiguous timeout instead of a clean
+  failure. See [Timing](#timing) below.
+
+A Pacto that has just been created has no `status` at all, and the expression
+errors while that is true. Flux treats the error as not-yet-healthy and keeps
+polling, so the first few seconds of a fresh apply are noisy in the logs and
+harmless in the outcome.
+
+That snippet is not an illustration. `tests/acceptance/kind/gitops-flux.sh`
+applies **that exact file** to a kind cluster running Flux, publishes a contract
+that contradicts the workload that ships, and asserts the dependent
+Kustomization's own manifest never reaches the cluster — then corrects the
+contract and asserts it does.
+
+`HelmRelease` gained the same field in helm-controller v1.5.0 / flux2 v2.8.0. The
+snippet above should transfer unchanged, but it is not covered here.
+
+## Argo CD
+
+Argo picks a health check from a fixed list of built-in kinds and returns nothing
+for everything else, and the roll-up that turns resource health into Application
+health starts at Healthy and ignores that nothing. A Pacto object is therefore
+not unhealthy to Argo — it is invisible, and nothing reports that a check is
+missing.
+
+A resource health customization in `argocd-cm` supplies the missing check:
+
+```yaml
+--8<-- "tests/acceptance/kind/fixtures/gitops/argocd-cm-pacto-health.yaml"
+```
+
+Apply it as a merge patch. `argocd-cm` holds Argo's own configuration and a plain
+`kubectl apply` of the manifest above would drop it:
+
+```bash
+kubectl -n argocd patch configmap argocd-cm --type merge \
+  --patch-file argocd-cm-pacto-health.yaml
+```
+
+- **Argo has no built-in generation check**, so the script does its own. Be
+  precise about what that proves: `observedGeneration` here is the Pacto object's
+  own generation, so it says the operator has seen the current *contract* — not
+  the current workload.
+- **The findings loop puts the reason in the Argo UI** instead of a bare red dot.
+- **Nothing maps to Argo's `Unknown`.** It ranks worse than `Degraded` in the
+  roll-up, so it would mask genuinely broken workloads in the same Application,
+  and it does not fire the on-degraded trigger. Anything unrecognised becomes
+  `Progressing` and times out.
+- **The Lua runs with the string library disabled.** Concatenation, comparison,
+  `ipairs` and `tostring()` are available; `string.format`, `s:gsub()` and the
+  rest are not, and reaching for one fails at runtime rather than at load.
+
+### Check that it took
+
+Argo ignores a `data` key it does not recognise, and an ignored key looks exactly
+like having configured nothing. Unlike the Flux snippet, this one has no live
+acceptance test standing behind it, which is why the read-back matters. Confirm
+the customization is live before you rely on it:
+
+```bash
+# The key must read back exactly, group and kind included.
+kubectl -n argocd get cm argocd-cm \
+  -o jsonpath='{.data.resource\.customizations\.health\.pacto\.trianalab\.io_Pacto}'
+
+# Then read the health Argo assigns a real object.
+argocd app resources <app> | grep Pacto
+```
+
+A Pacto whose `status.contractStatus` is `Compliant` should read `Healthy` with
+the message `contract satisfied`. If it reads `Healthy` with an empty message,
+the key did not take.
+
+## Timing
+
+The gate is only as fresh as the verdict behind it, and verdicts do not all land
+at the same speed.
+
+| Change | When it becomes `NonCompliant` |
+| --- | --- |
+| A mismatch — workload, persistence or configuration conformance | The first reconcile after the workload is observed |
+| An absence — a missing interface, capability, dependency, Secret or ConfigMap | After the [stabilization window](limitations.md#stabilization-delay) (default two minutes) plus one requeue interval |
+
+That split is why `timeout` has a floor. A five-minute timeout against the
+default two-minute window leaves room for the window, one requeue and the apply
+itself.
+
+There is one gap worth naming. kstatus will not call a Deployment current until
+its controller writes `observedGeneration` back, and that same write is the watch
+event that queues the Pacto reconcile. So the re-check is guaranteed *queued*
+before Flux can first see the workload as current. It is not guaranteed
+*finished*. The gap is one reconcile.
+
+## Limits
+
+- **Argo health customizations are instance-global.** They live in `argocd-cm`,
+  so one Argo serving several teams cannot give one team a blocking `Warning` and
+  another a passing one.
+- **Neither tool can refuse an artifact for what is inside it.** Flux's only
+  pre-apply gate is a signature check. "Reject this because its contract breaks
+  three consumers" is not something a health gate can express — that is a pull
+  request check.
+- **The verdict is about the contract, not the rollout.** A Pacto reporting
+  `Compliant` says the running workload matches its declared contract. It says
+  nothing about request errors, saturation or anything else your normal
+  progressive-delivery signals cover.
+- **`status.lastReconciledAt` cannot be used as a freshness gate.** Flux hands
+  the expression the custom resource and nothing else; Argo hands the Lua only
+  `obj`. Neither has a clock to compare it against.
+
+## Related
+
+- [Troubleshooting](troubleshooting.md#reading-the-events) — the events the
+  operator emits when a verdict changes, and why a `Count` above 1 means the
+  status actually flapped.
+- [Limitations](limitations.md) — what the operator declines to judge, and why
+  those cases read `Unknown` rather than `NonCompliant`.
+- [CRD reference](crd-reference.md) — the full `status` schema the expressions
+  above read from.

--- a/integrations/kubernetes/docs/limitations.md
+++ b/integrations/kubernetes/docs/limitations.md
@@ -120,11 +120,26 @@ runtime-evaluated.
 
 ## Stabilization delay
 
-Confirmed runtime-drift violations only surface after the stabilization window
-([`--stabilization-window`](operator-configuration.md), default two minutes).
-This trades immediacy for
-resistance to transient blips: a single negative observation reads `Unknown` until
-the negative streak spans the whole window.
+The stabilization window
+([`--stabilization-window`](operator-configuration.md), default two minutes)
+trades immediacy for resistance to transient blips: a single negative observation
+reads `Unknown` until the negative streak spans the whole window.
+
+It applies to **absences only** — something the operator expected to find and
+did not:
+
+- `INTERFACE_ABSENT`
+- `DEPENDENCY_UNREACHABLE`
+- `CAPABILITY_ABSENT` (active probing only)
+- `CONFIGURATION_ABSENT`, for a declared Secret or ConfigMap
+
+A **mismatch** — something that is there and contradicts the contract — is
+`NonCompliant` on the first reconcile that observes it, with no delay:
+`WORKLOAD_MISMATCH`, `PERSISTENCE_MISMATCH` and `CONFIGURATION_MISMATCH`. There
+is nothing transient to wait out; the evidence is already conclusive.
+
+This split matters if you gate deployments on the verdict. See
+[GitOps promotion gates](gitops.md#timing).
 
 ## API version
 

--- a/integrations/kubernetes/docs/troubleshooting.md
+++ b/integrations/kubernetes/docs/troubleshooting.md
@@ -57,13 +57,14 @@ kubectl get events --field-selector involvedObject.name=<name> \
   --sort-by=.lastTimestamp
 ```
 
-The operator emits exactly seven, and no others:
+The operator emits exactly eight, and no others:
 
 | Reason | Type | Emitted when | What it tells you |
 | --- | --- | --- | --- |
 | `ContractInvalid` | `Warning` | The contract was obtained and judged invalid | Carries the same message as the `ContractValid` / `Invalid` condition. Fix the contract. |
 | `ContractUnavailable` | `Warning` | The contract could not be obtained at all | Registry unreachable, auth rejected, tag missing. See [Contract not resolving](#contract-not-resolving). |
-| `ValidationFailed` | `Warning` | A contract that *did* load ends the reconcile as anything but `Compliant` or `Reference` | Carries the counts -- `ContractStatus: NonCompliant, 2 errors, 1 warnings`. `status.findings` names each one. |
+| `ValidationFailed` | `Warning` | A contract that *did* load ends the reconcile as anything but `Compliant` or `Reference`, and the status differs from the one the previous reconcile persisted | Carries the counts -- `ContractStatus: NonCompliant, 2 errors, 1 warnings`. `status.findings` names each one. |
+| `ContractRecovered` | `Normal` | The contract status returned to `Compliant` or `Reference` from any other value | The other half of the three warnings above. |
 | `RevisionCreated` | `Normal` | A `PactoRevision` was created for a newly resolved contract | `Created revision <name> for contract v<version>`. Expected on the first resolve and on every version change; not a problem. |
 | `TagOverwritten` | `Warning` | A tag that already resolved now points at a different digest | Someone force-pushed the tag. See [Choosing a reference form](contract-bindings.md#choosing-a-reference-form). |
 | `ReadinessGateUnmet` | `Warning` | The readiness gate went from met to unmet | The message breaks the score down by claim status. |
@@ -77,11 +78,14 @@ Three things about them are easy to misread:
   `ValidationFailed ... ContractStatus: Unknown, 0 errors, 0 warnings`. Read
   the counts, not the reason. A contract that could not be obtained at all
   never reaches this event; it gets `ContractUnavailable` instead.
-- **Only the two readiness events are transition-gated.** The rest are emitted by
-  the reconcile that produces them, so a contract that stays broken keeps
-  producing one. Kubernetes folds repeats of the same reason and message into a
-  single entry with a rising `Count`, so a `Count` of 40 means forty failed
-  reconciles, not forty distinct faults.
+- **Every event except `RevisionCreated` and `TagOverwritten` is transition-gated.**
+  The three contract warnings and `ContractRecovered` fire only when the contract
+  status differs from the one the previous reconcile persisted, and the two
+  readiness events only when the gate flips. A contract that stays broken emits
+  one event, not one per reconcile -- so a `Count` above 1 means the status
+  actually flapped, or the same reason recurred after a recovery. `TagOverwritten`
+  is the exception that still repeats: see
+  [Choosing a reference form](contract-bindings.md#choosing-a-reference-form).
 - **Events expire.** The API server discards them after its `--event-ttl`, one
   hour by default. An absent event means nothing -- absence is not evidence that
   it never fired. Conditions and `status` are the durable record; events are the
@@ -150,9 +154,11 @@ pacto validate oci://ghcr.io/your-org/my-service-pacto:1.2.0
 
 `NonCompliant` means at least one confirmed violation. `CONFIGURATION_ABSENT` (a
 declared configuration is missing) is distinct from `CONFIGURATION_MISMATCH` (it
-exists but differs) -- the finding message names which. Runtime-drift findings only
-fire after the stabilization window; a transient negative reads `Unknown` until the
-window elapses (tune with `--stabilization-window`).
+exists but differs) -- the finding message names which, and the two do not arrive
+at the same speed. An **absence** waits out the stabilization window and reads
+`Unknown` until the negative streak spans it (tune with
+`--stabilization-window`); a **mismatch** is `NonCompliant` on the first reconcile
+that observes it. See [Stabilization delay](limitations.md#stabilization-delay).
 
 ## Status is `Reference`
 

--- a/integrations/kubernetes/internal/controller/contract_event_test.go
+++ b/integrations/kubernetes/internal/controller/contract_event_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2026.
+
+Licensed under the MIT License.
+See LICENSE file in the project root for full license text.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+
+	pactov1alpha1 "github.com/trianalab/pacto/integrations/kubernetes/v5/api/v1alpha1"
+)
+
+// ---------- contractStatusDegraded ----------
+
+func TestContractStatusDegraded(t *testing.T) {
+	cases := []struct {
+		status string
+		want   bool
+	}{
+		// Never reconciled: not degraded, so the first evaluation still fires an event.
+		{"", false},
+		{pactov1alpha1.ContractStatusCompliant, false},
+		{pactov1alpha1.ContractStatusReference, false},
+		{pactov1alpha1.ContractStatusWarning, true},
+		{pactov1alpha1.ContractStatusNonCompliant, true},
+		{pactov1alpha1.ContractStatusUnknown, true},
+		{pactov1alpha1.ContractStatusInvalid, true},
+		{pactov1alpha1.ContractStatusNotEvaluated, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.status, func(t *testing.T) {
+			if got := contractStatusDegraded(tc.status); got != tc.want {
+				t.Errorf("contractStatusDegraded(%q) = %v, want %v", tc.status, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------- contractStatusMessage ----------
+
+func TestContractStatusMessage(t *testing.T) {
+	pacto := &pactov1alpha1.Pacto{}
+	pacto.Status.ContractStatus = pactov1alpha1.ContractStatusNonCompliant
+	pacto.Status.Summary = &pactov1alpha1.Summary{ErrorCount: 2, WarningCount: 3}
+
+	if got, want := contractStatusMessage(pacto), "ContractStatus: NonCompliant, 2 errors, 3 warnings"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestContractStatusMessage_NilSummary(t *testing.T) {
+	pacto := &pactov1alpha1.Pacto{}
+	pacto.Status.ContractStatus = pactov1alpha1.ContractStatusUnknown
+
+	// A missing summary must still yield a message, not a dropped event.
+	if got, want := contractStatusMessage(pacto), "ContractStatus: Unknown, 0 errors, 0 warnings"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// ---------- emitContractStatusEvent ----------
+
+func newEventReconciler() (*PactoReconciler, *record.FakeRecorder) {
+	rec := record.NewFakeRecorder(20)
+	return &PactoReconciler{Recorder: rec}, rec
+}
+
+func TestEmitContractStatusEvent(t *testing.T) {
+	cases := []struct {
+		name       string
+		prev       string
+		current    string
+		wantEvents int
+		wantSubstr string
+	}{
+		{
+			name: "first evaluation degraded emits warning", prev: "",
+			current: pactov1alpha1.ContractStatusNonCompliant, wantEvents: 1,
+			wantSubstr: "Warning " + pactov1alpha1.EventValidationFailed,
+		},
+		{
+			name: "steady degraded is silent", prev: pactov1alpha1.ContractStatusNonCompliant,
+			current: pactov1alpha1.ContractStatusNonCompliant, wantEvents: 0,
+		},
+		{
+			name: "escalation between degraded states emits warning", prev: pactov1alpha1.ContractStatusWarning,
+			current: pactov1alpha1.ContractStatusNonCompliant, wantEvents: 1,
+			wantSubstr: "Warning " + pactov1alpha1.EventValidationFailed,
+		},
+		{
+			name: "recovery to compliant emits normal", prev: pactov1alpha1.ContractStatusNonCompliant,
+			current: pactov1alpha1.ContractStatusCompliant, wantEvents: 1,
+			wantSubstr: "Normal " + pactov1alpha1.EventContractRecovered,
+		},
+		{
+			name: "recovery to reference emits normal", prev: pactov1alpha1.ContractStatusInvalid,
+			current: pactov1alpha1.ContractStatusReference, wantEvents: 1,
+			wantSubstr: "Normal " + pactov1alpha1.EventContractRecovered,
+		},
+		{
+			name: "steady compliant is silent", prev: pactov1alpha1.ContractStatusCompliant,
+			current: pactov1alpha1.ContractStatusCompliant, wantEvents: 0,
+		},
+		{
+			name: "first evaluation compliant is silent", prev: "",
+			current: pactov1alpha1.ContractStatusCompliant, wantEvents: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, rec := newEventReconciler()
+			pacto := &pactov1alpha1.Pacto{}
+			pacto.Status.ContractStatus = tc.current
+
+			r.emitContractStatusEvent(pacto, tc.prev, pactov1alpha1.EventValidationFailed, "msg")
+
+			events := drainEvents(rec)
+			if len(events) != tc.wantEvents {
+				t.Fatalf("expected %d events, got %v", tc.wantEvents, events)
+			}
+			if tc.wantSubstr != "" && !strings.Contains(events[0], tc.wantSubstr) {
+				t.Errorf("expected event containing %q, got %q", tc.wantSubstr, events[0])
+			}
+		})
+	}
+}
+
+// ---------- terminal paths thread the previous status ----------
+
+// A steady non-compliant reconciliation must not re-emit ValidationFailed: the
+// controller watches workloads, so an unguarded event fires once per rollout step.
+func TestFinishReconciliation_SteadyDegradedIsSilent(t *testing.T) {
+	pacto := &pactov1alpha1.Pacto{
+		ObjectMeta: metav1.ObjectMeta{Name: "steady", Namespace: "default"},
+	}
+	r := newReconciler(pacto)
+	rec := record.NewFakeRecorder(20)
+	r.Recorder = rec
+
+	pacto.Status.ContractStatus = pactov1alpha1.ContractStatusNonCompliant
+	pacto.Status.Summary = &pactov1alpha1.Summary{ErrorCount: 1}
+
+	if _, err := r.finishReconciliation(context.Background(), pacto, pactov1alpha1.ContractStatusNonCompliant); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if events := drainEvents(rec); len(events) != 0 {
+		t.Errorf("expected no event for steady NonCompliant, got %v", events)
+	}
+}
+
+// Coming back to Compliant from a degraded status emits the recovery event.
+func TestFinishReconciliation_RecoveryEvent(t *testing.T) {
+	pacto := &pactov1alpha1.Pacto{
+		ObjectMeta: metav1.ObjectMeta{Name: "recovered", Namespace: "default"},
+	}
+	r := newReconciler(pacto)
+	rec := record.NewFakeRecorder(20)
+	r.Recorder = rec
+
+	pacto.Status.ContractStatus = pactov1alpha1.ContractStatusCompliant
+	pacto.Status.Summary = &pactov1alpha1.Summary{}
+
+	if _, err := r.finishReconciliation(context.Background(), pacto, pactov1alpha1.ContractStatusNonCompliant); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	events := drainEvents(rec)
+	if len(events) != 1 || !strings.Contains(events[0], pactov1alpha1.EventContractRecovered) {
+		t.Errorf("expected one ContractRecovered event, got %v", events)
+	}
+}
+
+// failReconciliation is guarded by the same helper: a registry that stays
+// unreachable emits ContractUnavailable once, not once per requeue.
+func TestFailReconciliation_SteadyUnknownIsSilent(t *testing.T) {
+	pacto := &pactov1alpha1.Pacto{
+		ObjectMeta: metav1.ObjectMeta{Name: "steady-unknown", Namespace: "default"},
+	}
+	r := newReconciler(pacto)
+	rec := record.NewFakeRecorder(20)
+	r.Recorder = rec
+
+	_, err := r.failReconciliation(context.Background(), pacto, "registry unreachable", nil,
+		pactov1alpha1.ContractStatusUnknown, pactov1alpha1.ContractStatusUnknown)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if events := drainEvents(rec); len(events) != 0 {
+		t.Errorf("expected no event for steady Unknown, got %v", events)
+	}
+}
+
+func TestFailReconciliation_FirstFailureEmitsWarning(t *testing.T) {
+	pacto := &pactov1alpha1.Pacto{
+		ObjectMeta: metav1.ObjectMeta{Name: "first-fail", Namespace: "default"},
+	}
+	r := newReconciler(pacto)
+	rec := record.NewFakeRecorder(20)
+	r.Recorder = rec
+
+	_, err := r.failReconciliation(context.Background(), pacto, "bad bundle", nil,
+		pactov1alpha1.ContractStatusCompliant, pactov1alpha1.ContractStatusInvalid)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	events := drainEvents(rec)
+	if len(events) != 1 || !strings.Contains(events[0], pactov1alpha1.EventContractInvalid) {
+		t.Errorf("expected one ContractInvalid event, got %v", events)
+	}
+}

--- a/integrations/kubernetes/internal/controller/pacto_controller.go
+++ b/integrations/kubernetes/internal/controller/pacto_controller.go
@@ -92,6 +92,12 @@ func (r *PactoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	prevReadiness := meta.FindStatusCondition(pacto.Status.Conditions, pactov1alpha1.ConditionReadinessSatisfied)
 	readinessWasUnmet := prevReadiness != nil && prevReadiness.Status == metav1.ConditionFalse
 
+	// Same for the contract status, which resetDerivedStatus clears below: the
+	// value read from the API server is the one the previous reconciliation
+	// persisted, and every terminal path threads it back to
+	// emitContractStatusEvent. Empty means never reconciled.
+	prevContractStatus := pacto.Status.ContractStatus
+
 	// 2. Reset all derived status fields so no stale data survives.
 	//    Fields will be repopulated by each step below.
 	r.resetDerivedStatus(pacto)
@@ -105,7 +111,7 @@ func (r *PactoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				&pactov1alpha1.ValidationResult{
 					Valid:  false,
 					Errors: []pactov1alpha1.ValidationIssue{{Path: "spec.contractRef.pullSecretRef", Message: secretErr.Error()}},
-				}, nil, pactov1alpha1.ContractStatusUnknown)
+				}, prevContractStatus, pactov1alpha1.ContractStatusUnknown)
 		}
 		ociAuth = auth
 	}
@@ -121,7 +127,7 @@ func (r *PactoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			&pactov1alpha1.ValidationResult{
 				Valid:  false,
 				Errors: []pactov1alpha1.ValidationIssue{{Message: err.Error()}},
-			}, nil, status)
+			}, prevContractStatus, status)
 	}
 
 	// 4b. Apply configuration overrides (if specified)
@@ -135,7 +141,7 @@ func (r *PactoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				&pactov1alpha1.ValidationResult{
 					Valid:  false,
 					Errors: []pactov1alpha1.ValidationIssue{{Path: "spec.overrides", Message: overrideErr.Error()}},
-				}, loadResult.Contract, pactov1alpha1.ContractStatusInvalid)
+				}, prevContractStatus, pactov1alpha1.ContractStatusInvalid)
 		}
 	}
 
@@ -145,7 +151,7 @@ func (r *PactoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	if len(contractResult.Errors) > 0 {
 		msg := formatValidationErrors(contractResult.Errors)
-		return r.failReconciliation(ctx, pacto, msg, pacto.Status.Validation, effectiveContract, pactov1alpha1.ContractStatusInvalid)
+		return r.failReconciliation(ctx, pacto, msg, pacto.Status.Validation, prevContractStatus, pactov1alpha1.ContractStatusInvalid)
 	}
 
 	r.setCondition(pacto, pactov1alpha1.ConditionContractValid, metav1.ConditionTrue,
@@ -190,7 +196,7 @@ func (r *PactoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			fmt.Sprintf("Reference contract %s v%s is valid", effectiveContract.Service.Name, effectiveContract.Service.Version))
 		pacto.Status.ContractStatus = pactov1alpha1.ContractStatusReference
 		pacto.Status.Summary = &pactov1alpha1.Summary{}
-		return r.finishReconciliation(ctx, pacto)
+		return r.finishReconciliation(ctx, pacto, prevContractStatus)
 	}
 
 	// 9. Resolve target
@@ -323,7 +329,7 @@ func (r *PactoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	pacto.Status.Summary = &summary
 	pacto.Status.ContractStatus = status
 
-	return r.finishReconciliation(ctx, pacto)
+	return r.finishReconciliation(ctx, pacto, prevContractStatus)
 }
 
 // resetDerivedStatus clears all status fields that are recomputed each reconciliation.
@@ -356,7 +362,9 @@ func (r *PactoReconciler) resetDerivedStatus(pacto *pactov1alpha1.Pacto) {
 
 // failReconciliation handles the common pattern for contract-level failures with phase-classified status
 // (spec section 9.8): Invalid vs Unknown. The status parameter drives condition reason + summary.
-func (r *PactoReconciler) failReconciliation(ctx context.Context, pacto *pactov1alpha1.Pacto, msg string, valResult *pactov1alpha1.ValidationResult, _ *contract.Contract, status string) (ctrl.Result, error) {
+// prevContractStatus is the contract status persisted by the previous reconciliation; it gates the
+// transition event (see emitContractStatusEvent).
+func (r *PactoReconciler) failReconciliation(ctx context.Context, pacto *pactov1alpha1.Pacto, msg string, valResult *pactov1alpha1.ValidationResult, prevContractStatus, status string) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	switch status {
@@ -392,12 +400,11 @@ func (r *PactoReconciler) failReconciliation(ctx context.Context, pacto *pactov1
 		return ctrl.Result{}, statusErr
 	}
 
-	eventType := corev1.EventTypeWarning
-	eventReason := "ContractInvalid"
+	eventReason := pactov1alpha1.EventContractInvalid
 	if status == pactov1alpha1.ContractStatusUnknown {
-		eventReason = "ContractUnavailable"
+		eventReason = pactov1alpha1.EventContractUnavailable
 	}
-	r.Recorder.Event(pacto, eventType, eventReason, msg)
+	r.emitContractStatusEvent(pacto, prevContractStatus, eventReason, msg)
 
 	// Emit metrics
 	metrics.RecordContractStatus(pacto.Namespace, pacto.Name, pacto.Status.ContractStatus)
@@ -525,8 +532,53 @@ func errorsAsAny(err error, targets ...error) bool {
 	return false
 }
 
+// contractStatusDegraded reports whether a contract status is one a promotion gate
+// should block on. Compliant and Reference are the healthy terminal states; the
+// empty string means "not evaluated yet" and is deliberately NOT degraded, so a
+// Pacto that is born non-compliant still emits its first warning event.
+func contractStatusDegraded(status string) bool {
+	switch status {
+	case "", pactov1alpha1.ContractStatusCompliant, pactov1alpha1.ContractStatusReference:
+		return false
+	default:
+		return true
+	}
+}
+
+// contractStatusMessage renders the event body for a completed evaluation. Summary
+// is set by every path that reaches finishReconciliation, but a nil one must still
+// produce an event rather than silently drop the transition.
+func contractStatusMessage(pacto *pactov1alpha1.Pacto) string {
+	summary := pacto.Status.Summary
+	if summary == nil {
+		summary = &pactov1alpha1.Summary{}
+	}
+	return fmt.Sprintf("ContractStatus: %s, %d errors, %d warnings",
+		pacto.Status.ContractStatus, summary.ErrorCount, summary.WarningCount)
+}
+
+// emitContractStatusEvent records a contract-status event only when the status
+// CHANGED since the reconciliation that last persisted it (prev, captured before
+// resetDerivedStatus wiped it). The controller watches Deployments, ReplicaSets,
+// StatefulSets, Jobs, CronJobs and Services, so an unguarded event fires once per
+// workload status write — a rolling update alone produces dozens. warnReason is
+// the reason for the degraded direction; recovery always uses EventContractRecovered.
+// This mirrors the readiness gate guard (see reconcileReadiness).
+func (r *PactoReconciler) emitContractStatusEvent(pacto *pactov1alpha1.Pacto, prev, warnReason, msg string) {
+	current := pacto.Status.ContractStatus
+	switch {
+	case contractStatusDegraded(current) && current != prev:
+		// Includes escalation between degraded states (Warning -> NonCompliant).
+		r.Recorder.Event(pacto, corev1.EventTypeWarning, warnReason, msg)
+	case !contractStatusDegraded(current) && contractStatusDegraded(prev):
+		r.Recorder.Event(pacto, corev1.EventTypeNormal, pactov1alpha1.EventContractRecovered, msg)
+	}
+}
+
 // finishReconciliation sets final metadata, persists status, and emits metrics.
-func (r *PactoReconciler) finishReconciliation(ctx context.Context, pacto *pactov1alpha1.Pacto) (ctrl.Result, error) {
+// prevContractStatus is the contract status persisted by the previous
+// reconciliation; it gates the transition event (see emitContractStatusEvent).
+func (r *PactoReconciler) finishReconciliation(ctx context.Context, pacto *pactov1alpha1.Pacto, prevContractStatus string) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	now := metav1.Now()
@@ -538,13 +590,8 @@ func (r *PactoReconciler) finishReconciliation(ctx context.Context, pacto *pacto
 		return ctrl.Result{}, statusErr
 	}
 
-	if pacto.Status.ContractStatus != pactov1alpha1.ContractStatusCompliant && pacto.Status.ContractStatus != pactov1alpha1.ContractStatusReference {
-		if pacto.Status.Summary != nil {
-			r.Recorder.Eventf(pacto, corev1.EventTypeWarning, "ValidationFailed",
-				"ContractStatus: %s, %d errors, %d warnings", pacto.Status.ContractStatus,
-				pacto.Status.Summary.ErrorCount, pacto.Status.Summary.WarningCount)
-		}
-	}
+	r.emitContractStatusEvent(pacto, prevContractStatus,
+		pactov1alpha1.EventValidationFailed, contractStatusMessage(pacto))
 
 	// Emit Prometheus metrics
 	metrics.RecordContractStatus(pacto.Namespace, pacto.Name, pacto.Status.ContractStatus)

--- a/integrations/kubernetes/internal/controller/s6_7_coverage_test.go
+++ b/integrations/kubernetes/internal/controller/s6_7_coverage_test.go
@@ -333,7 +333,7 @@ func TestFailReconciliation_UnknownStatus(t *testing.T) {
 	}
 	r := newReconciler(pacto)
 
-	_, err := r.failReconciliation(context.Background(), pacto, "contract unavailable", nil, nil, pactov1alpha1.ContractStatusUnknown)
+	_, err := r.failReconciliation(context.Background(), pacto, "contract unavailable", nil, "", pactov1alpha1.ContractStatusUnknown)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -359,7 +359,7 @@ func TestFailReconciliation_InvalidStatus(t *testing.T) {
 	}
 	r := newReconciler(pacto)
 
-	_, err := r.failReconciliation(context.Background(), pacto, "contract invalid", nil, nil, pactov1alpha1.ContractStatusInvalid)
+	_, err := r.failReconciliation(context.Background(), pacto, "contract invalid", nil, "", pactov1alpha1.ContractStatusInvalid)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -385,7 +385,7 @@ func TestFailReconciliation_UnexpectedStatusFallback(t *testing.T) {
 	}
 	r := newReconciler(pacto)
 
-	_, err := r.failReconciliation(context.Background(), pacto, "unexpected", nil, nil, "unexpected-status")
+	_, err := r.failReconciliation(context.Background(), pacto, "unexpected", nil, "", "unexpected-status")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -231,6 +231,7 @@ nav:
           - Kubernetes overview: integrations/kubernetes/overview.md
           - Install the operator: integrations/kubernetes/installation.md
           - Upgrade the operator: integrations/kubernetes/upgrade.md
+          - GitOps promotion gates: integrations/kubernetes/gitops.md
           - Contract bindings: integrations/kubernetes/contract-bindings.md
           - Runtime observations: integrations/kubernetes/runtime-observations.md
           - Operator configuration: integrations/kubernetes/operator-configuration.md

--- a/release/scripts/docs_check.py
+++ b/release/scripts/docs_check.py
@@ -363,6 +363,30 @@ def go_call_args(text: str, limit: int) -> list[str]:
     return args
 
 
+def resolve_param_arg(tok: str, src: str, api_consts: dict, seen: set) -> list[str]:
+    """Resolve a function PARAMETER to the arguments its call sites pass it.
+
+    A parameter has no assignment to read, so the assignment search below finds
+    nothing and the token reads as unresolvable. That is wrong for the one shape
+    it keeps hitting: a small helper that takes the reason and does the emitting,
+    which is the natural factoring when several paths emit the same event under
+    the same transition rule. Follow one hop -- find the declaring signature, take
+    the parameter's position, and resolve what every call in this file passes
+    there. Anything the hop cannot read still resolves to nothing and is reported.
+    """
+    out = []
+    for m in re.finditer(r"^func\s+(?:\([^)]*\)\s*)?(\w+)\(([^)]*)\)", src, re.M):
+        names = [p.strip().split()[0] for p in m.group(2).split(",") if p.strip()]
+        if tok not in names:
+            continue
+        idx = names.index(tok)
+        for call in re.finditer(rf"\b{re.escape(m.group(1))}\(", src):
+            args = go_call_args(src[call.end():], idx + 1)
+            if len(args) > idx and args[idx]:
+                out.extend(resolve_event_token(args[idx], src, api_consts, seen))
+    return out
+
+
 def resolve_event_token(tok: str, src: str, api_consts: dict, seen=None) -> list[str]:
     """Resolve an event-type or event-reason argument to the strings it can be.
 
@@ -382,6 +406,8 @@ def resolve_event_token(tok: str, src: str, api_consts: dict, seen=None) -> list
     out = []
     for rhs in re.findall(rf"^\s*{re.escape(tok)}\s*(?::=|=)\s*(.+?)\s*$", src, re.M):
         out.extend(resolve_event_token(rhs, src, api_consts, seen))
+    if not out:
+        out = resolve_param_arg(tok, src, api_consts, seen)
     return sorted(set(out))
 
 
@@ -391,8 +417,9 @@ def check_events() -> None:
     Those are the strings an operator greps `kubectl get events` for, so a new
     call site or a renamed reason silently invalidates the page. Resolve the real
     call sites rather than restating them here: a literal is taken as-is, an
-    api/v1alpha1 `EventXxx` constant is looked up, and a local variable is
-    resolved through its assignments in the same file. A token that resolves to
+    api/v1alpha1 `EventXxx` constant is looked up, a local variable is resolved
+    through its assignments in the same file, and a parameter is resolved through
+    the arguments that file's own call sites pass it. A token that resolves to
     none of those is reported, so a new emission pattern fails this gate instead
     of slipping past it.
     """

--- a/tests/acceptance/kind/fixtures/gitops/argocd-cm-pacto-health.yaml
+++ b/tests/acceptance/kind/fixtures/gitops/argocd-cm-pacto-health.yaml
@@ -1,0 +1,77 @@
+# Argo CD health customization that makes a violated Pacto contract turn its
+# Application red.
+#
+# This file is published verbatim in integrations/kubernetes/docs/gitops.md.
+# Apply it as a MERGE PATCH, never as a plain `kubectl apply` -- argocd-cm holds
+# Argo's own keys and a full apply would drop them:
+#
+#   kubectl -n argocd patch configmap argocd-cm --type merge \
+#     --patch-file argocd-cm-pacto-health.yaml
+#
+# The data key must be typed exactly. Argo silently ignores a key it does not
+# recognise, which looks identical to having configured nothing at all.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+data:
+  resource.customizations.health.pacto.trianalab.io_Pacto: |
+    -- Argo runs this with the Lua string library disabled.
+    -- Only concatenation, comparison, ipairs and tostring() are available.
+
+    -- Set to "Degraded" to make contract warnings block a promotion.
+    local warningHealth = "Healthy"
+
+    local hs = {}
+
+    if obj.status == nil or obj.status.contractStatus == nil then
+      hs.status = "Progressing"
+      hs.message = "waiting for the first contract evaluation"
+      return hs
+    end
+
+    if obj.status.observedGeneration ~= obj.metadata.generation then
+      hs.status = "Progressing"
+      hs.message = "contract not yet evaluated at this generation"
+      return hs
+    end
+
+    local s = obj.status.contractStatus
+
+    if s == "Compliant" or s == "Reference" then
+      hs.status = "Healthy"
+      hs.message = "contract satisfied"
+      return hs
+    end
+
+    if s == "Warning" then
+      hs.status = warningHealth
+      hs.message = "contract satisfied with warnings"
+      return hs
+    end
+
+    if s == "NonCompliant" then
+      hs.status = "Degraded"
+      hs.message = "contract violated"
+      if obj.status.findings ~= nil then
+        for _, f in ipairs(obj.status.findings) do
+          if f.severity == "error" then
+            hs.message = "contract violated: " .. tostring(f.code) .. ": " .. tostring(f.message)
+            break
+          end
+        end
+      end
+      return hs
+    end
+
+    if s == "Invalid" then
+      hs.status = "Degraded"
+      hs.message = "contract is invalid and could not be evaluated"
+      return hs
+    end
+
+    -- Unknown, NotEvaluated, and anything added later.
+    hs.status = "Progressing"
+    hs.message = "contract verdict pending: " .. tostring(s)
+    return hs

--- a/tests/acceptance/kind/fixtures/gitops/flux-kustomization.yaml
+++ b/tests/acceptance/kind/fixtures/gitops/flux-kustomization.yaml
@@ -1,0 +1,47 @@
+# Flux promotion gate driven by the Pacto contract verdict.
+#
+# This file is published verbatim in integrations/kubernetes/docs/gitops.md and
+# applied verbatim by tests/acceptance/kind/gitops-flux.sh. Edit it and you edit
+# both; the documented snippet cannot drift from the tested one.
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: orders-staging
+  namespace: flux-system
+spec:
+  interval: 1m
+  # Must exceed the operator's stabilization window (default 2m) plus one
+  # requeue interval, or a real violation arrives as an ambiguous timeout
+  # instead of a clean failure.
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: OCIRepository
+    name: orders
+  path: ./staging
+  healthCheckExprs:
+    - apiVersion: pacto.trianalab.io/v1alpha1
+      kind: Pacto
+      failed: status.contractStatus in ['NonCompliant', 'Invalid']
+      current: status.contractStatus in ['Compliant', 'Reference', 'Warning']
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: orders-production
+  namespace: flux-system
+spec:
+  interval: 1m
+  timeout: 5m
+  prune: true
+  wait: true
+  # Production does not start until staging is healthy, and healthy now
+  # includes the contract verdict. This line is the promotion gate.
+  dependsOn:
+    - name: orders-staging
+  sourceRef:
+    kind: OCIRepository
+    name: orders
+  path: ./production

--- a/tests/acceptance/kind/gitops-argocd.sh
+++ b/tests/acceptance/kind/gitops-argocd.sh
@@ -1,0 +1,442 @@
+#!/usr/bin/env bash
+# Kind acceptance for the Argo CD half of the GitOps promotion gate: a violated
+# Pacto contract turns its Argo Application red, and satisfying it turns it green.
+#
+# The health customization published in integrations/kubernetes/docs/gitops.md is
+# the thing under test, and it fails SILENTLY. A `data` key Argo does not
+# recognise is ignored, a Lua slip leaves the object unjudged, and both look
+# exactly like having configured nothing: the Application stays green and nobody
+# is told a check is missing. So this scenario runs the documented file itself,
+# never a copy, from
+# tests/acceptance/kind/fixtures/gitops/argocd-cm-pacto-health.yaml.
+#
+# It runs in two phases, cheap first.
+#
+#   Phase 1 needs no cluster at all. `argocd admin settings resource-overrides
+#   health` evaluates the customization against a Pacto manifest using the same
+#   Lua sandbox the server runs, so every contract verdict — including the ones a
+#   live cluster cannot cheaply manufacture, like a stale observedGeneration —
+#   gets an assertion. It fails in seconds when the mapping is wrong.
+#
+#   Phase 2 is the claim phase 1 cannot make: that a real Argo CD, reading that
+#   ConfigMap out of its own namespace, reports the Application Degraded. It runs
+#   the operator, the manifests and the verdict end to end.
+set -euo pipefail
+CLUSTER="${KIND_CLUSTER:-pacto-gitops-argo}"
+NS=pacto-system
+APP_NS=demo
+ARGO_NS=argocd
+REG_HOST="pacto-registry.${NS}.svc.cluster.local:5000"
+LOCAL_REG_PORT=5602
+# ONE pin for both halves. The CLI in phase 1 and the server in phase 2 must be
+# the same release, or phase 1 is evidence about a Lua sandbox nobody deployed.
+# Pinned to a version with OCI application sources (v3.1.0 and later), which is
+# what lets this scenario reuse the in-cluster registry instead of standing up a
+# git server for Argo to clone from.
+ARGOCD_VERSION=v3.5.2
+# What ORAS labels the manifest layer. Argo allows this media type by default
+# (cmd/argocd-repo-server: application/vnd.oci.image.layer.v1.tar+gzip) and
+# refuses an artifact carrying anything but exactly one content layer.
+ARGO_LAYER_TYPE=application/vnd.oci.image.layer.v1.tar+gzip
+MANIFEST_REPO="demo/orders-manifests"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+FIXTURE="$HERE/fixtures/gitops/argocd-cm-pacto-health.yaml"
+HEALTH_KEY='resource.customizations.health.pacto.trianalab.io_Pacto'
+# shellcheck source=tests/acceptance/kind/lib.sh
+source "$HERE/lib.sh"
+
+echo "== phase 1: the documented customization, judged offline =="
+
+# The CLI is cached by version rather than taken from PATH: a developer's argocd
+# is whatever they last installed, and the whole point of the pin is that this
+# check speaks for the server phase 2 deploys.
+ARGOCD_BIN=""
+install_argocd_cli() {
+  local os arch
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  case "$(uname -m)" in
+    x86_64 | amd64) arch=amd64 ;;
+    arm64 | aarch64) arch=arm64 ;;
+    *) fail "no argocd release asset for $(uname -m)" ;;
+  esac
+  ARGOCD_BIN="${TMPDIR:-/tmp}/pacto-argocd-${ARGOCD_VERSION}-${os}-${arch}"
+  [ -x "$ARGOCD_BIN" ] && return 0
+  # Downloaded to .part and renamed, so an interrupted download can never be
+  # reused as a working binary by the next run.
+  curl -sSfL -o "${ARGOCD_BIN}.part" \
+    "https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_VERSION}/argocd-${os}-${arch}" \
+    || fail "could not download the argocd CLI ${ARGOCD_VERSION} for ${os}/${arch}"
+  chmod +x "${ARGOCD_BIN}.part"
+  mv "${ARGOCD_BIN}.part" "$ARGOCD_BIN"
+}
+install_argocd_cli
+
+# verdict CONTRACT_STATUS [GENERATION] [OBSERVED_GENERATION] — a Pacto manifest
+# carrying one verdict. The spec is minimal on purpose: the script under test
+# reads status and metadata.generation and nothing else.
+verdict() {
+  cat <<YAML
+apiVersion: pacto.trianalab.io/v1alpha1
+kind: Pacto
+metadata: { name: orders, namespace: $APP_NS, generation: ${2:-1} }
+spec: { contractRef: { inline: "pactoVersion: '2.0'" } }
+status: { contractStatus: $1, observedGeneration: ${3:-1} }
+YAML
+}
+
+# health_case NAME WANT_STATUS WANT_MESSAGE_SUBSTRING < MANIFEST
+health_case() {
+  local name="$1" want_status="$2" want_msg="$3" manifest out status message
+  manifest="$(mktemp)"
+  cat > "$manifest"
+  out="$("$ARGOCD_BIN" admin settings resource-overrides health "$manifest" \
+    --argocd-cm-path "$FIXTURE" 2>&1)" \
+    || fail "$name: argocd could not evaluate the customization: $out"
+  # This is the silent failure the whole phase exists for, and argocd reports it
+  # on stdout while exiting 0 — verified against ${ARGOCD_VERSION}. Read the
+  # output; the exit status cannot tell configured from unconfigured.
+  if grep -q 'Health script is not configured' <<< "$out"; then
+    fail "$name: Argo found no health check for pacto.trianalab.io/Pacto — $(basename "$FIXTURE") does not carry a key Argo recognises"
+  fi
+  status="$(sed -n 's/^STATUS: //p' <<< "$out")"
+  message="$(sed -n 's/^MESSAGE: //p' <<< "$out")"
+  [ "$status" = "$want_status" ] \
+    || fail "$name: expected STATUS $want_status, got '$status' (message: $message)"
+  grep -qF "$want_msg" <<< "$message" \
+    || fail "$name: expected the message to contain '$want_msg', got '$message'"
+  pass "$name -> $status: $message"
+}
+
+# Every contractStatus in the CRD enum, plus the two states a live cluster passes
+# through too fast to assert. None of them expects Argo's `Unknown`: it ranks
+# worse than Degraded in the Application roll-up and does not fire the
+# on-degraded trigger, and the page promises nothing lands there.
+health_case "Compliant"      Healthy     "contract satisfied"                   < <(verdict Compliant)
+health_case "Reference"      Healthy     "contract satisfied"                   < <(verdict Reference)
+health_case "Warning"        Healthy     "contract satisfied with warnings"     < <(verdict Warning)
+health_case "NonCompliant"   Degraded    "contract violated"                    < <(verdict NonCompliant)
+health_case "Invalid"        Degraded    "invalid"                              < <(verdict Invalid)
+health_case "Unknown"        Progressing "verdict pending: Unknown"             < <(verdict Unknown)
+health_case "NotEvaluated"   Progressing "verdict pending: NotEvaluated"        < <(verdict NotEvaluated)
+# The fail-closed property: a verdict added in some later release must hold the
+# promotion rather than pass it.
+health_case "a verdict added later" Progressing "verdict pending: Provisional"  < <(verdict Provisional)
+health_case "verdict behind the contract" Progressing "not yet evaluated at this generation" < <(verdict Compliant 2 1)
+
+# A Pacto the operator has not reached yet. Written out rather than produced by
+# `verdict`, because the absent field IS the case.
+health_case "no status yet" Progressing "waiting for the first contract evaluation" <<YAML
+apiVersion: pacto.trianalab.io/v1alpha1
+kind: Pacto
+metadata: { name: orders, namespace: $APP_NS, generation: 1 }
+spec: { contractRef: { inline: "pactoVersion: '2.0'" } }
+YAML
+
+# The findings loop is what puts the reason in the Argo UI instead of a bare red
+# dot, and it is the one branch that reads a nested list under the sandbox's
+# restrictions.
+health_case "the reason reaches the UI" Degraded "WORKLOAD_MISMATCH" <<YAML
+apiVersion: pacto.trianalab.io/v1alpha1
+kind: Pacto
+metadata: { name: orders, namespace: $APP_NS, generation: 1 }
+spec: { contractRef: { inline: "pactoVersion: '2.0'" } }
+status:
+  contractStatus: NonCompliant
+  observedGeneration: 1
+  findings:
+    - { severity: warning, code: CONFIGURATION_ABSENT, message: not the headline }
+    - { severity: error, code: WORKLOAD_MISMATCH, message: declared job, observed Deployment }
+YAML
+
+echo "== phase 2: the same file, inside a real Argo CD =="
+
+# Argo lives outside $NS, so dump_diag alone cannot explain a red — or wrongly
+# green — Application: the reason is in the Application's own conditions, in the
+# per-resource health Argo computed, and in the repo-server's log when the OCI
+# source is what failed.
+dump_argo() {
+  echo "--- argocd applications ---"
+  kubectl -n "$ARGO_NS" get applications -o wide || true
+  kubectl -n "$ARGO_NS" describe application orders || true
+  echo "--- resource health as Argo computed it ---"
+  kubectl -n "$ARGO_NS" get application orders \
+    -o jsonpath='{range .status.resources[*]}{.kind}{"/"}{.name}{" health="}{.health.status}{" msg="}{.health.message}{"\n"}{end}' || true
+  echo "--- the customization argocd-cm actually holds ---"
+  kubectl -n "$ARGO_NS" get cm argocd-cm -o jsonpath="{.data.${HEALTH_KEY//./\\.}}" || true
+  echo
+  echo "--- $APP_NS objects ---"
+  kubectl -n "$APP_NS" get all,pactos || true
+  for c in argocd-repo-server argocd-application-controller; do
+    echo "--- logs $c ($ARGO_NS) ---"
+    kubectl -n "$ARGO_NS" logs -l "app.kubernetes.io/name=$c" --tail=200 --all-containers || true
+  done
+}
+# shellcheck disable=SC2154  # rc is assigned by rc=$? inside the trap body
+trap 'rc=$?; [ $rc -ne 0 ] && { dump_diag "$NS"; dump_argo; }; pkill -f "kubectl.*port-forward" 2>/dev/null || true; exit $rc' EXIT
+
+command -v oras > /dev/null 2>&1 \
+  || fail "oras is required: it publishes the manifest artifact Argo's OCI source pulls"
+
+VER="$(release_version kubernetes)"
+CORE="$(release_version core)"
+OP_IMG="localhost:5001/pacto-operator/pacto-controller:${VER}"
+OP_REPO="localhost:5001/pacto-operator/pacto-controller"
+DASH_IMG="localhost:5001/pacto-dashboard:${CORE}"
+
+build_operator_images "$OP_IMG" "$DASH_IMG" "$VER"
+
+echo "== package the chart =="
+CHART="$(package_chart "$PACTO_CHART")"
+
+ensure_cluster
+# The dashboard is off for this scenario, so only the operator image is loaded.
+load_images "$OP_IMG"
+for ns in "$NS" "$APP_NS" "$ARGO_NS"; do
+  kubectl create namespace "$ns" --dry-run=client -o yaml | kubectl apply -f - > /dev/null
+done
+# $APP_NS is created OUTSIDE Argo's inventory on purpose: with automated pruning
+# on, a namespace inside it would take the Pacto CR under test down with it.
+
+echo "== the operator =="
+helm install pacto-operator "$CHART" -n "$NS" \
+  --set image.repository="$OP_REPO" --set image.tag="$VER" --set image.pullPolicy=Never \
+  --set dashboard.enabled=false --wait --timeout 240s
+
+echo "== an in-cluster OCI registry to publish the Application's manifests to =="
+install_registry
+REG_PF_PID="$(pf "$LOCAL_REG_PORT" svc/pacto-registry 5000)"
+
+# publish WORKLOAD TAG — the Application's manifests, as the OCI artifact Argo
+# pulls. WORKLOAD is what the contract DECLARES; the workload that actually ships
+# is always a Deployment, so `job` is a contract that contradicts the cluster.
+publish() {
+  local workload="$1" tag="$2" tree tgz
+  tree="$(mktemp -d)"
+  tgz="$(mktemp -t orders-manifests.XXXXXX)"
+
+  cat > "$tree/deployment.yaml" << YAML
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: orders, namespace: $APP_NS }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: orders } }
+  template:
+    metadata: { labels: { app: orders } }
+    spec:
+      containers:
+        - { name: app, image: registry.k8s.io/pause:3.9 }
+YAML
+  # workloadRef carries BOTH name and kind, which is what makes the mismatch
+  # assertable: without an explicit kind the operator reports EVIDENCE_INSUFFICIENT
+  # (Unknown) rather than WORKLOAD_MISMATCH, and the Application would go amber
+  # for a reason this scenario did not set up.
+  cat > "$tree/pacto.yaml" << YAML
+apiVersion: pacto.trianalab.io/v1alpha1
+kind: Pacto
+metadata: { name: orders, namespace: $APP_NS }
+spec:
+  checkIntervalSeconds: 30
+  contractRef:
+    inline: |
+      pactoVersion: '2.0'
+      service: {name: orders, version: 1.0.0, owner: {team: audit, dri: d, contacts: [{type: email, value: a@e.com, purpose: escalation}]}}
+      workload: $workload
+      state: {type: stateless, persistence: {scope: local, durability: ephemeral}, dataCriticality: low}
+  target: {workloadRef: {name: orders, kind: Deployment}}
+YAML
+
+  tar -czf "$tgz" -C "$tree" .
+  # --disable-path-validation: $tgz is absolute and ORAS refuses an absolute file
+  # argument unless told the path is deliberate. It is; nothing here is user input.
+  oras push --plain-http --disable-path-validation \
+    "127.0.0.1:${LOCAL_REG_PORT}/${MANIFEST_REPO}:${tag}" "${tgz}:${ARGO_LAYER_TYPE}" > /dev/null
+  echo "  published $tag (contract declares workload: $workload)"
+}
+
+echo "== publish v1: a contract that CONTRADICTS the workload that ships =="
+publish job v1
+
+echo "== Argo CD $ARGOCD_VERSION (core install: no API server, no UI) =="
+# The manifests come from the repository at the tag, not from the GitHub release:
+# Argo attaches CLI binaries to a release and nothing else, so there is no
+# core-install.yaml asset to download.
+#
+# --server-side: Argo's Application CRD is far past the size a
+# last-applied-configuration annotation can hold, and a client-side apply of it
+# fails on exactly that.
+kubectl apply -n "$ARGO_NS" --server-side \
+  -f "https://raw.githubusercontent.com/argoproj/argo-cd/${ARGOCD_VERSION}/manifests/core-install.yaml" > /dev/null
+# The apply returns as soon as the CRD objects are written, which is before the
+# API server serves argoproj.io in discovery. Anything applied in that window
+# fails with `no matches for kind`, which reads like a manifest problem. Asking
+# for the resources is the check, rather than `kubectl wait --for=established`:
+# that errors outright on a CRD whose status has not been written yet, which is
+# the very window being waited out.
+argo_crds_served() {
+  kubectl get appprojects.argoproj.io -A > /dev/null 2>&1 \
+    && kubectl get applications.argoproj.io -A > /dev/null 2>&1
+}
+eventually 40 argo_crds_served || fail "argoproj.io never reached discovery after the core install"
+# Nothing here reconciles an ApplicationSet, and unlike Flux's notification
+# controller nothing posts to it, so scaling it away costs no diagnostics.
+kubectl -n "$ARGO_NS" scale deploy argocd-applicationset-controller --replicas=0 > /dev/null 2>&1 || true
+
+# The `default` AppProject is created by the API server on startup, and the core
+# install has no API server. Without it every Application sits at
+# InvalidSpecError with no sync attempted, which looks nothing like an OCI or a
+# health-check problem and would send a reader debugging the wrong half.
+kubectl apply -f - > /dev/null << YAML
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata: { name: default, namespace: $ARGO_NS }
+spec:
+  sourceRepos: ['*']
+  destinations: [{ server: '*', namespace: '*' }]
+  clusterResourceWhitelist: [{ group: '*', kind: '*' }]
+YAML
+
+# Argo computes per-resource health either way; this only decides where it is
+# written. By default the result stays in the controller's cache, which the UI
+# and `argocd app get` read through the API server — and there is no API server
+# here. Persisting it puts the same verdict on .status.resources[] where kubectl
+# can read it, so this scenario asserts on Argo's judgement rather than on its
+# own re-derivation of it. The controller reads the flag once at startup.
+kubectl -n "$ARGO_NS" patch configmap argocd-cmd-params-cm --type merge \
+  -p '{"data":{"controller.resource.health.persist":"true"}}' > /dev/null
+kubectl -n "$ARGO_NS" rollout restart statefulset/argocd-application-controller > /dev/null
+
+kubectl -n "$ARGO_NS" rollout status deploy/argocd-redis --timeout=300s
+kubectl -n "$ARGO_NS" rollout status deploy/argocd-repo-server --timeout=300s
+kubectl -n "$ARGO_NS" rollout status statefulset/argocd-application-controller --timeout=300s
+
+echo "== apply the DOCUMENTED customization, verbatim, the way the page says to =="
+kubectl -n "$ARGO_NS" patch configmap argocd-cm --type merge --patch-file "$FIXTURE" > /dev/null
+
+# Read it back before anything depends on it. argocd-cm is a plain ConfigMap:
+# every key is accepted, and one Argo does not recognise is dropped on the floor
+# at read time with no event, no log line and a green Application. This is the
+# same check the page tells a reader to run.
+LIVE_SCRIPT="$(kubectl -n "$ARGO_NS" get cm argocd-cm -o jsonpath="{.data.${HEALTH_KEY//./\\.}}")"
+[ -n "$LIVE_SCRIPT" ] \
+  || fail "argocd-cm has no $HEALTH_KEY after the merge patch — Argo would judge nothing"
+# Argo's own configuration has to survive the patch, or the page is telling
+# readers to break their installation.
+kubectl -n "$ARGO_NS" get cm argocd-cm -o jsonpath='{.metadata.labels.app\.kubernetes\.io/part-of}' \
+  | grep -q argocd || fail "the merge patch replaced argocd-cm instead of adding to it"
+pass "the customization is live in argocd-cm and Argo's own keys survived"
+
+echo "== point an Application at the in-cluster registry =="
+# type: oci and insecureOCIForceHttp are the whole reason this Secret exists: the
+# registry speaks plain HTTP, and without the Secret Argo would try TLS against
+# it and fail in the repo-server rather than anywhere a reader would look.
+kubectl apply -f - > /dev/null << YAML
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orders-manifests
+  namespace: $ARGO_NS
+  labels: { argocd.argoproj.io/secret-type: repository }
+stringData:
+  name: orders-manifests
+  type: oci
+  url: oci://${REG_HOST}/${MANIFEST_REPO}
+  insecureOCIForceHttp: "true"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata: { name: orders, namespace: $ARGO_NS }
+spec:
+  project: default
+  source:
+    repoURL: oci://${REG_HOST}/${MANIFEST_REPO}
+    targetRevision: v1
+    path: .
+  destination: { server: https://kubernetes.default.svc, namespace: $APP_NS }
+  syncPolicy:
+    automated: { prune: true }
+YAML
+
+app_sync() { kubectl -n "$ARGO_NS" get application orders -o jsonpath='{.status.sync.status}' 2>/dev/null || true; }
+app_health() { kubectl -n "$ARGO_NS" get application orders -o jsonpath='{.status.health.status}' 2>/dev/null || true; }
+pacto_health() { kubectl -n "$ARGO_NS" get application orders -o jsonpath='{.status.resources[?(@.kind=="Pacto")].health.status}' 2>/dev/null || true; }
+pacto_msg() { kubectl -n "$ARGO_NS" get application orders -o jsonpath='{.status.resources[?(@.kind=="Pacto")].health.message}' 2>/dev/null || true; }
+
+echo "== A Argo pulls the artifact and applies it =="
+# Asserted on its own so an OCI problem — plain HTTP refused, the wrong layer
+# media type, a path that resolves to nothing — reads as an OCI problem rather
+# than as a gate that failed to close.
+synced() { [ "$(app_sync)" = "Synced" ]; }
+eventually 60 synced || fail "Argo never synced the OCI source: sync=$(app_sync)"
+kubectl -n "$APP_NS" get pacto orders > /dev/null 2>&1 \
+  || fail "Argo reports Synced but the Pacto from the artifact is not in the cluster"
+# Everything after this reads Argo's per-resource verdict off the Application.
+# Argo records here where it put that verdict: `appTree` means the cache, and
+# inline is the zero value, so persisting leaves the field absent. Every later
+# health read would come back empty under `appTree`, which is indistinguishable
+# from a customization that never took.
+if [ "$(kubectl -n "$ARGO_NS" get application orders -o jsonpath='{.status.resourceHealthSource}')" = "appTree" ]; then
+  fail "Argo is keeping per-resource health in its cache, not on the Application: controller.resource.health.persist did not reach the controller"
+fi
+pass "Argo pulled v1 over plain HTTP and applied it"
+
+echo "== B the verdict arrives =="
+wait_pacto_status "$APP_NS" orders NonCompliant || fail "the violated contract never reached NonCompliant"
+kubectl -n "$APP_NS" get pacto orders -o jsonpath='{range .status.findings[*]}{.code}{" "}{end}' \
+  | grep -q WORKLOAD_MISMATCH || fail "NonCompliant, but not for the reason this scenario set up"
+pass "WORKLOAD_MISMATCH: the contract contradicts the workload that shipped"
+
+echo "== C Argo turns the Application red, and names the reason =="
+# The workload itself is healthy. If the Application went Degraded for any other
+# reason the customization would look like it worked while proving nothing, so
+# the Deployment is asserted first and the Pacto's own health has to carry the
+# finding code.
+kubectl -n "$APP_NS" rollout status deployment/orders --timeout=180s
+pacto_degraded() { [ "$(pacto_health)" = "Degraded" ]; }
+eventually 40 pacto_degraded \
+  || fail "Argo never judged the Pacto Degraded: health='$(pacto_health)' (empty means the customization did not take)"
+grep -q WORKLOAD_MISMATCH <<< "$(pacto_msg)" \
+  || fail "Argo judged the Pacto Degraded without the reason: $(pacto_msg)"
+app_red() {
+  [ "$(app_health)" = "Degraded" ] \
+    || { echo "  the Application read $(app_health) while the contract was violated"; return 1; }
+}
+# Held for 60s: a single check cannot distinguish "stayed red" from "went red
+# once and recovered on the next reconcile", and only the first is the claim.
+always 20 app_red || fail "the Application did not hold Degraded while the contract was violated"
+pass "Application Degraded, Pacto health: $(pacto_msg)"
+
+echo "== D fix the contract and publish v2 =="
+publish service v2
+kubectl -n "$ARGO_NS" patch application orders --type merge \
+  -p '{"spec":{"source":{"targetRevision":"v2"}}}' > /dev/null
+
+wait_pacto_status "$APP_NS" orders Compliant || fail "the corrected contract never reached Compliant"
+app_green() { [ "$(app_health)" = "Healthy" ] && [ "$(pacto_health)" = "Healthy" ]; }
+eventually 60 app_green \
+  || fail "the Application never recovered: app=$(app_health) pacto=$(pacto_health)"
+# The page tells a reader to look for this exact message, and an empty one is how
+# a customization that never took presents itself.
+[ "$(pacto_msg)" = "contract satisfied" ] \
+  || fail "the Application is Healthy, but not because the customization said so: '$(pacto_msg)'"
+pass "the Application went green: $(pacto_msg)"
+
+echo "== E the page's own read-back recipe, run against this cluster =="
+# Dump argocd-cm and the Pacto and ask the CLI what Argo makes of them — exactly
+# what the page tells a reader to do when a gate looks configured and is not. A
+# troubleshooting recipe nobody runs is one that quietly stops working, and this
+# one is the only way to tell a live customization from an ignored key.
+CM_DUMP="$(mktemp)"
+CR_DUMP="$(mktemp)"
+kubectl -n "$ARGO_NS" get cm argocd-cm -o yaml > "$CM_DUMP"
+kubectl -n "$APP_NS" get pacto orders -o yaml > "$CR_DUMP"
+RECIPE="$("$ARGOCD_BIN" admin settings resource-overrides health "$CR_DUMP" --argocd-cm-path "$CM_DUMP" 2>&1)"
+grep -q '^STATUS: Healthy' <<< "$RECIPE" \
+  || fail "the documented read-back recipe does not report the status the page says: $RECIPE"
+grep -q '^MESSAGE: contract satisfied' <<< "$RECIPE" \
+  || fail "the documented read-back recipe does not report the message the page says: $RECIPE"
+pass "the recipe agrees with the cluster"
+
+kill "$REG_PF_PID" 2>/dev/null || true
+echo "GITOPS ARGO CD PROMOTION GATE PASS"
+keep_or_teardown "$NS" "$CLUSTER" delete_cluster

--- a/tests/acceptance/kind/gitops-flux.sh
+++ b/tests/acceptance/kind/gitops-flux.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# Kind acceptance for the GitOps promotion gate: a violated Pacto contract stops
+# a Flux promotion, and satisfying it lets the promotion through.
+#
+# The claim is not "the CR says NonCompliant" — reconcile.sh already proves that.
+# It is that the verdict CHANGES WHAT SHIPS. Two Flux Kustomizations model the
+# promotion: `orders-staging` carries a healthCheckExprs entry reading the Pacto
+# verdict, and `orders-production` dependsOn staging. While the contract is
+# violated, production's own manifest must not exist in the cluster; when the
+# contract is satisfied, it must appear. The ConfigMap is the assertion — a
+# condition can be argued about, an absent object cannot.
+#
+# The Kustomizations are applied VERBATIM from
+# tests/acceptance/kind/fixtures/gitops/flux-kustomization.yaml, which is the same
+# file published in integrations/kubernetes/docs/gitops.md. The documented snippet
+# and the tested one cannot drift because they are one file.
+#
+# The operator runs at its DEFAULT stabilization window (two minutes), unlike
+# every other scenario here. That is deliberate: the violation is a
+# WORKLOAD_MISMATCH, the docs say a mismatch is NonCompliant on the first
+# reconcile with no window to wait out, and a run that shortened the window would
+# not be able to say so.
+set -euo pipefail
+CLUSTER="${KIND_CLUSTER:-pacto-gitops}"
+NS=pacto-system
+APP_NS=demo
+REG_HOST="pacto-registry.${NS}.svc.cluster.local:5000"
+LOCAL_REG_PORT=5601
+# Pinned: healthCheckExprs needs kustomize-controller v1.5.0 or newer (flux2
+# v2.5.0), and the gate under test is that field.
+FLUX_VERSION=v2.9.5
+# Flux's own artifact layer type. source-controller takes layers[0] whatever its
+# media type, so this is documentation rather than a selector — but an artifact
+# labelled as something else is one a real Flux user would never publish.
+FLUX_LAYER_TYPE=application/vnd.cncf.flux.content.v1.tar+gzip
+MANIFEST_REPO="demo/orders-manifests"
+# shellcheck source=tests/acceptance/kind/lib.sh
+source "$(dirname "$0")/lib.sh"
+
+# Flux lives outside $NS, so dump_diag alone cannot explain a stuck gate: the
+# reason a Kustomization is not Ready is in its conditions and in the two
+# controllers' logs.
+dump_flux() {
+  echo "--- flux sources + kustomizations ---"
+  kubectl -n flux-system get ocirepositories,kustomizations -o wide || true
+  kubectl -n flux-system describe kustomizations || true
+  echo "--- $APP_NS objects the promotion should or should not have created ---"
+  kubectl -n "$APP_NS" get all,configmaps,pactos || true
+  for d in source-controller kustomize-controller; do
+    echo "--- logs deploy/$d (flux-system) ---"
+    kubectl -n flux-system logs "deploy/$d" --tail=200 || true
+  done
+}
+# shellcheck disable=SC2154  # rc is assigned by rc=$? inside the trap body
+trap 'rc=$?; [ $rc -ne 0 ] && { dump_diag "$NS"; dump_flux; }; pkill -f "kubectl.*port-forward" 2>/dev/null || true; exit $rc' EXIT
+
+command -v oras >/dev/null 2>&1 \
+  || fail "oras is required: it publishes the manifest artifact Flux's OCIRepository pulls"
+
+VER="$(release_version kubernetes)"
+CORE="$(release_version core)"
+OP_IMG="localhost:5001/pacto-operator/pacto-controller:${VER}"
+OP_REPO="localhost:5001/pacto-operator/pacto-controller"
+DASH_IMG="localhost:5001/pacto-dashboard:${CORE}"
+
+build_operator_images "$OP_IMG" "$DASH_IMG" "$VER"
+
+echo "== package the chart =="
+CHART="$(package_chart "$PACTO_CHART")"
+
+ensure_cluster
+# The dashboard is off for this scenario, so only the operator image is loaded.
+load_images "$OP_IMG"
+kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+# $APP_NS is created OUTSIDE the Flux inventory on purpose: a namespace inside it
+# would be pruned along with everything in it the moment a Kustomization failed,
+# which would delete the very Pacto CR whose verdict is under test.
+kubectl create namespace "$APP_NS" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+echo "== the operator, at its DEFAULT stabilization window =="
+helm install pacto-operator "$CHART" -n "$NS" \
+  --set image.repository="$OP_REPO" --set image.tag="$VER" --set image.pullPolicy=Never \
+  --set dashboard.enabled=false --wait --timeout 240s
+if kubectl -n "$NS" get deploy pacto-operator -o jsonpath='{.spec.template.spec.containers[0].args}' \
+  | grep -q 'stabilization-window'; then
+  fail "the chart set an explicit stabilization window; this scenario must run at the default"
+fi
+pass "operator installed with no --stabilization-window override"
+
+echo "== an in-cluster OCI registry to publish the promotion's manifests to =="
+install_registry
+REG_PF_PID="$(pf "$LOCAL_REG_PORT" svc/pacto-registry 5000)"
+
+echo "== Flux $FLUX_VERSION (source + kustomize controllers) =="
+# --server-side: Flux's CRDs are far past the size a last-applied-configuration
+# annotation can hold, and a client-side apply of them fails on exactly that.
+kubectl apply --server-side -f "https://github.com/fluxcd/flux2/releases/download/${FLUX_VERSION}/install.yaml" >/dev/null
+# Nothing here reconciles a HelmRelease or sends an alert; scaling the other two
+# controllers to zero saves their image pulls and keeps the diagnostics readable.
+kubectl -n flux-system scale deploy helm-controller notification-controller --replicas=0 >/dev/null 2>&1 || true
+kubectl -n flux-system rollout status deploy/source-controller --timeout=240s
+kubectl -n flux-system rollout status deploy/kustomize-controller --timeout=240s
+
+# publish WORKLOAD TAG — the promotion's manifests, as the OCI artifact Flux
+# pulls. WORKLOAD is what the contract DECLARES; the workload that actually ships
+# is always a Deployment, so `job` is a contract that contradicts the cluster.
+publish() {
+  local workload="$1" tag="$2" tree tgz
+  tree="$(mktemp -d)"; tgz="$(mktemp -t orders-manifests.XXXXXX)"
+  mkdir -p "$tree/staging" "$tree/production"
+
+  cat > "$tree/staging/kustomization.yaml" <<'YAML'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - pacto.yaml
+YAML
+  cat > "$tree/staging/deployment.yaml" <<YAML
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: orders, namespace: $APP_NS }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: orders } }
+  template:
+    metadata: { labels: { app: orders } }
+    spec:
+      containers:
+        - { name: app, image: registry.k8s.io/pause:3.9 }
+YAML
+  # workloadRef carries BOTH name and kind, which is what makes the mismatch
+  # assertable: without an explicit kind the operator reports EVIDENCE_INSUFFICIENT
+  # (Unknown) rather than WORKLOAD_MISMATCH, and the gate would never close.
+  cat > "$tree/staging/pacto.yaml" <<YAML
+apiVersion: pacto.trianalab.io/v1alpha1
+kind: Pacto
+metadata: { name: orders, namespace: $APP_NS }
+spec:
+  checkIntervalSeconds: 15
+  contractRef:
+    inline: |
+      pactoVersion: '2.0'
+      service: {name: orders, version: 1.0.0, owner: {team: audit, dri: d, contacts: [{type: email, value: a@e.com, purpose: escalation}]}}
+      workload: $workload
+      state: {type: stateless, persistence: {scope: local, durability: ephemeral}, dataCriticality: low}
+  target: {workloadRef: {name: orders, kind: Deployment}}
+YAML
+
+  cat > "$tree/production/kustomization.yaml" <<'YAML'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+YAML
+  # The promotion's payload. It is a ConfigMap and not a workload because what is
+  # being tested is whether production RAN AT ALL, and the cheapest object that
+  # answers that is the honest one.
+  cat > "$tree/production/configmap.yaml" <<YAML
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: orders-release, namespace: $APP_NS }
+data: { promoted: "$tag" }
+YAML
+
+  tar -czf "$tgz" -C "$tree" staging production
+  # --disable-path-validation: $tgz is absolute and ORAS refuses an absolute file
+  # argument unless told the path is deliberate. It is; nothing here is user input.
+  oras push --plain-http --disable-path-validation \
+    "127.0.0.1:${LOCAL_REG_PORT}/${MANIFEST_REPO}:${tag}" "${tgz}:${FLUX_LAYER_TYPE}" >/dev/null
+  echo "  published $tag (contract declares workload: $workload)"
+}
+
+echo "== publish v1: a contract that CONTRADICTS the workload that ships =="
+publish job v1
+
+kubectl apply -f - >/dev/null <<YAML
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata: { name: orders, namespace: flux-system }
+spec:
+  interval: 20s
+  insecure: true
+  url: oci://${REG_HOST}/${MANIFEST_REPO}
+  ref: { tag: v1 }
+YAML
+oci_ready() {
+  [ "$(kubectl -n flux-system get ocirepository orders -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ]
+}
+eventually 30 oci_ready || fail "Flux never pulled the manifest artifact from the in-cluster registry"
+pass "OCIRepository resolved v1"
+
+echo "== apply the DOCUMENTED Kustomizations, verbatim =="
+kubectl apply -f "$(dirname "$0")/fixtures/gitops/flux-kustomization.yaml" >/dev/null
+
+# The gate is a CRD field, and an unknown CRD field is PRUNED without a word.
+# Read it back: a fixture that no longer matches the installed kustomize-controller
+# would otherwise "pass" every assertion below by never gating anything at all.
+GATE_EXPR="$(kubectl -n flux-system get kustomization orders-staging \
+  -o jsonpath='{.spec.healthCheckExprs[0].failed}')"
+[ -n "$GATE_EXPR" ] \
+  || fail "kustomize-controller pruned spec.healthCheckExprs — the documented gate does not exist on Flux $FLUX_VERSION"
+pass "the gate survived admission: failed = $GATE_EXPR"
+
+ready_status() { kubectl -n flux-system get kustomization "$1" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'; }
+ready_reason() { kubectl -n flux-system get kustomization "$1" -o jsonpath='{.status.conditions[?(@.type=="Ready")].reason}'; }
+ready_message() { kubectl -n flux-system get kustomization "$1" -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}'; }
+promoted() { kubectl -n "$APP_NS" get configmap orders-release >/dev/null 2>&1; }
+
+echo "== A the verdict arrives with no window to wait out =="
+wait_pacto_status "$APP_NS" orders NonCompliant || fail "the violated contract never reached NonCompliant"
+kubectl -n "$APP_NS" get pacto orders -o jsonpath='{range .status.findings[*]}{.code}{" "}{end}' \
+  | grep -q WORKLOAD_MISMATCH || fail "NonCompliant, but not for the reason this scenario set up"
+pass "WORKLOAD_MISMATCH at the DEFAULT two-minute window: a mismatch does not stabilize"
+
+echo "== B staging fails, and fails BECAUSE of the contract =="
+# The workload itself is healthy. If staging failed for any other reason the gate
+# would look like it worked while proving nothing, so the Deployment is asserted
+# first and the failure message has to name the Pacto.
+kubectl -n "$APP_NS" rollout status deployment/orders --timeout=120s
+staging_failed() { [ "$(ready_reason orders-staging)" = "HealthCheckFailed" ]; }
+eventually 40 staging_failed || fail "staging never reported a failed health check: reason=$(ready_reason orders-staging)"
+MSG="$(ready_message orders-staging)"
+if ! grep -q "Pacto" <<<"$MSG" || ! grep -q "orders" <<<"$MSG"; then
+  fail "staging failed, but not on the Pacto: $MSG"
+fi
+pass "staging Ready=False, HealthCheckFailed: $MSG"
+
+echo "== C production does not run =="
+gate_closed() {
+  [ "$(ready_status orders-production)" != "True" ] \
+    || { echo "  production went Ready while the contract was violated"; return 1; }
+  ! promoted \
+    || { echo "  the production manifest was applied while the contract was violated"; return 1; }
+}
+production_blocked() { [ "$(ready_reason orders-production)" = "DependencyNotReady" ]; }
+eventually 20 production_blocked \
+  || fail "production is blocked, but not by the gate: reason=$(ready_reason orders-production)"
+# Held for 90s, three times production's 30s dependency requeue: a single check
+# cannot distinguish "never promoted" from "promoted and rolled back".
+always 30 gate_closed || fail "the promotion gate opened while the contract was violated"
+pass "production held at DependencyNotReady for 90s and applied nothing"
+
+echo "== D fix the contract and publish v2 =="
+publish service v2
+kubectl -n flux-system patch ocirepository orders --type merge -p '{"spec":{"ref":{"tag":"v2"}}}' >/dev/null
+
+wait_pacto_status "$APP_NS" orders Compliant || fail "the corrected contract never reached Compliant"
+staging_ready() { [ "$(ready_status orders-staging)" = "True" ]; }
+production_ready() { [ "$(ready_status orders-production)" = "True" ]; }
+eventually 60 staging_ready || fail "staging never recovered: reason=$(ready_reason orders-staging)"
+eventually 60 production_ready || fail "production never promoted: reason=$(ready_reason orders-production)"
+promoted || fail "production reports Ready but its manifest is not in the cluster"
+[ "$(kubectl -n "$APP_NS" get configmap orders-release -o jsonpath='{.data.promoted}')" = "v2" ] \
+  || fail "the promoted manifest is not the revision that satisfied the contract"
+pass "the gate opened: production promoted v2"
+
+kill "$REG_PF_PID" 2>/dev/null || true
+echo "GITOPS FLUX PROMOTION GATE PASS"
+keep_or_teardown "$NS" "$CLUSTER" delete_cluster

--- a/tests/acceptance/kind/gitops-flux.sh
+++ b/tests/acceptance/kind/gitops-flux.sh
@@ -95,9 +95,12 @@ echo "== Flux $FLUX_VERSION (source + kustomize controllers) =="
 # --server-side: Flux's CRDs are far past the size a last-applied-configuration
 # annotation can hold, and a client-side apply of them fails on exactly that.
 kubectl apply --server-side -f "https://github.com/fluxcd/flux2/releases/download/${FLUX_VERSION}/install.yaml" >/dev/null
-# Nothing here reconciles a HelmRelease or sends an alert; scaling the other two
-# controllers to zero saves their image pulls and keeps the diagnostics readable.
-kubectl -n flux-system scale deploy helm-controller notification-controller --replicas=0 >/dev/null 2>&1 || true
+# Nothing here reconciles a HelmRelease, so helm-controller is scaled away to save
+# its image pull. notification-controller STAYS: the other two post every event to
+# it, and with it gone each post retries five times and logs a connection-refused
+# error. That spam lands in the same controller logs dump_flux prints, which is
+# exactly where the real reason a gate is stuck has to be readable.
+kubectl -n flux-system scale deploy helm-controller --replicas=0 >/dev/null 2>&1 || true
 kubectl -n flux-system rollout status deploy/source-controller --timeout=240s
 kubectl -n flux-system rollout status deploy/kustomize-controller --timeout=240s
 
@@ -137,7 +140,9 @@ apiVersion: pacto.trianalab.io/v1alpha1
 kind: Pacto
 metadata: { name: orders, namespace: $APP_NS }
 spec:
-  checkIntervalSeconds: 15
+  # 30 is the CRD floor. It is also not what this scenario relies on: the verdict
+  # that closes the gate arrives on the workload watch, not on the timer.
+  checkIntervalSeconds: 30
   contractRef:
     inline: |
       pactoVersion: '2.0'

--- a/tests/acceptance/kind/lib.sh
+++ b/tests/acceptance/kind/lib.sh
@@ -65,6 +65,22 @@ eventually() {
   return 1
 }
 
+# always ROUNDS CMD... — the mirror of eventually: run CMD every 3s and fail on
+# the FIRST round it does not hold. `eventually` proves something becomes true;
+# a gate has to prove something STAYS false, and the two are not the same claim.
+# Checking a gate once, after a sleep, cannot tell "it never opened" from "it
+# opened and closed again" — which is precisely the failure a promotion gate
+# exists to prevent.
+always() {
+  local rounds="$1"; shift
+  local i
+  for ((i = 0; i < rounds; i++)); do
+    "$@" || return 1
+    sleep 3
+  done
+  return 0
+}
+
 # --- cluster lifecycle ------------------------------------------------------
 
 # Every scenario runs against its own KUBECONFIG copy rather than the caller's

--- a/tests/architecture/gitops_snippets_test.go
+++ b/tests/architecture/gitops_snippets_test.go
@@ -1,0 +1,329 @@
+package architecture
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The GitOps promotion gates page ships two snippets a reader is meant to paste
+// into their own cluster: a Flux healthCheckExprs block and an Argo CD health
+// customization. Both hard-code the contract verdicts by name, and both fail
+// SILENTLY when they drift — Flux falls through to in-progress and times out,
+// Argo goes straight back to ignoring the object, which looks exactly like
+// having configured nothing.
+//
+// The snippets therefore live in tests/acceptance/kind/fixtures/gitops and are
+// included into the page verbatim, so the documented text is the tested text.
+// What is left for this file is the drift the include cannot catch: a verdict
+// added to the CRD that neither snippet knows about, a verdict misspelled, the
+// one ConfigMap key that must be exact, and Lua that reaches for a library Argo
+// does not load.
+
+const (
+	gitopsPage      = "gitops.md"
+	fluxFixture     = "flux-kustomization.yaml"
+	argocdFixture   = "argocd-cm-pacto-health.yaml"
+	pactoAPIVersion = "pacto.trianalab.io/v1alpha1"
+)
+
+func repoDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate this test file")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", "..")
+}
+
+func gitopsFixturePath(t *testing.T, name string) string {
+	t.Helper()
+	return filepath.Join(repoDir(t), "tests", "acceptance", "kind", "fixtures", "gitops", name)
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path) //nolint:gosec // a path this test computed
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+// pactoCRD is the slice of the generated CRD the snippets depend on. Parsing the
+// CRD rather than the Go constants keeps the check on the artifact Flux and Argo
+// actually read.
+type pactoCRD struct {
+	Spec struct {
+		Group string `yaml:"group"`
+		Names struct {
+			Kind string `yaml:"kind"`
+		} `yaml:"names"`
+		Versions []struct {
+			Schema struct {
+				OpenAPIV3Schema struct {
+					Properties struct {
+						Status struct {
+							Properties struct {
+								ContractStatus struct {
+									Enum []string `yaml:"enum"`
+								} `yaml:"contractStatus"`
+							} `yaml:"properties"`
+						} `yaml:"status"`
+					} `yaml:"properties"`
+				} `yaml:"openAPIV3Schema"`
+			} `yaml:"schema"`
+		} `yaml:"versions"`
+	} `yaml:"spec"`
+}
+
+func loadPactoCRD(t *testing.T) pactoCRD {
+	t.Helper()
+	path := filepath.Join(repoDir(t), "integrations", "kubernetes", "config", "crd",
+		"bases", "pacto.trianalab.io_pactos.yaml")
+	var crd pactoCRD
+	if err := yaml.Unmarshal([]byte(readFile(t, path)), &crd); err != nil {
+		t.Fatalf("cannot parse the Pacto CRD: %v", err)
+	}
+	if crd.Spec.Group == "" || crd.Spec.Names.Kind == "" || len(crd.Spec.Versions) == 0 {
+		t.Fatal("the Pacto CRD did not parse into group/kind/versions; the shape moved")
+	}
+	return crd
+}
+
+func contractStatusEnum(t *testing.T, crd pactoCRD) []string {
+	t.Helper()
+	enum := crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties.Status.Properties.ContractStatus.Enum
+	if len(enum) == 0 {
+		t.Fatal("status.contractStatus has no enum in the CRD; the snippets have nothing to be checked against")
+	}
+	return enum
+}
+
+// luaBlock returns the Lua script out of the Argo ConfigMap fixture, keyed by the
+// customization key the test independently derives.
+func luaBlock(t *testing.T, key string) string {
+	t.Helper()
+	var cm struct {
+		Data map[string]string `yaml:"data"`
+	}
+	if err := yaml.Unmarshal([]byte(readFile(t, gitopsFixturePath(t, argocdFixture))), &cm); err != nil {
+		t.Fatalf("cannot parse %s: %v", argocdFixture, err)
+	}
+	script, ok := cm.Data[key]
+	if !ok {
+		t.Fatalf("%s has no data key %q; Argo ignores a key it does not recognise, and an "+
+			"ignored key is indistinguishable from no configuration at all (keys present: %v)",
+			argocdFixture, key, mapKeys(cm.Data))
+	}
+	return script
+}
+
+func mapKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestArgoHealthKeyMatchesTheCRD pins the one string in the Argo snippet that has
+// no forgiving failure mode. The key is resource.customizations.health.<group>_<kind>
+// and Argo silently ignores anything else.
+func TestArgoHealthKeyMatchesTheCRD(t *testing.T) {
+	crd := loadPactoCRD(t)
+	want := "resource.customizations.health." + crd.Spec.Group + "_" + crd.Spec.Names.Kind
+	luaBlock(t, want) // fails with the present keys if the derived key is absent
+}
+
+// TestArgoLuaHandlesEveryVerdict fails when a contract status is added to the CRD
+// and the Lua does not mention it — either as its own branch or in the comment
+// naming what deliberately falls through to Progressing.
+func TestArgoLuaHandlesEveryVerdict(t *testing.T) {
+	crd := loadPactoCRD(t)
+	script := luaBlock(t, "resource.customizations.health."+crd.Spec.Group+"_"+crd.Spec.Names.Kind)
+	for _, verdict := range contractStatusEnum(t, crd) {
+		if !strings.Contains(script, verdict) {
+			t.Errorf("contractStatus %q is in the CRD but nowhere in the Argo Lua; give it a "+
+				"branch, or name it in the fall-through comment if Progressing is correct", verdict)
+		}
+	}
+}
+
+var luaVerdictLiteral = regexp.MustCompile(`s == "([^"]*)"`)
+
+// TestArgoLuaComparesRealVerdicts catches a misspelled verdict, which reads as a
+// branch that can never be taken.
+func TestArgoLuaComparesRealVerdicts(t *testing.T) {
+	crd := loadPactoCRD(t)
+	valid := make(map[string]bool)
+	for _, v := range contractStatusEnum(t, crd) {
+		valid[v] = true
+	}
+	script := luaBlock(t, "resource.customizations.health."+crd.Spec.Group+"_"+crd.Spec.Names.Kind)
+	matches := luaVerdictLiteral.FindAllStringSubmatch(script, -1)
+	if len(matches) == 0 {
+		t.Fatal("the Argo Lua compares no verdict at all; the extractor or the script moved")
+	}
+	for _, m := range matches {
+		if !valid[m[1]] {
+			t.Errorf("the Argo Lua branches on %q, which is not a contractStatus value", m[1])
+		}
+	}
+}
+
+// luaStringLibrary lists what Argo's sandbox does not provide. gitops-engine runs
+// the script in a gopher-lua VM with the string library left unloaded, so a call
+// fails at runtime rather than at load — the object just stays unknown.
+var luaStringLibrary = []string{
+	"string.",
+	":format(", ":gsub(", ":sub(", ":find(", ":len(", ":rep(",
+	":upper(", ":lower(", ":match(", ":gmatch(", ":byte(", ":char(", ":reverse(",
+}
+
+func TestArgoLuaAvoidsTheStringLibrary(t *testing.T) {
+	crd := loadPactoCRD(t)
+	script := luaBlock(t, "resource.customizations.health."+crd.Spec.Group+"_"+crd.Spec.Names.Kind)
+	for _, banned := range luaStringLibrary {
+		if strings.Contains(script, banned) {
+			t.Errorf("the Argo Lua uses %q; Argo runs it with the string library disabled, so "+
+				"only concatenation, comparison, ipairs and tostring() are available", banned)
+		}
+	}
+}
+
+// healthCheckExpr is one entry of a Flux Kustomization's spec.healthCheckExprs.
+type healthCheckExpr struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Failed     string `yaml:"failed"`
+	Current    string `yaml:"current"`
+	InProgress string `yaml:"inProgress"`
+}
+
+// fluxKustomization is the slice of the Flux fixture this file checks.
+type fluxKustomization struct {
+	Spec struct {
+		HealthCheckExprs []healthCheckExpr `yaml:"healthCheckExprs"`
+	} `yaml:"spec"`
+}
+
+func pactoHealthCheckExprs(t *testing.T) []healthCheckExpr {
+	t.Helper()
+	dec := yaml.NewDecoder(strings.NewReader(readFile(t, gitopsFixturePath(t, fluxFixture))))
+	var found []healthCheckExpr
+	for {
+		var doc fluxKustomization
+		err := dec.Decode(&doc)
+		if err != nil {
+			break
+		}
+		for _, expr := range doc.Spec.HealthCheckExprs {
+			if expr.APIVersion == pactoAPIVersion && expr.Kind == "Pacto" {
+				found = append(found, expr)
+			}
+		}
+	}
+	if len(found) == 0 {
+		t.Fatalf("%s declares no healthCheckExprs for %s/Pacto, so it gates nothing",
+			fluxFixture, pactoAPIVersion)
+	}
+	return found
+}
+
+var celVerdictLiteral = regexp.MustCompile(`'([^']*)'`)
+
+// TestFluxExpressionsUseRealVerdicts checks both directions of the CEL sets: every
+// verdict named is real, and no verdict is claimed by both failed and current.
+// Flux matches on group and kind and throws the API version away, so these names
+// are a promise to everyone who copies the snippet.
+func TestFluxExpressionsUseRealVerdicts(t *testing.T) {
+	crd := loadPactoCRD(t)
+	valid := make(map[string]bool)
+	for _, v := range contractStatusEnum(t, crd) {
+		valid[v] = true
+	}
+	for _, expr := range pactoHealthCheckExprs(t) {
+		failed := celLiterals(expr.Failed)
+		current := celLiterals(expr.Current)
+		if len(failed) == 0 || len(current) == 0 {
+			t.Fatal("a Pacto healthCheckExprs entry is missing either failed or current; " +
+				"without both, a violation reads as in-progress and only surfaces as a timeout")
+		}
+		for _, name := range append(append([]string{}, failed...), current...) {
+			if !valid[name] {
+				t.Errorf("the Flux expressions name %q, which is not a contractStatus value", name)
+			}
+		}
+		for _, name := range failed {
+			for _, other := range current {
+				if name == other {
+					t.Errorf("%q is in both failed and current; Flux evaluates failed first, so "+
+						"current would never be reached for it", name)
+				}
+			}
+		}
+	}
+}
+
+// TestFluxLeavesUnrecognisedVerdictsToFallThrough is the fail-closed property.
+// An inProgress expression, or a current set covering every verdict, would turn
+// an unrecognised future value into a pass.
+func TestFluxLeavesUnrecognisedVerdictsToFallThrough(t *testing.T) {
+	crd := loadPactoCRD(t)
+	enum := contractStatusEnum(t, crd)
+	for _, expr := range pactoHealthCheckExprs(t) {
+		if strings.TrimSpace(expr.InProgress) != "" {
+			t.Error("the Pacto healthCheckExprs entry sets inProgress; leave it unset so a " +
+				"verdict no expression matches falls through to in-progress on its own")
+		}
+		covered := len(celLiterals(expr.Failed)) + len(celLiterals(expr.Current))
+		if covered >= len(enum) {
+			t.Errorf("the Flux expressions enumerate all %d contract statuses, so a verdict "+
+				"added later would be judged by neither and the snippet no longer says which "+
+				"way it fails", len(enum))
+		}
+	}
+}
+
+func celLiterals(expr string) []string {
+	var out []string
+	for _, m := range celVerdictLiteral.FindAllStringSubmatch(expr, -1) {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// TestGitOpsPageIncludesTheTestedFixtures is what makes every check above mean
+// something: the page must publish these exact files, not a copy of them.
+func TestGitOpsPageIncludesTheTestedFixtures(t *testing.T) {
+	page := readFile(t, filepath.Join(repoDir(t), "integrations", "kubernetes", "docs", gitopsPage))
+	for _, fixture := range []string{fluxFixture, argocdFixture} {
+		include := `--8<-- "tests/acceptance/kind/fixtures/gitops/` + fixture + `"`
+		if !strings.Contains(page, include) {
+			t.Errorf("%s does not include %s verbatim; expected the line %s so the published "+
+				"snippet cannot drift from the checked one", gitopsPage, fixture, include)
+		}
+	}
+}
+
+// TestGitOpsPageNamesEveryVerdict is the tripwire for the whole page. A verdict
+// added to the CRD that the prose never mentions leaves a reader with a gate that
+// silently does not cover it.
+func TestGitOpsPageNamesEveryVerdict(t *testing.T) {
+	crd := loadPactoCRD(t)
+	page := readFile(t, filepath.Join(repoDir(t), "integrations", "kubernetes", "docs", gitopsPage))
+	fixtures := readFile(t, gitopsFixturePath(t, fluxFixture)) +
+		readFile(t, gitopsFixturePath(t, argocdFixture))
+	for _, verdict := range contractStatusEnum(t, crd) {
+		if !strings.Contains(page, verdict) && !strings.Contains(fixtures, verdict) {
+			t.Errorf("contractStatus %q appears nowhere on the GitOps page or in its snippets; "+
+				"say which way the gate treats it", verdict)
+		}
+	}
+}

--- a/tests/architecture/kind_image_loading_test.go
+++ b/tests/architecture/kind_image_loading_test.go
@@ -53,8 +53,8 @@ func scenarios(t *testing.T) []string {
 			out = append(out, path)
 		}
 	}
-	if len(out) < 6 {
-		t.Fatalf("expected the six kind scenarios, found %d: %v", len(out), out)
+	if len(out) < 7 {
+		t.Fatalf("expected at least seven kind scenarios, found %d: %v", len(out), out)
 	}
 	return out
 }

--- a/tests/architecture/kind_image_loading_test.go
+++ b/tests/architecture/kind_image_loading_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -53,10 +54,63 @@ func scenarios(t *testing.T) []string {
 			out = append(out, path)
 		}
 	}
-	if len(out) < 7 {
-		t.Fatalf("expected at least seven kind scenarios, found %d: %v", len(out), out)
+	if len(out) < 8 {
+		t.Fatalf("expected at least eight kind scenarios, found %d: %v", len(out), out)
 	}
 	return out
+}
+
+// kindMatrixScenarios returns the scenario list the ci-e2e-kind job shards over.
+func kindMatrixScenarios(t *testing.T) []string {
+	t.Helper()
+	wf := readFile(t, filepath.Join(repoDir(t), ".github", "workflows", "ci.yml"))
+	_, after, ok := strings.Cut(wf, "scenario: [")
+	if !ok {
+		t.Fatal("no `scenario: [...]` matrix in .github/workflows/ci.yml; the shards are wired some other way now")
+	}
+	list, _, ok := strings.Cut(after, "]")
+	if !ok {
+		t.Fatal("the ci-e2e-kind scenario matrix has no closing bracket")
+	}
+	var out []string
+	for name := range strings.SplitSeq(list, ",") {
+		out = append(out, strings.TrimSpace(name))
+	}
+	return out
+}
+
+// TestEveryKindScenarioRuns is the tripwire for a scenario that exists and never
+// executes. A script is only a gate if something invokes it: ci.mk needs a target
+// whose recipe runs it, and that target's name has to appear in the ci-e2e-kind
+// matrix. Miss either half and the pipeline stays green with one fewer thing
+// proved — and nothing in the repository looks wrong, which is the whole problem.
+func TestEveryKindScenarioRuns(t *testing.T) {
+	mk := readFile(t, filepath.Join(repoDir(t), "ci.mk"))
+	matrix := kindMatrixScenarios(t)
+	const prefix = "test-acceptance-kind-"
+	for _, path := range scenarios(t) {
+		script := "bash tests/acceptance/kind/" + filepath.Base(path)
+		before, _, ok := strings.Cut(mk, script)
+		if !ok {
+			t.Errorf("no ci.mk recipe runs %s, so the scenario runs nowhere", filepath.Base(path))
+			continue
+		}
+		// The target owning that recipe is the nearest rule declared above it.
+		target := ""
+		for line := range strings.SplitSeq(before, "\n") {
+			if name, _, isRule := strings.Cut(line, ":"); isRule && strings.HasPrefix(name, prefix) {
+				target = strings.TrimPrefix(name, prefix)
+			}
+		}
+		if target == "" {
+			t.Errorf("%s is run by a ci.mk recipe with no %s* target above it", filepath.Base(path), prefix)
+			continue
+		}
+		if !slices.Contains(matrix, target) {
+			t.Errorf("%s runs under `make %s%s`, which the ci-e2e-kind matrix does not list, "+
+				"so CI never runs it (matrix: %v)", filepath.Base(path), prefix, target, matrix)
+		}
+	}
 }
 
 func TestScenariosLoadImagesThroughTheSharedBoundary(t *testing.T) {


### PR DESCRIPTION
Closes #343. Closes #358.

The operator has always reached a verdict and written it to `status.contractStatus`. Neither Flux nor Argo CD reads that field, so a violated contract stops nothing.

Flux decides health with kstatus, which recognises `Ready`, `Reconciling` and `Stalled` and discards every condition Pacto publishes — a Kustomization holding a `NonCompliant` Pacto reports healthy. Argo picks health checks from a closed list of built-in kinds and returns nothing for the rest, and the roll-up ignores nothing — a violated contract is not unhealthy to Argo, it is invisible. Both tools have an extension point for this; neither ships one for Pacto.

## What this adds

A new **GitOps promotion gates** page (`integrations/kubernetes/docs/gitops.md`) with the two snippets that close the gap, plus the timing they depend on.

- **Flux** — a `spec.healthCheckExprs` entry with no `inProgress` expression, so `Unknown`, `NotEvaluated` and any verdict added later hold the deploy instead of going falsely green. No hand-written generation guard either: Flux compares `observedGeneration` to `generation` before any expression runs, and a hand-rolled one throws on an object with no status yet.
- **Argo CD** — a Lua resource health customization written for the sandbox Argo actually runs it in, which has the string library disabled. Nothing maps to Argo's `Unknown` (it outranks `Degraded` in the roll-up and does not fire the on-degraded trigger); anything unrecognised becomes `Progressing` and times out.

Both snippets live as files under `tests/acceptance/kind/fixtures/gitops/`; the page includes them with `--8<--` rather than holding a copy, so the published YAML and the tested YAML cannot drift. Each has a kind acceptance shard that applies **that exact file** to a real cluster running the tool it targets.

## The Flux snippet is tested live

`tests/acceptance/kind/gitops-flux.sh` installs Flux v2.9.5, publishes the promotion's manifests as an OCI artifact to an in-cluster registry, and:

1. publishes a contract declaring `workload: job` while a Deployment ships, and asserts `WORKLOAD_MISMATCH` / `NonCompliant`;
2. asserts `orders-staging` goes `Ready=False, HealthCheckFailed` with the Pacto named in the message, after asserting the Deployment itself rolled out — so the gate cannot look like it worked while failing for some other reason;
3. asserts `orders-production` sits at `DependencyNotReady` and that its own manifest is **absent from the cluster**, held for 90s across three dependency requeues. A single check cannot tell "never promoted" from "promoted and rolled back";
4. corrects the contract, publishes v2, and asserts the promotion goes through and the ConfigMap carries the revision that satisfied the contract.

Two things worth calling out. The shard runs the operator at its **default** two-minute stabilization window, unlike every other shard here — the page claims a mismatch does not wait one out, and a run that shortened the window could not say so. And it reads `spec.healthCheckExprs[0].failed` back after applying: a CRD prunes an unknown field silently, and every assertion downstream would then pass against a gate that gates nothing.

## So is the Argo CD one

`tests/acceptance/kind/gitops-argocd.sh` runs the fixture twice, because the Argo snippet's failure mode is silence: a `data` key Argo does not recognise is dropped at read time with no event, no log line and a green Application — indistinguishable from having configured nothing.

**The first pass needs no cluster.** `argocd admin settings resource-overrides health` evaluates the customization in the same Lua sandbox the controller uses. That is what makes every contract status assertable, including the ones a running cluster passes through too quickly to catch: no status yet, a verdict that has not caught up with the contract, a status added in some future release. Eleven cases, and a mapping error fails in seconds rather than after a cluster build.

**The second pass is a real Argo CD in kind**, served from an OCI source rather than git: the manifests are published to the in-cluster registry as a `tar+gzip` layer, a repository `Secret` with `type: oci` and `insecureOCIForceHttp` lets the repo-server pull them over plain HTTP, and then the Application must

1. sync the artifact and land the Pacto in the cluster — asserted on its own, so an OCI problem reads as an OCI problem rather than as a gate that failed to close;
2. reach `NonCompliant` / `WORKLOAD_MISMATCH`, after the Deployment itself has rolled out;
3. go **Degraded with the finding code in the message**, and hold it for 60s — a single check cannot tell "stayed red" from "went red once and recovered";
4. return to `Healthy` with `contract satisfied` once v2 corrects the contract.

Step 5 runs **the page's own read-back recipe against the live cluster** — dump `argocd-cm` and the Pacto, ask the CLI what Argo makes of them. A troubleshooting command nobody runs is one that quietly stops working, and this one is the only way to tell a live customization from an ignored key. Worth knowing if you ever wire it into a check: when the key is absent the CLI prints `Health script is not configured for ...` **and exits 0**, so read the output, not the status.

Three things the Argo core install does not do, each of which fails in a way that points at the wrong half of the scenario, and each now handled with the reason written down next to it:

- it ships no `default` AppProject — the API server creates that on startup, and core mode has no API server — so every Application sits at `InvalidSpecError` with no sync attempted;
- its apply returns before `argoproj.io` reaches discovery, so anything applied in that window fails with `no matches for kind`. The wait is a `get`, not `kubectl wait --for=established`, which errors outright on a CRD whose status has not been written yet — the very window being waited out;
- `--persist-resource-health` defaults to false, so the per-resource verdict stays in the cache the UI reads through the API server and never reaches `.status.resources[]`. The scenario turns it on so it asserts on Argo's judgement rather than re-deriving it, and checks `.status.resourceHealthSource` first, so a flag that did not land says so instead of looking like a customization that never took.

`TestEveryKindScenarioRuns` is new. Wiring a shard in means hand-editing `ci.mk` and the `ci-e2e-kind` matrix, and missing either half leaves the pipeline green with one fewer thing proved and nothing in the repository looking wrong. It maps every `tests/acceptance/kind/*.sh` to the target that runs it and requires that target in the matrix; removing `gitops-argocd` from the matrix turns it red.

`always ROUNDS CMD...` is new in `lib.sh` — the mirror of `eventually`. A gate has to prove something stays false, which is not the same claim as something becoming true.

## Operator change

`ContractRecovered` is a new event. The three contract warnings are transition-gated, so a contract returning to `Compliant` used to fall silent with no event marking the recovery; it now has one, matching the pair `ReadinessGateUnmet` and `ReadinessRecovered` already formed. `ValidationFailed` also fired only when `status.summary` happened to be set — it now fires on the transition itself.

## Docs corrections

Both load-bearing for the timing advice on the new page:

- The stabilization window applies to **absences only** (`INTERFACE_ABSENT`, `DEPENDENCY_UNREACHABLE`, `CAPABILITY_ABSENT`, `CONFIGURATION_ABSENT`). A **mismatch** is `NonCompliant` on the first reconcile that observes it. That split is why the Flux `timeout` has a floor.
- The events table said seven events and listed seven. There are eight.

The `docs-check` events gate learned one hop to keep up: a reason passed as a function *parameter* now resolves through the arguments that file's own call sites pass it, instead of reading as unresolvable.

## Verification

Both shards run green end to end locally against kind. `ci-test` (100% coverage), `ci-integration-kubernetes` (100% per package, 63 chart tests), `ci-gates`, `docs-check` 16/16, `ci-fmt` / `ci-vet` / `ci-cyclo` / `ci-lint` / `check-section`, `verify-k8s-standalone`. The `docs-check` hop was mutation-proven: swapping the constant at one call site turns the gate red.
