### PR TITLE
fix(release): keep the module proxy for third-party deps in standalone builds

### DIFF
--- a/integrations/kubernetes/Dockerfile
+++ b/integrations/kubernetes/Dockerfile
@@ -21,6 +21,16 @@ ARG DASHBOARD_IMAGE=
 # and the staging dry-run leave it unset and build through go.work (the local core,
 # which for those flows is the same commit being released).
 ARG RELEASE_BUILD=
+# The release build must resolve the core tag it just published, which the module
+# proxy has not indexed yet — so the core has to come straight from VCS. GOPRIVATE
+# alone does that: it feeds GONOPROXY, which routes github.com/trianalab/* direct and
+# leaves every OTHER module on the proxy. Forcing the proxy off entirely as well is
+# not a stronger version of the same thing, it is a different and worse one: it sends the
+# whole dependency graph to VCS, so the build depends on every upstream repo still
+# existing at its pinned revision. github.com/google/cel-go (an indirect dep) was
+# deleted from GitHub, which broke the 5.3.0 operator image while the proxy still
+# served the exact version go.sum asks for. The proxy is the durable copy; use it for
+# everything except the one module that is genuinely too fresh to be there.
 
 WORKDIR /workspace
 # Workspace + both module manifests first (cache-friendly).
@@ -35,8 +45,8 @@ RUN set -eu; \
     if [ -n "${RELEASE_BUILD}" ]; then \
       echo "release build: GOWORK=off against the published pinned core"; \
       cd integrations/kubernetes; \
-      GOWORK=off GOFLAGS=-mod=mod GOPROXY=direct GOPRIVATE='github.com/trianalab/*' GONOSUMDB='github.com/trianalab/*' go mod download; \
-      CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GOWORK=off GOFLAGS=-mod=mod GOPROXY=direct GOPRIVATE='github.com/trianalab/*' GONOSUMDB='github.com/trianalab/*' \
+      GOWORK=off GOFLAGS=-mod=mod GOPROXY=https://proxy.golang.org,direct GOPRIVATE='github.com/trianalab/*' GONOSUMDB='github.com/trianalab/*' go mod download; \
+      CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GOWORK=off GOFLAGS=-mod=mod GOPROXY=https://proxy.golang.org,direct GOPRIVATE='github.com/trianalab/*' GONOSUMDB='github.com/trianalab/*' \
         go build -ldflags "${LDFLAGS}" -o /workspace/manager ./cmd; \
     else \
       echo "workspace build: go.work resolves the local core"; \

--- a/release/orchestrator/verify-k8s-standalone.sh
+++ b/release/orchestrator/verify-k8s-standalone.sh
@@ -62,11 +62,11 @@ EOF
 
 cd "$WORK/consumer"
 export GIT_CONFIG_GLOBAL="$TMPGIT" GIT_CONFIG_SYSTEM=/dev/null \
-       GOWORK=off GOFLAGS=-mod=mod GOPROXY=direct \
+       GOWORK=off GOFLAGS=-mod=mod GOPROXY=https://proxy.golang.org,direct \
        GOPRIVATE='github.com/trianalab/*' GONOSUMDB='github.com/trianalab/*' \
        GOMODCACHE="$MODCACHE"
 
-echo "go get ${MODULE}@v${K8S_VER} (external, GOWORK=off, GOPROXY=direct)..."
+echo "go get ${MODULE}@v${K8S_VER} (external, GOWORK=off, trianalab direct via GOPRIVATE)..."
 go get "${MODULE}@v${K8S_VER}"
 # Fail closed: an external consumer must resolve the module with NO replace.
 [ "$(grep -c '^replace' go.mod)" = "0" ] || { echo "ERROR: consumer go.mod grew a replace directive"; exit 1; }

--- a/release/scripts/verify-standalone.sh
+++ b/release/scripts/verify-standalone.sh
@@ -40,7 +40,7 @@ perl -i -pe "s{github.com/trianalab/pacto/v3 v[0-9][0-9.]*}{github.com/trianalab
 [ "$(grep -c '^replace' "$WORK/op/go.mod")" = "0" ] || { echo "ERROR: replace directive present in release state"; exit 1; }
 cd "$WORK/op"
 export GIT_CONFIG_GLOBAL="$TMPGIT" GIT_CONFIG_SYSTEM=/dev/null GOWORK=off GOFLAGS=-mod=mod \
-       GOPROXY=direct GOPRIVATE='github.com/trianalab/*' GONOSUMDB='github.com/trianalab/*' GOMODCACHE="$(mktemp -d)"
+       GOPROXY=https://proxy.golang.org,direct GOPRIVATE='github.com/trianalab/*' GONOSUMDB='github.com/trianalab/*' GOMODCACHE="$(mktemp -d)"
 echo "go mod download (external, GOWORK=off)..."; go mod download github.com/trianalab/pacto/v3
 echo "go build ./... (standalone operator, no go.work, no replace)..."
 go build ./... && go build -o /dev/null ./cmd

--- a/tests/release/operator_dockerfile_test.go
+++ b/tests/release/operator_dockerfile_test.go
@@ -8,23 +8,52 @@ import (
 )
 
 // The operator image release build (RELEASE_BUILD=1) resolves the freshly-published,
-// pinned core module. proxy.golang.org may not have indexed a just-tagged version
-// yet, so the release build must fetch direct from VCS (GOPROXY=direct) and skip the
-// checksum database for the in-flight module — mirroring the standalone verify
-// scripts. Without it the operator-image job can fail to resolve the core right after
-// a core tag is published.
-func TestOperatorDockerfileReleaseBuildFetchesDirect(t *testing.T) {
+// pinned core module, which proxy.golang.org has not indexed yet — so the core must
+// come straight from VCS. GOPRIVATE='github.com/trianalab/*' is what buys that: it
+// feeds GONOPROXY, so trianalab modules bypass the proxy and everything else keeps
+// using it.
+//
+// This gate used to require GOPROXY=direct instead, which turns the same knob far too
+// far: it routes the ENTIRE dependency graph to VCS, making the build depend on every
+// upstream repository still existing at its pinned revision. github.com/google/cel-go
+// (an indirect dependency) was deleted from GitHub and the 5.3.0 operator image stopped
+// building, even though the proxy still served the exact version go.sum pins. So the
+// invariant is now stated as the two things that actually have to hold, and
+// GOPROXY=direct is banned rather than required.
+func TestOperatorDockerfileReleaseBuildResolvesFreshCoreWithoutDisablingTheProxy(t *testing.T) {
 	root := repoRoot(t)
-	b, err := os.ReadFile(filepath.Join(root, "integrations", "kubernetes", "Dockerfile"))
-	if err != nil {
-		t.Fatalf("read Dockerfile: %v", err)
-	}
-	df := string(b)
 
-	if !strings.Contains(df, "GOPROXY=direct") {
-		t.Error("operator Dockerfile release build must set GOPROXY=direct so a freshly-published core tag resolves before the module proxy indexes it")
-	}
-	if !strings.Contains(df, "GONOSUMDB='github.com/trianalab/*'") {
-		t.Error("operator Dockerfile release build must set GONOSUMDB for github.com/trianalab/* so the checksum database is not consulted for the in-flight module")
+	// Every place that builds the operator module standalone against a published core
+	// shares the failure mode, so they share the gate.
+	for _, rel := range []string{
+		filepath.Join("integrations", "kubernetes", "Dockerfile"),
+		filepath.Join("release", "scripts", "verify-standalone.sh"),
+		filepath.Join("release", "orchestrator", "verify-k8s-standalone.sh"),
+	} {
+		b, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		body := string(b)
+
+		// Only the assignment is banned; prose explaining why may name it.
+		for _, line := range strings.Split(body, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			if strings.Contains(line, "GOPROXY=direct") {
+				t.Errorf("%s sets GOPROXY=direct, which sends every dependency to VCS and breaks the build when any upstream repo disappears (github.com/google/cel-go did). Use the proxy chain and let GOPRIVATE route trianalab direct.", rel)
+			}
+		}
+		if !strings.Contains(body, "GOPROXY=https://proxy.golang.org,direct") {
+			t.Errorf("%s must set GOPROXY=https://proxy.golang.org,direct so third-party modules resolve from the durable proxy copy", rel)
+		}
+		if !strings.Contains(body, "GOPRIVATE='github.com/trianalab/*'") {
+			t.Errorf("%s must set GOPRIVATE='github.com/trianalab/*' — it feeds GONOPROXY, which is what makes a just-published core tag resolve before the proxy indexes it", rel)
+		}
+		if !strings.Contains(body, "GONOSUMDB='github.com/trianalab/*'") {
+			t.Errorf("%s must set GONOSUMDB for github.com/trianalab/* so the checksum database is not consulted for the in-flight module", rel)
+		}
 	}
 }


### PR DESCRIPTION
The 5.3.0 operator image failed to build on both arches:

```
go: github.com/google/cel-go@v0.29.2: reading .../go.mod at revision v0.29.2:
    git ls-remote -q https://github.com/google/cel-go: exit status 128:
    fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

`github.com/google/cel-go` no longer exists on GitHub — `git ls-remote` returns
"Repository not found" and the API returns 404. It is an indirect dependency of the
operator module. proxy.golang.org still serves the exact version `go.sum` pins.

## Why the build reached VCS at all

The release build set `GOPROXY=direct`. The reason was real: `RELEASE_BUILD=1` resolves
the core tag published moments earlier in the same run, and the proxy has not indexed it
yet. But `GOPROXY=direct` does not scope that to the core — it sends the whole dependency
graph to VCS, so the build quietly depends on every upstream repository still existing at
its pinned revision. One deletion anywhere in the graph breaks it permanently.

`GOPRIVATE='github.com/trianalab/*'` was already set alongside it, and that is the setting
that actually solves the freshness problem: it feeds `GONOPROXY`, so trianalab modules
bypass the proxy while everything else keeps using it. The `GOPROXY` override was
redundant for its stated purpose and load-bearing for the outage.

## Change

`GOPROXY=direct` becomes `GOPROXY=https://proxy.golang.org,direct` in the operator
Dockerfile's release branch and in the two standalone verify scripts, which build the same
way and share the failure mode. Both scripts redirect the trianalab module to a local clone
via `git insteadOf`, which keeps working because `GONOPROXY` still routes it direct.

Verified against a clean module cache:

```
GOPROXY=direct                            -> Repository not found (the CI error)
GOPROXY=https://proxy.golang.org,direct   -> added github.com/google/cel-go v0.29.2
```

## Gate

`TestOperatorDockerfileReleaseBuildFetchesDirect` required the literal `GOPROXY=direct`,
so it pinned the outage in place. It now asserts the invariant that was meant all along —
trianalab direct via `GOPRIVATE`/`GONOSUMDB`, everything else on the proxy — bans
`GOPROXY=direct` in non-comment lines, and covers all three files instead of only the
Dockerfile.

## Release impact

No changeset: this touches build plumbing, not shipped module code, and the release
manifest must stay at 5.3.0 so the pending transaction `4cfedb4665e4a1fd` remains valid.
Once this lands, the 5.3.0 recovery can be dispatched against the new `main` HEAD — which
also clears the second failure from that run, where the Go tag push was rejected because
the dispatched ref's `.github/workflows/release.yml` differed from the default branch.
