### PR TITLE
fix(test): load the Argo health customization before the controller starts

### DIFF
--- a/.changeset/gitops-promotion-gate.md
+++ b/.changeset/gitops-promotion-gate.md
@@ -44,6 +44,15 @@ to go `Degraded` naming the finding, then `Healthy` once the contract is
 corrected. The page's read-back recipe is that same CLI command, and the shard
 runs it against the live cluster rather than only publishing it.
 
+Building that second pass turned up something the page has to say out loud: the
+merge patch alone is not enough. Argo's application controller caches health
+customizations at startup and compares that cached verdict to decide whether a
+changed object is worth re-examining, so a controller that started without the
+customization treats every verdict the operator writes as no change and only
+catches up on the next periodic resync, minutes later. The page now pairs the
+patch with a controller restart, and says why the two read-back checks cannot
+detect the difference — both read the ConfigMap, not the controller.
+
 `ContractRecovered` is new. The three contract warnings — `ValidationFailed`,
 `ContractInvalid`, `ContractUnavailable` — are transition-gated, so a contract
 that goes back to `Compliant` used to fall silent with no event marking the

--- a/integrations/kubernetes/docs/gitops.md
+++ b/integrations/kubernetes/docs/gitops.md
@@ -91,7 +91,17 @@ Apply it as a merge patch. `argocd-cm` holds Argo's own configuration and a plai
 ```bash
 kubectl -n argocd patch configmap argocd-cm --type merge \
   --patch-file argocd-cm-pacto-health.yaml
+kubectl -n argocd rollout restart statefulset/argocd-application-controller
 ```
+
+The restart is not optional housekeeping. The application controller reads health
+customizations into its resource cache when it starts, and that cached verdict is
+what it compares to decide whether a changed object is worth re-examining. Until
+the controller has the customization, a Pacto's health is cached as nothing, every
+verdict the operator writes compares equal to the last one and the Application
+only catches up on the next periodic resync. On an install without `argocd-server`
+— Argo's core install — a restart is the *only* way in: hot reload of `argocd-cm`
+needs `server.secretkey`, which only `argocd-server` creates.
 
 - **Argo has no built-in generation check**, so the script does its own. Be
   precise about what that proves: `observedGeneration` here is the Pacto object's
@@ -144,6 +154,11 @@ A key that did not take prints `Health script is not configured for
 'pacto.trianalab.io/Pacto'` instead — and prints it while **exiting 0**, so read
 the output rather than the exit code if you wire this into a check.
 
+Both checks read the ConfigMap, not the controller. They will pass on an instance
+whose controller started before the patch and still has no idea the customization
+exists. The one that answers that question is the Application itself: it should
+change health within seconds of a verdict changing, not minutes.
+
 ## Timing
 
 The gate is only as fresh as the verdict behind it, and verdicts do not all land
@@ -163,6 +178,15 @@ its controller writes `observedGeneration` back, and that same write is the watc
 event that queues the Pacto reconcile. So the re-check is guaranteed *queued*
 before Flux can first see the workload as current. It is not guaranteed
 *finished*. The gap is one reconcile.
+
+Every row above is about how fast the verdict lands. When the GitOps tool *looks*
+is a separate question, and only Argo has an answer worth knowing. It re-examines
+a Pacto when the health status the customization returns changes — `Healthy` to
+`Degraded` and back shows up in about a second. A change that lands on the same
+status does not: one `NonCompliant` reason replaced by another is still
+`Degraded`, so the Application keeps showing the old message until the next
+periodic resync, two to five minutes out. The red dot is prompt. The wording
+behind it is not always.
 
 ## Limits
 

--- a/tests/acceptance/kind/gitops-argocd.sh
+++ b/tests/acceptance/kind/gitops-argocd.sh
@@ -296,21 +296,23 @@ spec:
   clusterResourceWhitelist: [{ group: '*', kind: '*' }]
 YAML
 
-# Argo computes per-resource health either way; this only decides where it is
-# written. By default the result stays in the controller's cache, which the UI
-# and `argocd app get` read through the API server — and there is no API server
-# here. Persisting it puts the same verdict on .status.resources[] where kubectl
-# can read it, so this scenario asserts on Argo's judgement rather than on its
-# own re-derivation of it. The controller reads the flag once at startup.
-kubectl -n "$ARGO_NS" patch configmap argocd-cmd-params-cm --type merge \
-  -p '{"data":{"controller.resource.health.persist":"true"}}' > /dev/null
-kubectl -n "$ARGO_NS" rollout restart statefulset/argocd-application-controller > /dev/null
-
-kubectl -n "$ARGO_NS" rollout status deploy/argocd-redis --timeout=300s
-kubectl -n "$ARGO_NS" rollout status deploy/argocd-repo-server --timeout=300s
-kubectl -n "$ARGO_NS" rollout status statefulset/argocd-application-controller --timeout=300s
-
 echo "== apply the DOCUMENTED customization, verbatim, the way the page says to =="
+# Patched before the controller comes up, which is the page's recipe — patch,
+# then restart — and the order is load-bearing rather than tidy. The application
+# controller reads health customizations into its live state cache when it
+# starts, and after that only when a settings notification arrives. On a core
+# install that notification can never arrive: argocd-secret ships with no data,
+# only argocd-server generates `server.secretkey`, and the reload errors out on
+# the missing key every time. A controller that started without the
+# customization therefore caches the Pacto's health as nothing forever — and
+# since Argo decides whether to re-examine an app by comparing cached health,
+# nothing-to-nothing compares equal and every verdict the operator writes is
+# dropped as a trigger. The Application then only catches up on the periodic
+# resync, minutes later, which is what made this shard flaky.
+#
+# What this leaves untested, deliberately: patching a controller that is already
+# running and NOT restarting it. That does not work on a core install, so there
+# is nothing to assert but the failure.
 kubectl -n "$ARGO_NS" patch configmap argocd-cm --type merge --patch-file "$FIXTURE" > /dev/null
 
 # Read it back before anything depends on it. argocd-cm is a plain ConfigMap:
@@ -325,6 +327,21 @@ LIVE_SCRIPT="$(kubectl -n "$ARGO_NS" get cm argocd-cm -o jsonpath="{.data.${HEAL
 kubectl -n "$ARGO_NS" get cm argocd-cm -o jsonpath='{.metadata.labels.app\.kubernetes\.io/part-of}' \
   | grep -q argocd || fail "the merge patch replaced argocd-cm instead of adding to it"
 pass "the customization is live in argocd-cm and Argo's own keys survived"
+
+# Argo computes per-resource health either way; this only decides where it is
+# written. By default the result stays in the controller's cache, which the UI
+# and `argocd app get` read through the API server — and there is no API server
+# here. Persisting it puts the same verdict on .status.resources[] where kubectl
+# can read it, so this scenario asserts on Argo's judgement rather than on its
+# own re-derivation of it. The controller reads the flag once at startup, and
+# this restart is also what loads the customization patched in above.
+kubectl -n "$ARGO_NS" patch configmap argocd-cmd-params-cm --type merge \
+  -p '{"data":{"controller.resource.health.persist":"true"}}' > /dev/null
+kubectl -n "$ARGO_NS" rollout restart statefulset/argocd-application-controller > /dev/null
+
+kubectl -n "$ARGO_NS" rollout status deploy/argocd-redis --timeout=300s
+kubectl -n "$ARGO_NS" rollout status deploy/argocd-repo-server --timeout=300s
+kubectl -n "$ARGO_NS" rollout status statefulset/argocd-application-controller --timeout=300s
 
 echo "== point an Application at the in-cluster registry =="
 # type: oci and insecureOCIForceHttp are the whole reason this Secret exists: the
@@ -393,7 +410,13 @@ echo "== C Argo turns the Application red, and names the reason =="
 # finding code.
 kubectl -n "$APP_NS" rollout status deployment/orders --timeout=180s
 pacto_degraded() { [ "$(pacto_health)" = "Degraded" ]; }
-eventually 40 pacto_degraded \
+# 60s, deliberately. The operator's verdict already landed in B, so all that is
+# left here is Argo noticing it, which is event-driven and takes about a second.
+# Argo's fallback path — the periodic resync — cannot fire sooner than its 120s
+# floor, so a budget under that says "noticed, not stumbled upon": if the
+# customization ever stops reaching the controller's cache this fails outright
+# instead of passing on whichever resync tick happens to land in time.
+eventually 20 pacto_degraded \
   || fail "Argo never judged the Pacto Degraded: health='$(pacto_health)' (empty means the customization did not take)"
 grep -q WORKLOAD_MISMATCH <<< "$(pacto_msg)" \
   || fail "Argo judged the Pacto Degraded without the reason: $(pacto_msg)"
@@ -413,7 +436,7 @@ kubectl -n "$ARGO_NS" patch application orders --type merge \
 
 wait_pacto_status "$APP_NS" orders Compliant || fail "the corrected contract never reached Compliant"
 app_green() { [ "$(app_health)" = "Healthy" ] && [ "$(pacto_health)" = "Healthy" ]; }
-eventually 60 app_green \
+eventually 20 app_green \
   || fail "the Application never recovered: app=$(app_health) pacto=$(pacto_health)"
 # The page tells a reader to look for this exact message, and an empty one is how
 # a customization that never took presents itself.
@@ -436,6 +459,20 @@ grep -q '^STATUS: Healthy' <<< "$RECIPE" \
 grep -q '^MESSAGE: contract satisfied' <<< "$RECIPE" \
   || fail "the documented read-back recipe does not report the message the page says: $RECIPE"
 pass "the recipe agrees with the cluster"
+
+# Not an assertion — evidence, printed on the way out. This shard was flaky once
+# because Argo was never re-examining the Application when the operator wrote a
+# verdict, and passed anyway whenever its one comparison happened to catch the
+# settled state. These lines are what distinguishes the two: each is Argo saying
+# a Pacto write is why it looked again. Expect one per verdict transition plus
+# one for the initial apply. Two total means only the applies produced them, the
+# customization is missing from the controller's cache and any pass above was
+# luck. The next person to see this shard go red should read this first.
+echo "-- Argo refreshes attributed to the Pacto --"
+kubectl -n "$ARGO_NS" logs argocd-application-controller-0 2>/dev/null \
+  | grep 'Requesting app refresh caused by object update' \
+  | grep '"kind":"Pacto"' \
+  | grep -oE '"time":"[^"]+"' || echo "  none — Argo never re-examined the app because of a Pacto write"
 
 kill "$REG_PF_PID" 2>/dev/null || true
 echo "GITOPS ARGO CD PROMOTION GATE PASS"


### PR DESCRIPTION
The `gitops-argocd` kind shard added in #357 is a coin flip, and it is currently
red on the release PR. It is not noise — the mechanism is specific, and the
documentation page shipped with the same bug in it.

## What is actually wrong

Argo computes a resource's health in two unrelated places:

- The app comparison re-reads `argocd-cm` live, so the customization's verdict
  lands on the Application whenever a comparison runs. This is what makes a
  broken setup look like it works.
- The live state cache computes health from a settings snapshot taken at
  startup. That cached value is the one `skipResourceUpdate` compares to decide
  whether a changed object is worth re-examining at all.

The shard patched `argocd-cm` **after** restarting the controller. So the cache
never received the customization, the Pacto's cached health stayed nil, nil
compared equal to nil, and every status write the operator made was dropped as a
refresh trigger — permanently, not for one reconcile period. On a core install
it cannot self-correct either: the settings reload needs `server.secretkey`, and
only `argocd-server` creates that key.

That left the periodic resync as the only recovery — 120s plus up to 60s of
jitter, worst case around 300s — against a 190s budget. Hence bimodal: runs
passed in under four seconds when the single comparison happened to catch the
settled verdict, and otherwise never finished. Step C's red hold was worse than
it looked: its `Degraded` came from a refresh Argo attributes to an unrelated
Deployment update, not to the Pacto's own write.

## The change

- Patch `argocd-cm` before the controller restart, so the customization is in
  the startup snapshot.
- Both post-verdict waits drop from 190s/120s to 60s. The operator's verdict has
  already landed at that point, so all that remains is Argo noticing it, which
  is event-driven and takes about a second. A budget under Argo's 120s resync
  floor turns a regression into a hard failure instead of another coin flip.
- On the way out the shard prints the refreshes Argo attributes to a Pacto
  write. The next person to see this go red can then tell "Argo looked and
  disagreed" from "Argo never looked".

## The documentation half

The page told readers to apply that merge patch to a running Argo with no
restart, which has exactly this failure mode — and neither read-back check it
offers can detect it, because both read the ConfigMap rather than the
controller. The page now pairs the patch with a restart and says why the checks
cannot see the difference.

It also names the one residual case that stays slow even when everything is
wired correctly: Argo re-examines on a health *status* transition, so one
`NonCompliant` reason replaced by another is still `Degraded` and the
Application keeps showing the old message until the next resync.

## Verification

The shard passes locally with the tightened budgets, offline phase and steps A
through E. The evidence line reports two refresh events per transition against
one in the failing CI run, consistent with the operator's status writes now
triggering refreshes on their own — CI provides the same-hardware comparison
this PR's run will settle.

The changeset for #357 is still pending on `main`, so this updates it in place
rather than adding a second one; the release PR picks up the added paragraph.
