### PR TITLE
fix(oci): treat a lost cache-commit race as the success it is

### DIFF
--- a/.changeset/oci-cache-concurrent-commit.md
+++ b/.changeset/oci-cache-concurrent-commit.md
@@ -1,0 +1,19 @@
+---
+"@pacto/core": patch
+---
+
+Stop the OCI bundle cache from reporting a failure when a concurrent pull of the
+same reference commits first.
+
+A cache entry is built in a staging directory and swapped into place with one
+rename, so a reader sees a whole entry or none. Two pulls of the same reference
+aim at the same destination, though, and nothing serializes them — the second
+pull is usually a second `pacto` process sharing one cache directory. Both clear
+the destination, one rename lands, and the loser's fails onto the winner's fresh
+entry with `directory not empty`.
+
+Nothing was wrong: the entry the losing pull set out to write was on disk, put
+there whole by the other one. But the loser reported the rename error, and the
+caller logs it, so a healthy parallel pull told the user `could not cache the
+pulled bundle`. The commit now asks the filesystem what is actually there and
+treats a lost race as the success it was.

--- a/pkg/oci/cache.go
+++ b/pkg/oci/cache.go
@@ -487,10 +487,65 @@ func (c *CachedStore) writeCacheEntry(dir string, rec CachedRef, bundle *contrac
 	}
 	// A directory rename cannot overwrite a directory, so the old entry goes
 	// first. Absence is coherent; a new bundle beside a stale sidecar is not. A
-	// RemoveAll that fails needs no report of its own: the rename then fails and
-	// says so, and what survives is the coherent entry that was already there.
-	_ = os.RemoveAll(dir)
-	return os.Rename(staging, dir)
+	// RemoveAll that fails needs no report of its own: the rename below fails
+	// and says so, and what survives is the coherent entry that was already
+	// there.
+	//
+	// Nothing serializes two pulls of the same ref, and a mutex would not help
+	// if it did -- the other pull is usually a second `pacto` process sharing
+	// one cache directory. They aim at the SAME entry, both clear it, one lands
+	// its rename, and the loser's fails onto the winner's fresh entry:
+	// ENOTEMPTY on Linux, EEXIST on macOS. Neither errno is worth matching on.
+	// Ask the filesystem what is there instead, because what is there is the
+	// entry this call set out to write, put down whole by somebody else.
+	// Reporting that as a failure reports a cache write that succeeded -- and
+	// the caller LOGS the report, so a healthy concurrent pull told the user
+	// its cache was broken. It surfaced in tests/integration, whose runner
+	// gives the command one buffer for both streams: the warning landed in
+	// front of a `pacto diff --output json` payload and the parse failed. The
+	// CLI logs to stderr, so no real invocation's JSON was ever polluted -- the
+	// warning itself was the defect.
+	//
+	// Both observations race in turn: a third committer's RemoveAll can empty
+	// the directory between the failed rename and the look. So this retries. A
+	// lost round means some other committer finished a whole entry, which is
+	// progress no matter who made it, and the committers are finite -- the loop
+	// is a bound on an event that is already converging, not a spin.
+	//
+	// If two pulls disagree about the bytes (a mutable tag moved between them)
+	// the winner's survive. Last writer wins is what a mutable tag already
+	// means, and every reader still sees one whole entry or none.
+	var commitErr error
+	for range commitAttempts {
+		_ = os.RemoveAll(dir)
+		if commitErr = os.Rename(staging, dir); commitErr == nil {
+			return nil
+		}
+		if entryIsCommitted(dir) {
+			return nil
+		}
+	}
+	return commitErr
+}
+
+// commitAttempts bounds the retry in [CachedStore.writeCacheEntry]. Losing a
+// round needs two separate races to land inside two adjacent syscalls, so the
+// bound is about terminating on a genuinely stuck destination -- one this
+// process cannot empty, say -- rather than about how many writers there are.
+const commitAttempts = 5
+
+// entryIsCommitted reports whether dir holds both files of a whole entry. Only
+// the single rename in [CachedStore.writeCacheEntry] ever puts them there
+// together, so finding both regular files means some committer finished: there
+// is no half-written state this can mistake for a complete one.
+func entryIsCommitted(dir string) bool {
+	for _, f := range []string{CachedBundleFile, CachedRefFile} {
+		st, err := os.Stat(filepath.Join(dir, f))
+		if err != nil || !st.Mode().IsRegular() {
+			return false
+		}
+	}
+	return true
 }
 
 // stageCacheEntry writes both files of an entry into an uncommitted directory.

--- a/pkg/oci/cache_internal_test.go
+++ b/pkg/oci/cache_internal_test.go
@@ -265,6 +265,107 @@ func TestWriteCacheEntry_FailedCommitsAreReported(t *testing.T) {
 	})
 }
 
+// Nothing serializes two pulls of the same ref -- in the case that produced
+// this test they were parallel `pacto` invocations sharing one cache dir. They
+// commit to the same entry directory, one rename wins, and every loser used to
+// come back with `rename ...: directory not empty` for a cache write that had
+// in fact just been made by somebody else. The caller logs that, so a healthy
+// concurrent pull told the user its cache was broken -- and in tests/integration,
+// whose runner hands the command one buffer for both streams, the warning landed
+// in front of a `pacto diff --output json` payload and the parse failed.
+func TestWriteCacheEntry_ConcurrentCommitsOfTheSameEntryAllSucceed(t *testing.T) {
+	root := t.TempDir()
+	c := &CachedStore{cacheDir: filepath.Join(root, "oci")}
+	dir := filepath.Join(c.cacheDir, "_v2", "reg%3A5000", "demo", "svc", "1.0.0")
+	rec := CachedRef{Ref: "reg:5000/demo/svc:1.0.0", Digest: "sha256:aaa"}
+
+	const writers = 24
+	start := make(chan struct{})
+	errs := make([]error, writers)
+	var wg sync.WaitGroup
+	for i := range errs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs[i] = c.writeCacheEntry(dir, rec, markedBundle())
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("concurrent commit %d reported a failure for an entry that was written: %v", i, err)
+		}
+	}
+	if !entryIsCommitted(dir) {
+		t.Error("after 24 concurrent commits the entry is not on disk")
+	}
+}
+
+// The race above is tolerated by asking what is on disk, not by ignoring the
+// rename error -- so a commit that fails for any OTHER reason must still say so.
+func TestWriteCacheEntry_ALostRenameIsOnlyForgivenWhenTheEntryIsThere(t *testing.T) {
+	rec := CachedRef{Ref: "reg:5000/demo/svc:1.0.0", Digest: "sha256:aaa"}
+
+	// A directory the process cannot empty stands in for the winner's entry: the
+	// RemoveAll leaves it, so the rename hits an occupied destination exactly as
+	// it does when another committer got there first.
+	occupied := func(t *testing.T, contents map[string]string) (*CachedStore, string) {
+		t.Helper()
+		root := t.TempDir()
+		c := &CachedStore{cacheDir: filepath.Join(root, "oci")}
+		dir := filepath.Join(c.cacheDir, "svc", "1.0.0")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for name, body := range contents {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := os.Chmod(dir, 0o500); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+		return c, dir
+	}
+
+	t.Run("a whole entry is already there", func(t *testing.T) {
+		c, dir := occupied(t, map[string]string{CachedBundleFile: "tgz", CachedRefFile: "{}"})
+		if err := c.writeCacheEntry(dir, rec, markedBundle()); err != nil {
+			t.Errorf("a commit that lost to a finished one reported %v, want success", err)
+		}
+	})
+
+	t.Run("what is there is not an entry", func(t *testing.T) {
+		c, dir := occupied(t, map[string]string{"stray": "x"})
+		if err := c.writeCacheEntry(dir, rec, markedBundle()); err == nil {
+			t.Error("a commit blocked by something that is not a cache entry reported success")
+		}
+	})
+
+	t.Run("the bundle is a directory wearing an entry's name", func(t *testing.T) {
+		root := t.TempDir()
+		c := &CachedStore{cacheDir: filepath.Join(root, "oci")}
+		dir := filepath.Join(c.cacheDir, "svc", "1.0.0")
+		if err := os.MkdirAll(filepath.Join(dir, CachedBundleFile), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, CachedRefFile), []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(dir, 0o500); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+		if err := c.writeCacheEntry(dir, rec, markedBundle()); err == nil {
+			t.Error("a directory named bundle.tar.gz was accepted as a committed entry")
+		}
+	})
+}
+
 func TestPinRefToDigest_DropsWhateverTheRefAlreadyPins(t *testing.T) {
 	for _, tc := range []struct{ ref, want string }{
 		{"localhost:5000/demo/svc:1.0.0", "localhost:5000/demo/svc@sha256:new"},


### PR DESCRIPTION
## The symptom

`ci-engine` went red on an unrelated PR:

```
diff_test.go:309: expected valid JSON output, got: time=... level=WARN
msg="could not cache the pulled bundle" ref=127.0.0.1:37703/redis-pacto:1.0.0
error="rename /tmp/pacto-e2e-cache-.../oci/_v2/127.0.0.1%3A37703/redis-pacto/1.0.0:
directory not empty"
{ ...the JSON the test wanted... }
```

## The bug

A cache entry is two files a reader has to agree about, so `writeCacheEntry` stages them outside the walked tree and swaps them in with one rename — a reader sees a whole entry or none.

Two pulls of the same reference aim at the same destination directory, and nothing serializes them. A mutex would not help if it did: the other pull is usually a second `pacto` process sharing one cache directory. Both clear the destination, one rename lands, and the loser's fails onto the winner's fresh entry — `ENOTEMPTY` on Linux, `EEXIST` on macOS.

Nothing is wrong when that happens. The entry the losing call set out to write is on disk, written whole by the other committer. But the loser returned the rename error, `pullAndCache` logs it, and a perfectly healthy parallel pull told the user its cache was broken.

Reproduced deterministically: 24 goroutines committing the same entry, several failures every run, both errno flavours.

## The fix

Ask the filesystem what is there rather than matching an errno, and retry.

The look races too — a third committer's `RemoveAll` can empty the directory between the failed rename and the check — so the commit retries a bounded number of times. Losing a round means somebody else finished a whole entry, which is progress no matter who made it; the bound is there to terminate on a destination this process genuinely cannot claim, not on contention.

If two pulls disagree about the bytes because a mutable tag moved between them, the winner's survive. Last writer wins is what a mutable tag already means, and every reader still sees one whole entry or none.

## Verification

- The 24-writer concurrency test fails every run before the change; 250 runs under `-race` after it, all clean.
- Three deterministic cases pin the acceptance rule: a whole entry already in place is forgiven, a destination holding something that is not an entry still errors, and a directory wearing `bundle.tar.gz`'s name is not mistaken for one.
- `pkg/oci` coverage stays at 100.0%.
- The full `tests/integration` suite passes, and the two previously failing test functions pass 20 consecutive runs.

## Scope

Only the false failure is in scope. The CLI logs to stderr, so no real invocation's JSON was ever polluted — `tests/integration` gives the command one buffer for both streams, which is why the warning showed up inside a parsed payload. That harness detail is left alone: it is what let the defect be seen.
