### PR TITLE
fix(release): stop a skipped job from poisoning the whole publish graph

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,30 +138,41 @@ jobs:
   # so the k8s module's require resolves. The GitHub Release + binaries are
   # finalized LAST by the `release` job. Fail-closed: an existing tag pointing at a
   # different commit is an immutable-version violation.
+  #
+  # The JOB runs for every release; the unit gate sits on the STEPS, so a release
+  # that does not change core costs a few seconds here and tags nothing. That looks
+  # like a wasted job and is not one. A skipped job poisons its ENTIRE downstream
+  # closure, not just the jobs that need it directly, and `always()` rescues only the
+  # job that carries it — never that job's descendants. So a skipped core-tag skipped
+  # ledger-init and every Kubernetes publisher straight through the core-ready
+  # barrier, which was built on the assumption that the rule is one hop deep. It is
+  # not. Keeping this job unconditional keeps a skipped node out of the graph
+  # entirely, which is the only thing that reliably breaks the chain.
   core-tag:
     needs: detect
-    if: needs.detect.outputs.release == 'true' && contains(fromJSON(needs.detect.outputs.units_json), 'core')
+    if: needs.detect.outputs.release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: contains(fromJSON(needs.detect.outputs.units_json), 'core')
         with:
           # Recovery-safe: build the EXACT transaction source commit, not the branch
           # HEAD at dispatch time (on push these are the same commit).
           ref: ${{ needs.detect.outputs.source_sha }}
           fetch-depth: 0
       - name: Tag the core module (immutable)
+        if: contains(fromJSON(needs.detect.outputs.units_json), 'core')
         env:
           TAG: v${{ needs.detect.outputs.core_version }}
           SRC: ${{ needs.detect.outputs.source_sha }}
         run: bash release/orchestrator/publish-go-tag.sh "$TAG" "$SRC"
 
-  # Core-readiness barrier for the Kubernetes line. Always runs for a release so
-  # the Kubernetes publishers have a stable dependency even when core is unchanged
-  # (a Kubernetes-only release skips core-tag, which would otherwise skip its
-  # dependents). If core changed, require core-tag to have succeeded; if not,
-  # verify the pinned core tag the integration go.mod requires already exists.
+  # Core-readiness barrier for the Kubernetes line. Always runs for a release so the
+  # Kubernetes publishers have a stable dependency. If core changed, require core-tag
+  # to have succeeded; if not, verify the pinned core tag the integration go.mod
+  # requires already exists.
   core-ready:
     needs: [detect, core-tag]
     if: always() && needs.detect.outputs.release == 'true'
@@ -757,9 +768,19 @@ jobs:
           esac
 
   # pacto-publishes: operator-chart
+  # operator-image is a sequencing dependency, not a required one: the chart is
+  # published after the image it points at, but a recovery that republishes only the
+  # chart against an already-published image is legitimate. Without always() that
+  # recovery skips instead — operator-image is gated on its own unit, so narrowing
+  # the dispatch to `operator-chart` skips the image and the skip lands here. The
+  # failure/cancelled guards keep the sequencing: a chart never publishes ahead of an
+  # image that tried to publish and could not.
   operator-chart:
     needs: [detect, operator-image, ledger-init]
-    if: needs.detect.outputs.release == 'true' && contains(fromJSON(needs.detect.outputs.units_json), 'operator-chart')
+    if: >-
+      always() && needs.detect.outputs.release == 'true' &&
+      contains(fromJSON(needs.detect.outputs.units_json), 'operator-chart') &&
+      !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -959,3 +980,43 @@ jobs:
           TAG: v${{ needs.detect.outputs.core_version }}
           SRC: ${{ needs.detect.outputs.source_sha }}
         run: bash release/orchestrator/finalize-release.sh "$TAG" "$SRC"
+
+  # A release that fired and published nothing must not report success. Twice now a
+  # run has gone green while the whole Kubernetes line skipped, and a green no-op is
+  # indistinguishable from a real release until someone goes looking for a version
+  # that was never created. This is the answer, and it deliberately does not model
+  # the runner: it reads what the run actually did. `tests/release/dag_test.go`
+  # simulates GitHub's skip semantics to catch a broken wiring before it merges, but
+  # that gate is only as good as our model of the runner — and it was our model of
+  # the runner that was wrong both times. This one cannot be wrong the same way.
+  #
+  # Terminal on purpose: nothing needs it, so it can only turn a run red, never
+  # withhold a publish. always() because the jobs it inspects are exactly the jobs
+  # that skip.
+  verify-transaction:
+    needs:
+      - detect
+      - core-tag
+      - ledger-init
+      - dashboard-image
+      - dashboard-contract-bundle
+      - demo-bundles
+      - demo-compose
+      - k8s-module
+      - operator-image
+      - operator-chart
+      - docs
+      - release
+    if: always() && needs.detect.outputs.release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      # Deliberately NOT `ref: source_sha`. This job reads the unit -> job mapping
+      # out of the workflow, and the workflow that ran is the one at the dispatched
+      # ref, not the one at the transaction's source commit. On a push they are the
+      # same commit; on a recovery dispatch they are not.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Every unit in the transaction must have published
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+          UNITS: ${{ needs.detect.outputs.units_json }}
+        run: bash release/orchestrator/verify-transaction.sh .github/workflows/release.yml

--- a/release/orchestrator/verify-transaction.sh
+++ b/release/orchestrator/verify-transaction.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Every unit the transaction fired for must have a publisher job that SUCCEEDED.
+#
+# The point is to make a no-op release loud. A skipped job poisons its entire
+# downstream closure — not only the jobs that need it directly — so a single
+# skipped node upstream of the publishers takes the whole Kubernetes line with it
+# while the run still reports success. That has happened twice, and both times the
+# only symptom was a version that quietly did not exist. This check reads what the
+# run actually did rather than modelling what it should have done, which is what
+# makes it independent of the wiring gate in tests/release/dag_test.go.
+#
+# Reads the unit -> job mapping from the `# pacto-publishes: <unit>` markers in the
+# workflow, so it cannot drift from the jobs it is checking.
+# tests/release/one_publisher_test.go already proves every unit has exactly one.
+#
+# Usage: verify-transaction.sh <workflow-file>
+#   NEEDS  JSON object of the `needs` context ({"job": {"result": "..."}, ...})
+#   UNITS  JSON array of the transaction's changed units
+set -euo pipefail
+
+workflow="${1:?usage: verify-transaction.sh <workflow-file>}"
+: "${NEEDS:?NEEDS (toJSON(needs)) is required}"
+: "${UNITS:?UNITS (units_json) is required}"
+
+# unit<TAB>job, one per marker: the job key is the next top-level `name:` line
+# after the marker, skipping any comment lines between them. POSIX awk only —
+# GNU's three-argument match() is not available on every runner image.
+publishers="$(awk '
+  /^[[:space:]]*# pacto-publishes:/ {
+    unit = $0
+    sub(/^.*# pacto-publishes:[[:space:]]*/, "", unit)
+    sub(/[^a-z0-9-].*$/, "", unit)
+    next
+  }
+  unit != "" && /^  [a-z0-9-]+:[[:space:]]*$/ {
+    job = $0
+    sub(/^  /, "", job)
+    sub(/:[[:space:]]*$/, "", job)
+    print unit "\t" job
+    unit = ""
+  }
+' "$workflow")"
+
+echo "units: $UNITS"
+echo "job results:"
+echo "$NEEDS" | jq -r 'to_entries[] | "  \(.key): \(.value.result)"'
+
+missing=0
+while read -r unit; do
+  [ -n "$unit" ] || continue
+  job="$(printf '%s\n' "$publishers" | awk -F'\t' -v u="$unit" '$1 == u { print $2; exit }')"
+  if [ -z "$job" ]; then
+    echo "::error::unit '$unit' is in the transaction but no job declares 'pacto-publishes: $unit'"
+    missing=1
+    continue
+  fi
+  result="$(printf '%s' "$NEEDS" | jq -r --arg j "$job" '.[$j].result // "absent"')"
+  if [ "$result" != "success" ]; then
+    echo "::error::unit '$unit' did not publish: job '$job' is '$result'"
+    missing=1
+  else
+    echo "  ok: $unit -> $job"
+  fi
+done <<< "$(printf '%s' "$UNITS" | jq -r '.[]')"
+
+if [ "$missing" -ne 0 ]; then
+  echo "::error::the release fired but did not publish every unit it claimed."
+  echo "::error::A 'skipped' above is the usual shape: look for a skipped job UPSTREAM"
+  echo "::error::of the publisher, including one it does not need directly."
+  exit 1
+fi
+
+echo "every unit in the transaction published"

--- a/tests/release/dag_test.go
+++ b/tests/release/dag_test.go
@@ -13,25 +13,72 @@ import (
 
 // This gate extracts the release.yml job DAG (needs + the unit each publisher
 // gates on) and simulates which jobs run for a given changedUnits set, so a
-// wiring mistake — like a Kubernetes publisher depending on the conditionally
-// skipped core-tag instead of the always-run core-ready barrier — fails the
-// build. It models GitHub's skip semantics:
+// wiring mistake fails the build instead of half-shipping a release.
+//
+// The skip semantics below are measured, not read off the documentation. The
+// documented rule — "if a job fails or is skipped, all jobs that need it are
+// skipped" — reads as one hop, and this simulator used to model it that way. It is
+// not one hop. A probe workflow on this repo showed a job with NO `if` at all, whose
+// only dependency succeeded, skipped anyway because a job further up the chain had
+// skipped. So:
+//
 //   - detect is the always-present root.
-//   - a job with `if: always()` runs whenever the release fires, regardless of a
-//     skipped dependency (that is how core-ready survives a skipped core-tag).
-//   - any other job runs only if its unit gate matches changedUnits AND every
-//     dependency ran successfully; a skipped/absent dependency skips it.
+//   - a skipped job POISONS its entire transitive downstream closure, not only the
+//     jobs that need it directly.
+//   - `if: always()` rescues the job that carries it and nothing else: it runs, and
+//     its descendants stay poisoned. An always() barrier does NOT unblock the jobs
+//     below it.
+//   - any other job runs only if its unit gate matches changedUnits AND nothing in
+//     its transitive ancestry skipped.
+//
+// The practical consequence, and the reason this file was rewritten: the only
+// reliable way to keep a conditional job from taking its dependents down with it is
+// to stop the JOB from skipping — run it unconditionally and gate its STEPS.
 
 type relJob struct {
 	needs   []string
 	unit    string // the changedUnits entry this job gates on ("" = no unit gate)
 	always  bool
 	release bool // gated on release == 'true'
+	steps   []relStep
+}
+
+type relStep struct {
+	name string
+	unit string // the changedUnits entry this step gates on ("" = no unit gate)
 }
 
 var unitGateRE = regexp.MustCompile(`contains\(fromJSON\(needs\.detect\.outputs\.units_json\),\s*'([a-z0-9-]+)'\)`)
 
-func loadReleaseDAG(t *testing.T) map[string]relJob {
+// publisherOf maps a release unit to the job that publishes it, read from the
+// `# pacto-publishes: <unit>` marker that precedes each publisher job.
+// TestExactlyOnePublisherPerUnit proves the markers are complete and unique; this
+// only needs to pair each one with the job key that follows it.
+var (
+	markerRE = regexp.MustCompile(`^\s*# pacto-publishes:\s*([a-z0-9-]+)`)
+	jobKeyRE = regexp.MustCompile(`^  ([a-z0-9-]+):\s*$`)
+)
+
+func publisherOf(src string) map[string]string {
+	out := map[string]string{}
+	unit := ""
+	for _, line := range strings.Split(src, "\n") {
+		if m := markerRE.FindStringSubmatch(line); m != nil {
+			unit = m[1]
+			continue
+		}
+		if unit == "" {
+			continue
+		}
+		if m := jobKeyRE.FindStringSubmatch(line); m != nil {
+			out[unit] = m[1]
+			unit = ""
+		}
+	}
+	return out
+}
+
+func loadReleaseDAG(t *testing.T) (map[string]relJob, map[string]string) {
 	t.Helper()
 	b, err := os.ReadFile(filepath.Join(repoRoot(t), ".github", "workflows", "release.yml"))
 	if err != nil {
@@ -41,6 +88,11 @@ func loadReleaseDAG(t *testing.T) map[string]relJob {
 		Jobs map[string]struct {
 			Needs any    `yaml:"needs"`
 			If    string `yaml:"if"`
+			Steps []struct {
+				Name string `yaml:"name"`
+				Uses string `yaml:"uses"`
+				If   string `yaml:"if"`
+			} `yaml:"steps"`
 		} `yaml:"jobs"`
 	}
 	if err := yaml.Unmarshal(b, &doc); err != nil {
@@ -63,9 +115,19 @@ func loadReleaseDAG(t *testing.T) map[string]relJob {
 		if m := unitGateRE.FindStringSubmatch(j.If); m != nil {
 			rj.unit = m[1]
 		}
+		for _, s := range j.Steps {
+			st := relStep{name: s.Name}
+			if st.name == "" {
+				st.name = s.Uses
+			}
+			if m := unitGateRE.FindStringSubmatch(s.If); m != nil {
+				st.unit = m[1]
+			}
+			rj.steps = append(rj.steps, st)
+		}
 		out[name] = rj
 	}
-	return out
+	return out, publisherOf(string(b))
 }
 
 // simulate returns the set of jobs that RUN for a release with the given
@@ -76,37 +138,42 @@ func simulate(dag map[string]relJob, changedUnits []string) map[string]bool {
 		inUnits[u] = true
 	}
 	ran := map[string]bool{"detect": true} // detect always resolves for a release
-	// Fixpoint: a job runs when its gate holds and its deps are satisfied.
+	decided := map[string]bool{"detect": true}
+	poisoned := map[string]bool{}
+	// Fixpoint: decide a job once every dependency has been decided.
 	for i := 0; i < len(dag)+2; i++ {
 		for name, j := range dag {
-			if name == "detect" || name == "changesets" {
+			if name == "detect" || name == "changesets" || decided[name] {
 				continue
 			}
-			if ran[name] {
-				continue
-			}
-			// unit gate
-			if j.unit != "" && !inUnits[j.unit] {
-				continue
-			}
-			// dependency satisfaction
-			depsOK := true
+			ready := true
+			poison := false
 			for _, d := range j.needs {
 				if d == "detect" {
 					continue
 				}
-				if !ran[d] {
-					// an always() job survives a skipped dep; others do not.
-					if !j.always {
-						depsOK = false
-						break
-					}
+				if !decided[d] {
+					ready = false
+					break
+				}
+				if !ran[d] || poisoned[d] {
+					poison = true
 				}
 			}
-			if !depsOK {
+			if !ready {
 				continue
 			}
-			ran[name] = true
+			gate := j.unit == "" || inUnits[j.unit]
+			run := gate && (j.always || !poison)
+			decided[name] = true
+			ran[name] = run
+			// always() rescues this job only — its descendants stay poisoned.
+			poisoned[name] = poison || !run
+		}
+	}
+	for name := range ran {
+		if !ran[name] {
+			delete(ran, name)
 		}
 	}
 	delete(ran, "detect")
@@ -123,29 +190,67 @@ func names(m map[string]bool) []string {
 }
 
 func TestReleaseDAGSelection(t *testing.T) {
-	dag := loadReleaseDAG(t)
+	dag, publisher := loadReleaseDAG(t)
 
 	core := []string{"core", "cli", "dashboard-image", "dashboard-contract-bundle", "demo-bundles", "demo-compose"}
 	k8s := []string{"k8s-module", "operator-image", "operator-chart", "k8s-docs"}
 	k8sPublishers := []string{"k8s-module", "operator-image", "operator-chart"}
 
-	t.Run("kubernetes-only runs every kubernetes publisher despite core-tag skip", func(t *testing.T) {
+	// The invariant every scenario below is really testing: a release that fires for
+	// a set of units must run the publisher of each one. Two releases shipped nothing
+	// and reported success because no test asserted this directly — the old
+	// kubernetes-only case enumerated three job names and the simulator's skip model
+	// was wrong in exactly the way that mattered.
+	requirePublished := func(t *testing.T, label string, units []string, ran map[string]bool) {
+		t.Helper()
+		for _, u := range units {
+			job, ok := publisher[u]
+			if !ok {
+				t.Errorf("%s: unit %q has no `# pacto-publishes: %s` marker", label, u, u)
+				continue
+			}
+			if !ran[job] {
+				t.Errorf("%s: unit %q did not publish — job %q skipped. A skipped job poisons its whole downstream closure, so look for a skipped node anywhere in its ancestry, not just its direct needs; ran=%v", label, u, job, names(ran))
+			}
+		}
+	}
+
+	t.Run("kubernetes-only publishes the whole kubernetes line", func(t *testing.T) {
 		ran := simulate(dag, k8s)
-		if ran["core-tag"] {
-			t.Error("core-tag must be skipped for a kubernetes-only release")
+		requirePublished(t, "kubernetes-only", k8s, ran)
+		// core-tag RUNS here and tags nothing. That is the fix, not a bug: while its
+		// job gate could skip it, the skip travelled through the core-ready barrier
+		// and took ledger-init and every kubernetes publisher with it. The "core is
+		// not tagged" half of the invariant is asserted at the step level below.
+		if !ran["core-tag"] {
+			t.Error("core-tag must RUN for every release (unconditional job, unit-gated steps) — a skipped core-tag poisons the whole kubernetes line")
 		}
 		if !ran["core-ready"] {
 			t.Error("core-ready barrier must run for any release")
 		}
-		for _, p := range k8sPublishers {
-			if !ran[p] {
-				t.Errorf("kubernetes-only: %q must run (got skipped) — it must depend on core-ready, not the skipped core-tag; ran=%v", p, names(ran))
+	})
+
+	t.Run("core-tag gates its steps, not the job", func(t *testing.T) {
+		ct, ok := dag["core-tag"]
+		if !ok {
+			t.Fatal("core-tag job is missing")
+		}
+		if ct.unit != "" {
+			t.Errorf("core-tag must NOT carry a unit gate on the JOB (%q) — skipping it poisons every job downstream of core-ready", ct.unit)
+		}
+		if len(ct.steps) == 0 {
+			t.Fatal("core-tag has no steps")
+		}
+		for _, s := range ct.steps {
+			if s.unit != "core" {
+				t.Errorf("core-tag step %q must be gated on the 'core' unit (got %q) — the job always runs, so the steps are what keep a non-core release from tagging core", s.name, s.unit)
 			}
 		}
 	})
 
 	t.Run("core-only runs no kubernetes publisher", func(t *testing.T) {
 		ran := simulate(dag, core)
+		requirePublished(t, "core-only", core, ran)
 		if !ran["core-tag"] {
 			t.Error("core-tag must run for a core release")
 		}
@@ -157,14 +262,11 @@ func TestReleaseDAGSelection(t *testing.T) {
 	})
 
 	t.Run("coordinated runs both groups with core-tag before kubernetes", func(t *testing.T) {
-		ran := simulate(dag, append(append([]string{}, core...), k8s...))
+		all := append(append([]string{}, core...), k8s...)
+		ran := simulate(dag, all)
+		requirePublished(t, "coordinated", all, ran)
 		if !ran["core-tag"] {
 			t.Error("core-tag must run in a coordinated release")
-		}
-		for _, p := range append(append([]string{}, k8sPublishers...), "core-ready") {
-			if !ran[p] {
-				t.Errorf("coordinated: %q must run", p)
-			}
 		}
 		// Ordering: every kubernetes publisher transitively depends on core-ready,
 		// which depends on core-tag.
@@ -178,14 +280,30 @@ func TestReleaseDAGSelection(t *testing.T) {
 		}
 	})
 
-	t.Run("recovery subset runs only the requested unit's publisher", func(t *testing.T) {
-		// A recovery of just operator-image: only operator-image (+ core-ready barrier).
-		ran := simulate(dag, []string{"operator-image"})
-		if !ran["operator-image"] {
-			t.Error("recovery of operator-image must run it")
-		}
-		if ran["k8s-module"] || ran["operator-chart"] {
-			t.Error("recovery subset must not run non-requested publishers")
+	// A recovery dispatch narrows units_json to the incomplete units, so every unit
+	// must be recoverable ALONE. This is where the poisoning bites hardest: the
+	// narrower the dispatch, the more sibling publishers skip, and each skip reaches
+	// everything below it.
+	t.Run("every unit is recoverable on its own", func(t *testing.T) {
+		units := append(append([]string{}, core...), k8s...)
+		for _, u := range units {
+			ran := simulate(dag, []string{u})
+			requirePublished(t, "recovery of "+u, []string{u}, ran)
+			for _, other := range units {
+				if other == u {
+					continue
+				}
+				job, ok := publisher[other]
+				// A job with no JOB-level unit gate runs unconditionally on purpose
+				// (core-tag) — its steps decide whether it publishes, and steps are
+				// asserted separately. Only a job-gated publisher running is a leak.
+				if !ok || dag[job].unit == "" {
+					continue
+				}
+				if ran[job] {
+					t.Errorf("recovery of %q must not also run %q (job %q)", u, other, job)
+				}
+			}
 		}
 	})
 }

--- a/tests/release/source_sha_test.go
+++ b/tests/release/source_sha_test.go
@@ -71,8 +71,11 @@ func TestReleaseJobsBuildTransactionSourceSha(t *testing.T) {
 	const pin = "ref: ${{ needs.detect.outputs.source_sha }}"
 
 	// detect pins via the dispatch INPUT (it validates HEAD==source_sha itself);
-	// changesets is push-only, opens the Version PR and publishes nothing.
-	exemptCheckout := map[string]bool{"detect": true, "changesets": true}
+	// changesets is push-only, opens the Version PR and publishes nothing;
+	// verify-transaction publishes nothing either and must read the workflow that
+	// ACTUALLY ran — on a recovery dispatch that is the file at the dispatched ref,
+	// not the one at the transaction's source commit.
+	exemptCheckout := map[string]bool{"detect": true, "changesets": true, "verify-transaction": true}
 	// github.sha is legitimate ONLY in detect (it derives source_sha from it on push)
 	// and in non-commit contexts (server_url/repository). Everywhere else it is the
 	// dispatch commit and must not stamp released-artifact metadata.


### PR DESCRIPTION
Two Kubernetes-only releases reported success and published nothing. **5.2.2 and 5.3.0 do not exist** — no Go tag, no operator image, no chart, no ledger entry. Published chart tags jump `5.2.1 -> 5.2.3`, and 5.3.0 is missing outright while the docs that same run *did* publish now advertise `helm ... --version 5.3.0` to anyone reading pacto.run.

## What happened

Both runs skipped `core-tag`, which is correct — neither changed core — and then skipped `ledger-init` and every Kubernetes publisher, which is not.

`core-ready` exists to absorb exactly that skip: it carries `always()` so it runs whether or not core was tagged, and every Kubernetes publisher needs the barrier rather than the tagger. That design assumes GitHub's skip rule is one hop deep.

It is not. A skipped job skips its **entire transitive downstream closure**, and `always()` rescues only the job that carries it — never its descendants. A probe workflow on this repo confirmed it: a job with no `if` at all, whose single dependency succeeded, still skipped because something further up the chain had. So the barrier ran and everything below it skipped anyway.

## The fix

**Keep the skipped node out of the graph.** `core-tag` now runs for every release and gates its two steps on the `core` unit instead of gating the job. A release that does not change core spends a few seconds there and tags nothing. One job changed repairs all nine publishers downstream; the alternative — sprinkling `always() && !contains(needs.*.result, 'failure')` — would have to be applied to every job in the closure, because `always()` does not compose downward.

**`operator-chart` had the same shape one hop away.** It needs `operator-image`, which is gated on its own unit, so narrowing a recovery dispatch to the chart alone skipped it. It now carries the `always()` plus failure/cancelled guards that `demo-compose` and `release` already use, which keeps the sequencing while allowing a chart-only republish against an image that is already out.

## Why the gate did not catch it

`tests/release/dag_test.go` simulated the one-hop rule, so it was green on the broken wiring for both releases. Its model now matches what the runner actually does, and the scenarios assert the invariant that was missing: **every unit the release fires for must have its publisher run** — including when a recovery narrows the dispatch to a single unit, which is where the poisoning bites hardest.

Reverting the `core-tag` gate makes the suite fail on exactly the two shipped ghosts.

## The check that does not model anything

That gate is only as good as our model of the runner, and it was the model that was wrong — both times. `verify-transaction` is the answer: a terminal job that reads the units the transaction fired for, maps each to its publisher through the existing `pacto-publishes` markers and fails if any of them did not succeed. It publishes nothing and nothing depends on it, so it can only turn a run red. Against the real 5.3.0 job results it names all three unpublished units.

## Recovery

Not in this PR. 5.3.0 is recovered by dispatching the existing transaction once this is on main — `workflow_dispatch` resolves the workflow YAML from main's HEAD, so a dispatch before this merges would skip identically. 5.2.2 is superseded by 5.2.3 and stays a gap in the sequence.
