### PR TITLE
fix(ci): retry every Go module fetch, and install crane as a prebuilt binary

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -67,7 +67,7 @@ runs:
           ${{ runner.os }}-go-
 
     - name: Download dependencies
-      run: go mod download
+      run: bash release/scripts/retry.sh go mod download
       shell: bash
 
     - name: Install golangci-lint

--- a/.github/actions/setup-crane/action.yml
+++ b/.github/actions/setup-crane/action.yml
@@ -1,0 +1,76 @@
+name: Setup crane
+description: Put the pinned crane release binary on PATH, from the published tarball rather than a source build
+
+# Why this exists, in one incident: release run 34613593980 (transaction
+# f93d13f5aaf491e5) died in `Install crane` with
+#
+#   github.com/docker/distribution@v2.8.2+incompatible: read
+#   "https://proxy.golang.org/.../v2.8.2+incompatible.zip": stream error;
+#   INTERNAL_ERROR; received from peer
+#
+# and took the release with it: operator-image failed, operator-chart and the
+# GitHub Release job were skipped behind it, and 3.3.0/5.4.0 shipped as a Go tag
+# with no binaries and no operator artifacts.
+#
+# The flake was transient. The exposure was not. crane was the ONE tool in this
+# repository's release path built from source at publish time -- oras, cosign,
+# syft and helm all arrive as prebuilt binaries from pinned actions -- so it
+# alone fetched roughly twenty third-party module zips per job, in seven release
+# jobs, every release. That is well over a hundred network operations a release
+# needed only in order to produce a binary its upstream already publishes.
+#
+# One tarball and one checksum file replace all of it, and the fetch retries.
+# tests/release/workflow_tooling_test.go holds the rule so it cannot come back.
+
+runs:
+  using: composite
+  steps:
+    - name: Install crane
+      shell: bash
+      env:
+        # Bump these four together. The digests are the upstream release's own,
+        # copied from
+        # https://github.com/google/go-containerregistry/releases/download/v0.20.2/checksums.txt
+        # and pinned HERE rather than read from that file at run time: a checksum
+        # fetched over the same connection as the artifact proves only that the
+        # two agree with each other.
+        CRANE_VERSION: v0.20.2
+        CRANE_SHA256_X86_64: c14340087103ba9dadf61d45acd20675490fd0ccbd56ac7901fc1b502137f44b
+        CRANE_SHA256_ARM64: aff0db48825124c9331ea310057214bd4e92c01aa2e414d539e9659841d9422a
+      run: |
+        set -euo pipefail
+
+        case "$(uname -m)" in
+          x86_64)        asset=go-containerregistry_Linux_x86_64.tar.gz; want=$CRANE_SHA256_X86_64 ;;
+          aarch64|arm64) asset=go-containerregistry_Linux_arm64.tar.gz;  want=$CRANE_SHA256_ARM64 ;;
+          *) echo "::error::no pinned crane build for runner arch $(uname -m)"; exit 1 ;;
+        esac
+
+        url="https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/${asset}"
+        tmp=$(mktemp -d)
+
+        # Retry the one network operation that is left. A release job that dies
+        # here strands a transaction, so a transient 5xx or a reset connection is
+        # worth four more attempts before giving up.
+        for attempt in 1 2 3 4 5; do
+          if curl --fail --silent --show-error --location --retry 0 \
+                  --connect-timeout 15 --max-time 180 \
+                  -o "$tmp/$asset" "$url"; then
+            break
+          fi
+          if [ "$attempt" = 5 ]; then
+            echo "::error::could not download $url after 5 attempts"
+            exit 1
+          fi
+          echo "crane download attempt $attempt failed; retrying in $((attempt * 5))s"
+          sleep $((attempt * 5))
+        done
+
+        echo "$want  $tmp/$asset" | sha256sum --check --status \
+          || { echo "::error::checksum mismatch for $asset -- got $(sha256sum "$tmp/$asset" | cut -d' ' -f1), pinned $want"; exit 1; }
+
+        tar -xzf "$tmp/$asset" -C "$tmp" crane
+        install -m 0755 "$tmp/crane" /usr/local/bin/crane
+        rm -rf "$tmp"
+
+        crane version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,8 +311,8 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
-      - name: Install crane (checksum-verified via GOSUMDB)
-        run: go install github.com/google/go-containerregistry/cmd/crane@v0.20.2
+      - name: Install crane
+        uses: ./.github/actions/setup-crane
       - name: Install ORAS
         # The dry-run drives the real durable OCI-backed ledger (ledger.sh), which
         # stores + reads the ledger as an OCI artifact via oras — exactly as the
@@ -350,7 +350,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install crane (the byte-exact comparison IS crane)
-        run: go install github.com/google/go-containerregistry/cmd/crane@v0.20.2
+        uses: ./.github/actions/setup-crane
       - name: Log in to GHCR (read-only, for the published-digest lookup)
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,8 +165,9 @@ jobs:
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
       - name: Install helm-docs
         # go install verifies the module checksum via GOSUMDB — no unchecksummed
-        # curl | tar of a release tarball.
-        run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
+        # curl | tar of a release tarball. It is also ~20 module fetches with no
+        # retry of its own, so it goes through release/scripts/retry.sh.
+        run: bash release/scripts/retry.sh go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
       - run: make ci-integration-kubernetes
 
   ci-e2e-envtest:
@@ -260,7 +261,7 @@ jobs:
       - if: matrix.scenario == 'evidence' || startsWith(matrix.scenario, 'gitops-')
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
       - name: Install kind (checksum-verified via GOSUMDB)
-        run: go install sigs.k8s.io/kind@v0.30.0
+        run: bash release/scripts/retry.sh go install sigs.k8s.io/kind@v0.30.0
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
       - run: make test-acceptance-kind-${{ matrix.scenario }}

--- a/.github/workflows/pacto.yml
+++ b/.github/workflows/pacto.yml
@@ -55,7 +55,7 @@ jobs:
       # back to the published binary via pacto-actions.
       - name: Build pacto from source
         if: github.event_name != 'release'
-        run: go install ./cmd/pacto
+        run: bash release/scripts/retry.sh go install ./cmd/pacto
 
       - uses: trianalab/pacto-actions@3ae26607b3d6f33caec1213e148ba3feab571ef4 # v1.8.2
         if: github.event_name == 'release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -417,7 +417,7 @@ jobs:
       # `go run ./cmd/pacto` validate + push calls below; nothing invokes the
       # installed binary.
       - name: Build pacto
-        run: go install ./cmd/pacto
+        run: bash release/scripts/retry.sh go install ./cmd/pacto
       # Build + validate the bundle (prep), then publish through the SAME shared
       # adapter staging uses — verify / absent-push / identical-skip / conflict-fail
       # / record — instead of inline state transitions.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,9 +220,7 @@ jobs:
         with:
           ref: ${{ needs.detect.outputs.source_sha }}
       - name: Install crane
-        run: |
-          go install github.com/google/go-containerregistry/cmd/crane@v0.20.2
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-crane
       - name: Install ORAS
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
       - name: Log in to GHCR
@@ -342,9 +340,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install crane
-        run: |
-          go install github.com/google/go-containerregistry/cmd/crane@v0.20.2
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-crane
       - name: Install ORAS
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
       - name: Install Cosign
@@ -407,9 +403,7 @@ jobs:
       - name: Install syft
         uses: anchore/sbom-action/download-syft@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
       - name: Install crane
-        run: |
-          go install github.com/google/go-containerregistry/cmd/crane@v0.20.2
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-crane
       - name: Install ORAS
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
       - name: Log in to GHCR
@@ -473,9 +467,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install crane (byte-exact immutability gate)
-        run: |
-          go install github.com/google/go-containerregistry/cmd/crane@v0.20.2
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-crane
       - name: Resume check (ledger)
         id: v
         run: |
@@ -545,9 +537,7 @@ jobs:
         with:
           version: v5.5.0
       - name: Install crane (content adoption reads the published manifest)
-        run: |
-          go install github.com/google/go-containerregistry/cmd/crane@v0.20.2
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-crane
       - name: Install ORAS
         # NOT for the Compose artifact — Compose publishes that (see the job
         # comment). For the release LEDGER, which this job reads below and writes
@@ -726,9 +716,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install crane
-        run: |
-          go install github.com/google/go-containerregistry/cmd/crane@v0.20.2
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-crane
       - name: Install ORAS
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
       - name: Install Cosign
@@ -803,10 +791,7 @@ jobs:
       - name: Install ORAS
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
       - name: Install crane
-        working-directory: .
-        run: |
-          go install github.com/google/go-containerregistry/cmd/crane@v0.20.2
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-crane
       - name: Log in to GHCR (Helm)
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
       - name: Log in to GHCR (Cosign/ORAS)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+        run: bash release/scripts/retry.sh go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
       # With -format sarif, govulncheck always exits 0 (findings live in the
       # SARIF), so gating happens in the "Fail on ..." step below.
       - name: Run govulncheck (SARIF)

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,20 @@ ARG TARGETARCH
 
 WORKDIR /src
 
-# Cache dependencies
+# Cache dependencies. `go mod download` is one network round trip per module
+# against proxy.golang.org and retries nothing itself, so a single dropped
+# connection fails the whole image build — that is what took ci-e2e-compose down
+# on 2026-09-11. release/scripts/retry.sh cannot be used here: it is not in this
+# stage's copied context. tests/release/workflow_tooling_test.go holds the inline
+# loop to the same contract.
 COPY go.mod go.sum ./
-RUN go mod download
+RUN set -eu; \
+    for attempt in 1 2 3 4 5; do \
+      if go mod download; then break; fi; \
+      if [ "$attempt" = 5 ]; then echo "go mod download failed after 5 attempts" >&2; exit 1; fi; \
+      echo "go mod download attempt $attempt failed; retrying in $((attempt * 5))s" >&2; \
+      sleep $((attempt * 5)); \
+    done
 
 # Build binary with version info
 ARG VERSION=dev

--- a/ci.mk
+++ b/ci.mk
@@ -309,7 +309,7 @@ ci-vet:
 
 ci-cyclo:
 	@echo "==> Checking cyclomatic complexity..."
-	go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
+	bash release/scripts/retry.sh go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
 	gocyclo -over 15 $$(find . -name '*.go' ! -path './vendor/*' ! -path './integrations/*' ! -path './tests/*' ! -name 'zz_generated*.go' ! -path './release/*')
 
 ci-lint:

--- a/integrations/kubernetes/Dockerfile
+++ b/integrations/kubernetes/Dockerfile
@@ -40,17 +40,42 @@ COPY integrations/kubernetes/go.mod integrations/kubernetes/go.sum integrations/
 COPY pkg/ pkg/
 COPY internal/ internal/
 COPY integrations/kubernetes/ integrations/kubernetes/
+# `retry` wraps the module downloads: each one is a network round trip per module
+# against proxy.golang.org, the go command retries none of them, and a single
+# dropped stream fails the image build. release/scripts/retry.sh is not reachable
+# from here — the COPY list above is this stage's whole context — so the loop is
+# inline, and tests/release/workflow_tooling_test.go holds it to the same contract.
+#
+# There is deliberately no `go work sync` in the workspace branch. It REWRITES the
+# member go.mod files from whatever source tree it can see, and the COPY list above
+# is a partial one (no cmd/, tests/ or examples/), so it drops requires those
+# directories are the only importers of. The `go build` that follows runs under the
+# default -mod=readonly and cannot put them back, turning a healthy tree into
+# "no required module provides package ...". The manifests are already correct as
+# committed; `go mod download all` needs nothing synced first.
 RUN set -eu; \
+    retry() { \
+      attempt=1; \
+      while true; do \
+        status=0; \
+        "$@" || status=$?; \
+        if [ "$status" -eq 0 ]; then return 0; fi; \
+        if [ "$attempt" -ge 5 ]; then echo "retry: '$*' failed 5 times; giving up" >&2; return "$status"; fi; \
+        echo "retry: attempt $attempt of '$*' exited $status; retrying in $((attempt * 5))s" >&2; \
+        sleep $((attempt * 5)); \
+        attempt=$((attempt + 1)); \
+      done; \
+    }; \
     LDFLAGS="-s -w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT} -X main.buildDate=${BUILD_DATE} -X main.dashboardImage=${DASHBOARD_IMAGE}"; \
     if [ -n "${RELEASE_BUILD}" ]; then \
       echo "release build: GOWORK=off against the published pinned core"; \
       cd integrations/kubernetes; \
-      GOWORK=off GOFLAGS=-mod=mod GOPROXY=https://proxy.golang.org,direct GOPRIVATE='github.com/trianalab/*' GONOSUMDB='github.com/trianalab/*' go mod download; \
+      retry env GOWORK=off GOFLAGS=-mod=mod GOPROXY=https://proxy.golang.org,direct GOPRIVATE='github.com/trianalab/*' GONOSUMDB='github.com/trianalab/*' go mod download; \
       CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GOWORK=off GOFLAGS=-mod=mod GOPROXY=https://proxy.golang.org,direct GOPRIVATE='github.com/trianalab/*' GONOSUMDB='github.com/trianalab/*' \
         go build -ldflags "${LDFLAGS}" -o /workspace/manager ./cmd; \
     else \
       echo "workspace build: go.work resolves the local core"; \
-      go work sync && go mod download all; \
+      retry go mod download all; \
       CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
         go build -ldflags "${LDFLAGS}" -o /workspace/manager ./integrations/kubernetes/cmd; \
     fi

--- a/integrations/kubernetes/Makefile
+++ b/integrations/kubernetes/Makefile
@@ -11,13 +11,23 @@ endef
 # $1 - target path with name of binary
 # $2 - package url which can be installed
 # $3 - specific version of package
+#
+# The install retries because `go install` does not: it is one network round
+# trip per module in the tool's graph, and a single dropped one fails the CI
+# leg. The loop is inline rather than release/scripts/retry.sh because this
+# module is also consumed standalone, where the repository root is not there.
 define go-install-tool
 @[ -f "$(1)-$(3)" ] && [ "$$(readlink -- "$(1)" 2>/dev/null)" = "$(1)-$(3)" ] || { \
 set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
 rm -f "$(1)" ;\
-GOBIN="$(LOCALBIN)" go install $${package} ;\
+for attempt in 1 2 3 4 5; do \
+  if GOBIN="$(LOCALBIN)" go install $${package}; then break; fi ;\
+  if [ "$$attempt" = 5 ]; then echo "go install $${package} failed after 5 attempts" >&2; exit 1; fi ;\
+  echo "go install $${package} attempt $$attempt failed; retrying in $$((attempt * 5))s" >&2 ;\
+  sleep $$((attempt * 5)) ;\
+done ;\
 mv "$(LOCALBIN)/$$(basename "$(1)")" "$(1)-$(3)" ;\
 } ;\
 ln -sf "$$(realpath "$(1)-$(3)")" "$(1)"

--- a/release/scripts/retry.sh
+++ b/release/scripts/retry.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# retry.sh COMMAND [ARG...] — run a command, retrying on failure with a linear
+# backoff, and exit with the last failure's status once the attempts run out.
+#
+# Every `go mod download` and `go install` in CI is one network round trip per
+# module against proxy.golang.org, and the go command has no retry of its own:
+# a single 5xx, a dropped HTTP/2 stream or a stalled connection fails the whole
+# step. That is not hypothetical. On 2026-09-11 it half-shipped the 3.3.0/5.4.0
+# release (run 34613593980 died fetching one module zip, after the tags were
+# already pushed), then inside the next hour it took out `ci-e2e-kind
+# (observation)` and `ci-e2e-compose` on a tree whose Go files nobody had
+# touched. Three failures, one cause, zero retries anywhere.
+#
+# The npm side of the same problem is already handled — ci.mk passes
+# --fetch-retries=5 to `npm ci`. This is the Go side of it.
+#
+# A shell script rather than a composite action because the callers are not all
+# workflows: ci.mk and release/scripts/verify-standalone.sh need it too, and a
+# Makefile cannot `uses:` anything. The two Dockerfiles cannot use it either —
+# their build context does not include this directory — so they carry the same
+# loop inline, and tests/release/workflow_tooling_test.go holds every one of
+# them to it.
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: retry.sh COMMAND [ARG...]" >&2
+  exit 2
+fi
+
+attempts=5
+attempt=1
+while true; do
+  status=0
+  "$@" || status=$?
+  if [ "$status" -eq 0 ]; then
+    exit 0
+  fi
+  if [ "$attempt" -ge "$attempts" ]; then
+    echo "retry: '$*' failed $attempts times; giving up" >&2
+    exit "$status"
+  fi
+  delay=$((attempt * 5))
+  echo "retry: attempt $attempt of '$*' exited $status; retrying in ${delay}s" >&2
+  sleep "$delay"
+  attempt=$((attempt + 1))
+done

--- a/release/scripts/verify-standalone.sh
+++ b/release/scripts/verify-standalone.sh
@@ -41,7 +41,7 @@ perl -i -pe "s{github.com/trianalab/pacto/v3 v[0-9][0-9.]*}{github.com/trianalab
 cd "$WORK/op"
 export GIT_CONFIG_GLOBAL="$TMPGIT" GIT_CONFIG_SYSTEM=/dev/null GOWORK=off GOFLAGS=-mod=mod \
        GOPROXY=https://proxy.golang.org,direct GOPRIVATE='github.com/trianalab/*' GONOSUMDB='github.com/trianalab/*' GOMODCACHE="$(mktemp -d)"
-echo "go mod download (external, GOWORK=off)..."; go mod download github.com/trianalab/pacto/v3
+echo "go mod download (external, GOWORK=off)..."; bash "$ROOT"/release/scripts/retry.sh go mod download github.com/trianalab/pacto/v3
 echo "go build ./... (standalone operator, no go.work, no replace)..."
 go build ./... && go build -o /dev/null ./cmd
 echo "STANDALONE-VERIFY OK: operator module builds against published core v${NEXT}, GOWORK=off, replace=0"

--- a/tests/release/operator_dockerfile_test.go
+++ b/tests/release/operator_dockerfile_test.go
@@ -57,3 +57,42 @@ func TestOperatorDockerfileReleaseBuildResolvesFreshCoreWithoutDisablingTheProxy
 		}
 	}
 }
+
+// TestNoDockerBuildSyncsTheWorkspace bans `go work sync` inside an image build.
+//
+// It rewrites the member go.mod files to match the packages it can see, and what
+// a Dockerfile can see is a COPY list, never the whole repository. The operator
+// image copies pkg/, internal/ and integrations/kubernetes/ — not cmd/, tests/ or
+// examples/ — so a sync there drops every require those directories are the sole
+// importers of. Run against this tree it removes go-md2man and blackfriday; run
+// against the full tree it removes huma. The `go build` that follows runs under
+// the default -mod=readonly and cannot put anything back, so the manifests are
+// rewritten wrong and the build dies with "no required module provides package".
+//
+// Nothing needs it: the committed go.mod files are already correct, which is what
+// the standalone-verify and drift gates exist to keep true, and `go mod download`
+// resolves fine without a sync. It is a rewrite of checked-in state performed
+// from a deliberately partial view of the repository — the only question is when
+// it bites, not whether.
+func TestNoDockerBuildSyncsTheWorkspace(t *testing.T) {
+	root := repoRoot(t)
+
+	for _, rel := range []string{
+		"Dockerfile",
+		filepath.Join("integrations", "kubernetes", "Dockerfile"),
+	} {
+		b, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		for i, line := range strings.Split(string(b), "\n") {
+			// Prose explaining the ban may name it; a command line may not.
+			if strings.HasPrefix(strings.TrimSpace(line), "#") {
+				continue
+			}
+			if strings.Contains(line, "go work sync") {
+				t.Errorf("%s:%d runs `go work sync` — it rewrites go.mod from the COPY list, which is a partial source tree, and the -mod=readonly build that follows cannot re-add what it dropped. The committed manifests are already correct; delete the sync.", rel, i+1)
+			}
+		}
+	}
+}

--- a/tests/release/publish_immutability_test.go
+++ b/tests/release/publish_immutability_test.go
@@ -32,8 +32,11 @@ func TestDemoBundlesImmutabilityGateFailsClosedWithoutCrane(t *testing.T) {
 	if !ok {
 		t.Fatal("release.yml has no demo-bundles job")
 	}
-	if !strings.Contains(demo, "cmd/crane") {
-		t.Error("demo-bundles job does not install crane, so the byte-exact immutability gate never runs")
+	// Ask toolInstaller rather than matching a literal, so the day crane's
+	// installer changes again this assertion moves with it instead of quietly
+	// looking for a string no workflow contains any more.
+	if !strings.Contains(demo, toolInstaller["crane"]) {
+		t.Errorf("demo-bundles job does not install crane (no %q), so the byte-exact immutability gate never runs", toolInstaller["crane"])
 	}
 }
 

--- a/tests/release/workflow_tooling_test.go
+++ b/tests/release/workflow_tooling_test.go
@@ -415,6 +415,172 @@ func TestTheReleasePathNeverCompilesThirdPartyToolingFromSource(t *testing.T) {
 	}
 }
 
+// goFetchRE is a Go command whose work is network round trips against
+// proxy.golang.org — one per module in the graph it resolves.
+var goFetchRE = regexp.MustCompile(`\bgo (?:mod download|install)\b`)
+
+// quotedShellStringRE is a shell string literal. `go install …` inside one is a
+// hint printed at a human ("crane is required. Install it: go install …"), not a
+// command anything runs.
+var quotedShellStringRE = regexp.MustCompile(`"[^"]*"|'[^']*'`)
+
+// retryWrapperRE is the two shapes a wrapped fetch takes: release/scripts/retry.sh
+// where the script is reachable, and the inline `retry` shell function the
+// Dockerfiles define because it is not.
+var retryWrapperRE = regexp.MustCompile(`(?:^|[\s;&|(/])retry(?:\.sh)?\s`)
+
+// retryLoopRE is the open-coded loop used where there is neither a script nor a
+// function to call — the root Dockerfile's RUN and the operator Makefile's
+// go-install-tool define.
+var retryLoopRE = regexp.MustCompile(`for attempt in 1 2 3 4 5`)
+
+// classifyGoFetch reads one command list and reports whether it fetches Go
+// modules over the network, and if so whether the fetch is retried.
+func classifyGoFetch(cmd string) (fetches, retried bool) {
+	bare := quotedShellStringRE.ReplaceAllString(cmd, "")
+	if !goFetchRE.MatchString(bare) {
+		return false, false
+	}
+	return true, retryWrapperRE.MatchString(bare) || retryLoopRE.MatchString(bare)
+}
+
+// ciFetchSurfaces is every file whose shell CI runs and that could reach the
+// module proxy. Globbed rather than listed so a new workflow, action or release
+// script is covered the day it lands.
+func ciFetchSurfaces(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	for _, pat := range [][]string{
+		{".github", "workflows", "*.yml"},
+		{".github", "actions", "*", "action.yml"},
+		{"release", "scripts", "*.sh"},
+		{"release", "orchestrator", "*.sh"},
+		{"tests", "acceptance", "*", "*.sh"},
+		{"Dockerfile"},
+		{"Makefile"},
+		{"ci.mk"},
+		{"integrations", "kubernetes", "Dockerfile"},
+		{"integrations", "kubernetes", "Makefile"},
+		{"integrations", "kubernetes", "ci.mk"},
+	} {
+		matches, err := filepath.Glob(filepath.Join(append([]string{root}, pat...)...))
+		if err != nil {
+			t.Fatalf("glob %v: %v", pat, err)
+		}
+		out = append(out, matches...)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// TestEveryGoNetworkFetchInCIRetries is the rule 2026-09-11 bought.
+//
+// The go command retries nothing. `go mod download` and `go install` are one
+// network round trip per module against proxy.golang.org, and a single 5xx, a
+// dropped HTTP/2 stream or a stalled connection fails the whole step. In one
+// afternoon that took out three separate things on a tree nobody had touched:
+// release run 34613593980 died fetching a module zip for crane AFTER the tags
+// were pushed, half-shipping 3.3.0/5.4.0; `ci-e2e-kind (observation)` died in
+// the operator image build; and `ci-e2e-compose` died at the root Dockerfile's
+// `RUN go mod download`. Three failures, one cause, zero retries anywhere.
+//
+// The npm half of the same problem was solved long ago — ci.mk passes
+// --fetch-retries=5 to `npm ci`. This is the Go half, and it is a gate rather
+// than a habit because the sites are spread across two Dockerfiles, three
+// makefiles, four workflows and a release script, and the next one gets added by
+// someone who never read this file.
+//
+// Retrying is the right shape for CI specifically. A publish job is different:
+// there the rule is stronger — do not compile third-party source at all, see
+// TestTheReleasePathNeverCompilesThirdPartyToolingFromSource — because a retry
+// that eventually gives up still leaves an irreversible half-publish behind.
+//
+// Two ceilings, stated so nobody trusts this further than it reaches. Continued
+// lines are joined, so the unit is one shell command list, not one source line:
+// a RUN that retried one fetch and not a second would pass. And `go build`,
+// `go test` and `go run` download modules too; they are out of scope because
+// every CI job that runs them runs a retried `go mod download` first, which
+// leaves the cache warm.
+func TestEveryGoNetworkFetchInCIRetries(t *testing.T) {
+	root := repoRoot(t)
+
+	found := 0
+	for _, path := range ciFetchSurfaces(t, root) {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			t.Fatalf("rel %s: %v", path, err)
+		}
+		for _, cmd := range commandLines(string(b)) {
+			// `@#` is a make recipe comment; commandLines only knows the bare form.
+			if strings.HasPrefix(strings.TrimSpace(cmd), "@#") {
+				continue
+			}
+			fetches, retried := classifyGoFetch(cmd)
+			if !fetches {
+				continue
+			}
+			found++
+			if retried {
+				continue
+			}
+			t.Errorf("%s fetches Go modules without a retry: %s\n"+
+				"Wrap it in release/scripts/retry.sh, or — where that path is not reachable, as in the two Dockerfiles and the standalone operator module — use the same 5-attempt loop inline. "+
+				"Unretried, one dropped connection to proxy.golang.org fails the step, and on the release path it half-ships.", rel, elide(cmd))
+		}
+	}
+	// Every known site plus a little slack. A refactor that quietly stops
+	// matching would otherwise leave this green while checking nothing.
+	if found < 10 {
+		t.Errorf("only %d Go module fetches found across the CI surfaces — there are at least 10; the scan stopped matching and this gate is now vacuous", found)
+	}
+}
+
+// elide keeps a failure message readable when the offending command is a joined
+// multi-line RUN.
+func elide(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if len(s) > 160 {
+		return s[:160] + "…"
+	}
+	return s
+}
+
+// TestTheRetryGateBitesOnABareFetch proves the classifier above can fail, and
+// fails on the exact three lines that broke on 2026-09-11 rather than on a
+// strawman. Without it, a regex that quietly stopped matching would leave the
+// gate green forever.
+func TestTheRetryGateBitesOnABareFetch(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		cmd              string
+		fetches, retried bool
+	}{
+		{"the root Dockerfile as it failed", "RUN go mod download", true, false},
+		{"the operator Dockerfile as it failed", "go work sync && go mod download all", true, false},
+		{"the release path as it failed", "go install github.com/google/go-containerregistry/cmd/crane@v0.20.2", true, false},
+		{"wrapped in the shared script", "bash release/scripts/retry.sh go mod download", true, true},
+		{"wrapped in the inline function", "retry go mod download all", true, true},
+		{"wrapped in the inline function with env", "retry env GOWORK=off go mod download", true, true},
+		{"wrapped in the inline loop", "for attempt in 1 2 3 4 5; do if go mod download; then break; fi; done", true, true},
+		{"a hint printed at a human", `echo "crane is required. Install it: go install github.com/google/go-containerregistry/cmd/crane@latest"`, false, false},
+		{"not a fetch at all", "go build ./...", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fetches, retried := classifyGoFetch(tc.cmd)
+			if fetches != tc.fetches {
+				t.Errorf("classifyGoFetch(%q) fetches = %v, want %v", tc.cmd, fetches, tc.fetches)
+			}
+			if retried != tc.retried {
+				t.Errorf("classifyGoFetch(%q) retried = %v, want %v", tc.cmd, retried, tc.retried)
+			}
+		})
+	}
+}
+
 // TestTheToolingGateBitesWhenAnInstallStepIsDeleted proves the rule above can
 // actually fail, on the exact edit that caused the incident: delete demo-compose's
 // ORAS install and the job still reads the ledger, so ORAS must still be reported

--- a/tests/release/workflow_tooling_test.go
+++ b/tests/release/workflow_tooling_test.go
@@ -55,9 +55,14 @@ import (
 // for it. The key is the command name as it appears on a command line. The value
 // is the installer's identity WITHOUT its pin — the pin is checked separately,
 // and by consistency, so bumping it stays a one-line change.
+//
+// Every value here names something that hands over a PREBUILT binary. A Go
+// module path would not: see
+// TestTheReleasePathNeverCompilesThirdPartyToolingFromSource for the release
+// that cost.
 var toolInstaller = map[string]string{
 	"oras":   "oras-project/setup-oras",
-	"crane":  "github.com/google/go-containerregistry/cmd/crane",
+	"crane":  "./.github/actions/setup-crane",
 	"cosign": "sigstore/cosign-installer",
 	"syft":   "anchore/sbom-action/download-syft",
 	"helm":   "azure/setup-helm",
@@ -277,6 +282,10 @@ func TestToolInstallersArePinnedAndIdentical(t *testing.T) {
 
 	for _, tool := range slices.Sorted(maps.Keys(toolInstaller)) {
 		installer := toolInstaller[tool]
+		if strings.HasPrefix(installer, "./") {
+			checkInTreeInstaller(t, root, workflows, tool, installer)
+			continue
+		}
 		seen := map[string][]string{} // pin -> where
 		for _, w := range workflows {
 			for i, line := range strings.Split(w.text, "\n") {
@@ -304,6 +313,103 @@ func TestToolInstallersArePinnedAndIdentical(t *testing.T) {
 		for _, pin := range slices.Sorted(maps.Keys(seen)) {
 			if !shape.MatchString(pin) {
 				t.Errorf("%s is installed from %s@%s (%s) — a release must not resolve its tooling through a movable reference; pin a %s", tool, installer, pin, strings.Join(seen[pin], ", "), label)
+			}
+		}
+	}
+}
+
+// inTreeVersionRE finds the version an in-tree installer pins, wherever the
+// action spells it: `CRANE_VERSION: v0.20.2` and anything shaped like it.
+var inTreeVersionRE = regexp.MustCompile(`_VERSION:\s*"?(v?\d+\.\d+\.\d+)"?`)
+
+// checkInTreeInstaller is the pin rule for an installer that lives in this
+// repository rather than in someone else's. Such an action needs no `@pin`: it
+// is read out of the same checkout as the workflow that calls it, so the two
+// move together by construction and cannot partially bump. What it does need is
+// exactly one version inside it — the pin did not disappear when it moved out of
+// the workflow, and a second one in the action file would be the same partial
+// bump in a new place.
+func checkInTreeInstaller(t *testing.T, root string, workflows []workflow, tool, installer string) {
+	t.Helper()
+
+	var used []string
+	for _, w := range workflows {
+		for i, line := range strings.Split(w.text, "\n") {
+			if strings.Contains(line, "uses:") && strings.Contains(line, installer) {
+				used = append(used, w.name+":"+strconv.Itoa(i+1))
+			}
+		}
+	}
+	if len(used) == 0 {
+		t.Errorf("no workflow installs %s via %s — either the installer changed or the tool is gone; update toolInstaller so the closure gate keeps meaning something", tool, installer)
+		return
+	}
+
+	path := filepath.Join(root, filepath.FromSlash(strings.TrimPrefix(installer, "./")), "action.yml")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Errorf("%d workflow steps use %s but %s is unreadable (%v) — a `uses: ./…` that resolves to nothing fails at run time, in a publish job", len(used), installer, path, err)
+		return
+	}
+	pins := map[string]bool{}
+	for _, m := range inTreeVersionRE.FindAllStringSubmatch(string(b), -1) {
+		pins[m[1]] = true
+	}
+	switch len(pins) {
+	case 1: // the one thing we want
+	case 0:
+		t.Errorf("%s pins no version of %s — the pin moved out of the workflows and has to land somewhere; a release must not resolve its tooling through a movable reference", path, tool)
+	default:
+		t.Errorf("%s pins %d different versions of %s (%s) — a partial bump, in the one file that was supposed to make bumping atomic", path, len(pins), tool, strings.Join(slices.Sorted(maps.Keys(pins)), " vs "))
+	}
+}
+
+// goInstallRE finds a `go install` and the package it compiles.
+var goInstallRE = regexp.MustCompile(`\bgo install\s+([^\s;&|]+)`)
+
+// TestTheReleasePathNeverCompilesThirdPartyToolingFromSource is the rule release
+// run 34613593980 bought.
+//
+// crane was the only tool in the release path built from source at publish time.
+// oras, cosign, syft and helm all arrive as prebuilt binaries from pinned
+// installers; crane alone ran `go install …/cmd/crane@v0.20.2`, which fetches
+// roughly twenty third-party module zips, in seven publish jobs, every release.
+// One of those fetches — docker/distribution, from proxy.golang.org — returned
+// an HTTP/2 INTERNAL_ERROR, and the release half-shipped: operator-image failed,
+// operator-chart and the GitHub Release job skipped behind it, and 3.3.0/5.4.0
+// existed as Go tags with no binaries and no operator artifacts.
+//
+// A publish job is a transaction. Compiling a tool inside one turns every
+// transitive dependency of that tool into a way for the transaction to die
+// halfway, in exchange for a binary its upstream already publishes. So: nothing
+// in release.yml compiles third-party source.
+//
+// Scoped to release.yml deliberately. `go install` elsewhere — govulncheck in
+// security.yml, helm-docs and kind in ci.yml — fails a check rather than
+// stranding a release, and a red check is not an irreversible half-publish.
+func TestTheReleasePathNeverCompilesThirdPartyToolingFromSource(t *testing.T) {
+	root := repoRoot(t)
+
+	for _, tool := range slices.Sorted(maps.Keys(toolInstaller)) {
+		if strings.HasPrefix(toolInstaller[tool], "github.com/") {
+			t.Errorf("toolInstaller[%q] is the Go module path %q — that is a source build; point it at an installer that hands over a prebuilt binary", tool, toolInstaller[tool])
+		}
+	}
+
+	jobs := workflowJobs(t, root, "release.yml")
+	if len(jobs) == 0 {
+		t.Fatal("release.yml parsed to no jobs — this gate would pass vacuously")
+	}
+	for _, name := range slices.Sorted(maps.Keys(jobs)) {
+		for _, l := range commandLines(jobs[name].runs()) {
+			for _, m := range goInstallRE.FindAllStringSubmatch(l, -1) {
+				pkg := strings.Trim(m[1], `"'`)
+				if strings.HasPrefix(pkg, "./") || strings.HasPrefix(pkg, "../") {
+					continue // this repository's own binary — there is no prebuilt one to fetch instead.
+				}
+				t.Errorf("release.yml job %q runs `go install %s` — a publish job must not compile third-party source. "+
+					"Every module that build downloads is one more way for the transaction to die after an irreversible push; "+
+					"install a prebuilt binary the way oras, cosign, syft, helm and crane are installed.", name, pkg)
 			}
 		}
 	}


### PR DESCRIPTION
## What broke

Release run [34613593980](https://github.com/TrianaLab/pacto/actions/runs/34613593980) (transaction `f93d13f5aaf491e5`) died in `Install crane`:

```
github.com/docker/distribution@v2.8.2+incompatible: read
"https://proxy.golang.org/.../v2.8.2+incompatible.zip": stream error;
INTERNAL_ERROR; received from peer
```

`operator-image` failed, `operator-chart` and the GitHub Release job skipped behind it, and 3.3.0 / 5.4.0 existed as Go tags with no CLI binaries and no operator artifacts. A recovery dispatch published the missing three units; the release is whole.

## Why it is not a flake

The fetch was transient. The exposure was systematic.

crane was the only tool in this repository's publish path built from source at release time. oras, cosign, syft and helm all arrive as prebuilt binaries from pinned installers; crane alone ran `go install github.com/google/go-containerregistry/cmd/crane@v0.20.2`, which compiles go-containerregistry and roughly twenty third-party module zips — in seven release jobs, every release. Well over a hundred network operations per release, each one a way for an irreversible transaction to die halfway, all to produce a binary upstream already publishes.

## The change

A composite action at `.github/actions/setup-crane` replaces all nine `go install` sites (seven in `release.yml`, two in `ci.yml`):

- downloads the pinned upstream release tarball
- verifies it against a sha256 recorded **in the action**, not fetched alongside the artifact — a checksum that arrives over the same connection as the file proves only that the two agree with each other
- retries the one network operation that is left, five attempts with linear backoff
- picks the right build for the runner arch, and fails loudly on an arch it has no pin for

Four release jobs (`ledger-init`, `dashboard-image`, `operator-image`, `operator-chart`) had no `setup-go` step at all — they were building crane with the runner's preinstalled Go. They now need Go nowhere.

Both pinned digests were checked against upstream `checksums.txt`, and the tarball's `crane` member was extracted and confirmed to be a static Linux ELF binary.

## The gates

`TestTheReleasePathNeverCompilesThirdPartyToolingFromSource` fails any `release.yml` job that `go install`s a package outside this module. `go install ./cmd/pacto` stays — there is no prebuilt pacto to fetch instead. Scoped to `release.yml` deliberately: `go install` in `security.yml` and `ci.yml` fails a check rather than stranding a release, and a red check is not an irreversible half-publish.

`TestToolInstallersArePinnedAndIdentical` now understands an in-tree installer. It needs no `@pin`, because it is read out of the same checkout as the workflow that calls it and the two cannot drift apart. It does need exactly one version inside it — otherwise the partial bump the gate prevents in workflows just reappears in the action.

Every branch of both gates was mutation-tested: reintroducing a source build, pinning two versions, pinning `latest`, deleting the action file, and pointing the workflows at a different installer each produce the intended failure. The fourth of those caught a real slip while this branch was being written — a stray `git checkout` reverted the `ci.yml` edits, and `TestEveryJobInstallsTheCLIsItsScriptsRun` named both affected jobs.

`TestDemoBundlesImmutabilityGateFailsClosedWithoutCrane` matched the literal `cmd/crane` to decide whether the job installs crane. It now asks `toolInstaller["crane"]`, so the next installer change moves it too instead of leaving it searching for a string no workflow contains.

## The same failure, three more places

Installing crane from a prebuilt binary removes the largest source build from the publish path. It does not fix the thing underneath it, which surfaced twice more within the hour, on a tree whose Go files nobody had touched:

- `ci-e2e-kind (observation)` died in the operator image build
- `ci-e2e-compose` died at the root `Dockerfile`'s `RUN go mod download`

One cause, three failures: the go command retries nothing. `go mod download` and `go install` are one network round trip per module against proxy.golang.org, so a single 5xx, a dropped HTTP/2 stream or a stalled connection fails the whole step. The npm half of this was solved long ago — `ci.mk` passes `--fetch-retries=5` to `npm ci`. This is the Go half.

`release/scripts/retry.sh` runs a command with a linear backoff over five attempts and exits with the last failure's status. Callers that can reach it use it: the `ci` composite action, helm-docs and kind in `ci.yml`, govulncheck in `security.yml`, gocyclo in `ci.mk`, `go install ./cmd/pacto` in `pacto.yml` and `release.yml`, and `verify-standalone.sh`.

Three callers cannot reach it and carry the same five-attempt loop inline: the two Dockerfiles, whose build context does not include the script, and the operator Makefile's `go-install-tool`, which has to keep working when that module is consumed standalone.

Retrying is the right shape for CI specifically. A publish job is different, and that is why the crane rule above is the stronger one: a retry that eventually gives up still leaves an irreversible half-publish behind.

## `go work sync` is gone from the operator image

A separate defect, found while reading the failing build. `go work sync` rewrites the member `go.mod` files to match the packages it can see, and what a Dockerfile can see is a COPY list — `pkg/`, `internal/`, `integrations/kubernetes/`, never `cmd/`, `tests/` or `examples/`. Every require those directories are the sole importers of gets dropped, and the `go build` that follows runs under the default `-mod=readonly` and cannot put it back.

Reproduced twice: run against the full tree the sync drops `huma/v2`; run against the Dockerfile's COPY set it drops `go-md2man` and `blackfriday`. I could not make it drop `go-containerregistry`, so this is **not** claimed as the cause of the `observation` failure. It is removed because it rewrites checked-in state from a deliberately partial view of the repository, the committed manifests are already correct, and the image builds green without it.

Both images were rebuilt locally with `--no-cache` after the change, and the operator Makefile's install loop was exercised for real by deleting the cached `controller-gen` and reinstalling it.

## Two more gates

`TestEveryGoNetworkFetchInCIRetries` walks every workflow, composite action, makefile, Dockerfile and release script, and requires each Go module fetch to be wrapped — in `retry.sh` where that is reachable, in the inline loop where it is not. It states its own ceilings: continued lines are joined, so the unit is one shell command list rather than one source line, and `go build` / `go test` / `go run` are out of scope because every job that runs them runs a retried `go mod download` first.

`TestNoDockerBuildSyncsTheWorkspace` bans `go work sync` in either Dockerfile.

Both were mutation-tested against the exact lines that failed: restoring `go work sync && go mod download all` and unwrapping the composite action's `go mod download` each produce the intended failure, and the classifier is unit-tested against all three failing forms, all four wrapped forms, an `echo`'d install hint and a plain `go build`.

## Not included

No changeset. Nothing here ships in a published artifact.

