### PR TITLE
fix(release): retry the fetches and refuse the unreadable reads in the publish window

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,11 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
+      # docs-generate shells out to `go run ./cmd/pacto --help`. This job is
+      # pre-tag, so a failure here is cheap, but the gate is uniform across
+      # release.yml rather than carrying an exception nobody would maintain.
+      - name: Warm the module cache (retried)
+        run: bash release/scripts/retry.sh go mod download
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.12'
@@ -458,6 +463,10 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
+      # publish-demo-bundles.sh runs `go run ./publishbundles` twice, after the
+      # tag is already pushed. Same reason as the `release` job above.
+      - name: Warm the module cache (retried)
+        run: bash release/scripts/retry.sh go mod download
       - name: Install ORAS
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
       - name: Log in to GHCR
@@ -532,6 +541,10 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
+      # `go run ./tests/acceptance/scenario/project` projects the application
+      # this job publishes, after the tag is pushed. Same reason as `release`.
+      - name: Warm the module cache (retried)
+        run: bash release/scripts/retry.sh go mod download
       - name: Install Docker Compose (it publishes this unit)
         uses: docker/setup-compose-action@4eb059ff7f16592f9c84d5ca339c53cb7c5064e2 # v2.3.0
         with:
@@ -900,6 +913,11 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
+      # This job compiles Go twice — the WASM demo, and the CLI that
+      # gen_demo_transcripts.sh records the docs transcripts with — and it runs
+      # after the tag is pushed. Same reason as the `release` job.
+      - name: Warm the module cache (retried)
+        run: bash release/scripts/retry.sh go mod download
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
@@ -952,6 +970,21 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
+      # Warm the module cache through a retry before anything compiles.
+      #
+      # `go build` fetches every module it does not already have, one network
+      # round trip each, and retries none of them. setup-go's cache usually
+      # covers that, but a cache miss (evicted, or a go.sum that moved) turns
+      # this job's `go build` into ~97 bare fetches. This job runs AFTER
+      # core-tag has pushed the git tag, so a single dropped connection here
+      # leaves the tag published and the GitHub Release without its binaries —
+      # which is exactly how 3.3.0 half-shipped. The fetch is idempotent and
+      # near-free on a cache hit, so it costs nothing to make it the only
+      # unretried-network-in-the-publish-window that cannot happen.
+      #
+      # Held by TestEveryReleaseJobThatCompilesGoWarmsTheCacheFirst.
+      - name: Warm the module cache (retried)
+        run: bash release/scripts/retry.sh go mod download
       - name: Install syft
         uses: anchore/sbom-action/download-syft@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
       - name: Build reproducible binaries + checksums + SBOM

--- a/release/orchestrator/verify-oci.sh
+++ b/release/orchestrator/verify-oci.sh
@@ -15,6 +15,9 @@
 #   conflict  -> the ref exists with a digest/provenance that does NOT match.
 #                Exits non-zero (3) so the caller fails closed — never an overwrite.
 #
+# A registry that cannot be READ is none of the four, and in particular is not
+# `absent`. The script exits 1 rather than guess — see digest() below.
+#
 #   verify-oci.sh <ref> [<expected-digest>] [<expect-revision> <expect-version>] \
 #                       [<expect-content-digest>]
 #
@@ -53,11 +56,65 @@ EXPECT_CONTENT="${5:-}"
 craneflags() { case "$1" in localhost*|127.0.0.1*) printf -- '--insecure';; esac; }
 # run <cmd...>: bounded so a wedged registry can never hang the release.
 run() { if command -v timeout >/dev/null 2>&1; then timeout 60 "$@"; else "$@"; fi; }
-digest() {
+# fetchDigest <ref>: the remote manifest digest, from whichever registry client
+# is on PATH. Stdout is the digest and nothing else; every diagnostic goes to
+# stderr, which digest() below captures separately — crane logs "HEAD request
+# failed, falling back on GET" to stderr on a path that still SUCCEEDS, so
+# folding the two together would hand back a warning as a digest.
+fetchDigest() {
   # shellcheck disable=SC2046  # $(craneflags) intentionally unquoted: empty => no arg.
-  if command -v crane >/dev/null 2>&1; then run crane digest $(craneflags "$1") "$1" 2>/dev/null
-  elif command -v oras  >/dev/null 2>&1; then run oras manifest fetch --descriptor "$1" 2>/dev/null | jq -r .digest
-  else docker manifest inspect "$1" >/dev/null 2>&1 && docker buildx imagetools inspect "$1" --format '{{.Manifest.Digest}}' 2>/dev/null; fi
+  if command -v crane >/dev/null 2>&1; then run crane digest $(craneflags "$1") "$1"
+  elif command -v oras  >/dev/null 2>&1; then run oras manifest fetch --descriptor "$1" | jq -r .digest
+  else docker manifest inspect "$1" >/dev/null && docker buildx imagetools inspect "$1" --format '{{.Manifest.Digest}}'; fi
+}
+# digest <ref> -> the remote manifest digest, or "" if the ref genuinely does not
+# exist.
+#
+# Only a real 404 yields "". Any other failure — auth, TLS, DNS, a rate limit, a
+# registry outage, the 60s timeout above — is fatal, because "" is load-bearing
+# here: it is what prints `absent`, and `absent` is what unlocks the caller's
+# push. Reporting an UNREADABLE ref as a MISSING one is precisely how a release
+# publishes over an immutable tag it merely failed to read, and how a resumed
+# unit reports itself verified against a registry that never answered. Same rule,
+# same reason and the same not-found vocabulary as ledger.sh's pull().
+#
+# Matched against the LAST line of stderr rather than all of it, which is one of
+# two places this is stricter than ledger.sh: crane's fallback warning carries
+# the HEAD's "404 Not Found" even when the GET that follows fails with a 500, and
+# scanning the whole buffer would read that pair as absent.
+#
+# The one caller assigns this to a variable with no `|| true` — `exit` inside a
+# command substitution only kills the subshell, so it is `set -e` on that
+# assignment that carries the failure out.
+
+# NOT_FOUND_RE is the vocabulary a REGISTRY uses to say a ref does not exist,
+# taken from what each client above actually prints (verified against ghcr.io,
+# for both a missing tag and a repository that never existed):
+#
+#   crane   Error: GET https://ghcr.io/v2/...: MANIFEST_UNKNOWN: manifest unknown
+#   oras    Error response from registry: failed to find "<ref>": <ref>: not found
+#   docker  manifest unknown
+#
+# It deliberately does NOT accept a bare "not found" — the other, stricter place
+# than ledger.sh. That phrase is equally how a machine says a TOOL is missing:
+# `exec: "docker-credential-desktop": executable file not found in $PATH`, which
+# oras prints as a plain `Error:` when the credential helper is unreachable and
+# which an earlier draft of this read as a 404. A missing tool reported as a
+# missing artifact is release run 32560058692 over again, and here it would
+# publish over an occupied immutable tag. oras's own `Error response from
+# registry:` prefix is the discriminator: it means the registry answered, not
+# that we failed to ask it.
+NOT_FOUND_RE='MANIFEST_UNKNOWN|NAME_UNKNOWN|manifest unknown|Error response from registry:.*not found|(^|[^0-9])404([^0-9]|$)'
+digest() {
+  local out err last rc=0
+  err="$(mktemp)"
+  out="$(fetchDigest "$1" 2>"$err")" || rc=$?
+  if [ "$rc" -eq 0 ]; then rm -f "$err"; printf '%s' "$out"; return; fi
+  last="$(grep -v '^[[:space:]]*$' "$err" | tail -1)"
+  rm -f "$err"
+  if printf '%s' "$last" | grep -qiE "$NOT_FOUND_RE"; then return; fi
+  echo "::error::registry read failed for $1 (exit $rc) — refusing to report an unreadable ref as an absent one, because absent is what publishes over it: ${last:-no output}" >&2
+  exit 1
 }
 # label <ref> <key> -> the provenance value for key ("" if unavailable/no crane).
 # Reads a docker-style config label first (images), then falls back to the OCI
@@ -94,7 +151,7 @@ content() {
          then .layers[0].digest else "" end' 2>/dev/null || printf ''
 }
 
-remote="$(digest "$REF" || true)"
+remote="$(digest "$REF")"
 if [ -z "$remote" ]; then echo absent; exit 0; fi
 if [ -n "$EXPECT" ] && [ "$remote" = "$EXPECT" ]; then echo identical; exit 0; fi
 # Crash-window adoption: nothing recorded/precomputed matched, but the artifact's

--- a/tests/release/publish_immutability_test.go
+++ b/tests/release/publish_immutability_test.go
@@ -2,7 +2,9 @@ package release
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -50,5 +52,69 @@ func TestFinalizeReleaseResumeUsesClobber(t *testing.T) {
 	}
 	if !strings.Contains(string(b), "gh release upload") || !strings.Contains(string(b), "--clobber") {
 		t.Error("finalize-release.sh resume upload does not use --clobber; a partial prior run makes the resume fail")
+	}
+}
+
+// verify-oci.sh prints `absent` when its registry read comes back empty, and
+// `absent` is the one answer that unlocks a push. So the question of which
+// failures are allowed to produce an empty read is the whole immutability
+// guarantee, compressed into one regex.
+//
+// It used to be no question at all: the read was `remote="$(digest "$REF" ||
+// true)"` and digest() swallowed every stderr, so an expired token, a rate
+// limit, a wedged registry or a 60-second timeout all reported the ref as
+// missing — and the caller published over it. The regex that replaced that is
+// prose-matching against tool output, which rots quietly, so it is checked here
+// against real messages rather than trusted.
+//
+// Every string below was captured from an actual client against ghcr.io.
+var registryReadCases = []struct {
+	name   string
+	msg    string
+	absent bool // may this be read as "the ref does not exist"?
+}{
+	{"crane, missing tag", `Error: GET https://ghcr.io/v2/trianalab/pacto/manifests/0.0.0-nope: MANIFEST_UNKNOWN: manifest unknown`, true},
+	{"crane, repo that never existed", `Error: GET https://ghcr.io/v2/trianalab/nope-xyz/manifests/0.0.1: MANIFEST_UNKNOWN: manifest unknown`, true},
+	{"oras, missing tag", `Error response from registry: failed to find "ghcr.io/trianalab/pacto:0.0.0-nope": ghcr.io/trianalab/pacto:0.0.0-nope: not found`, true},
+	{"docker manifest inspect", `manifest unknown`, true},
+	{"a registry that answers 404 with no OCI error body", `Error: GET https://reg.example/v2/x/manifests/1: unexpected status code 404 Not Found`, true},
+
+	// The half of the table that matters. Each of these is a failure to ASK,
+	// and reporting any of them as an answer publishes over a live tag.
+	{"oras, credential helper unreachable", `Error: failed to find "ghcr.io/trianalab/pacto:1": HEAD "https://ghcr.io/v2/trianalab/pacto/manifests/1": exec: "docker-credential-desktop": executable file not found in $PATH`, false},
+	{"the registry denies us", `Error response from registry: failed to find "ghcr.io/trianalab/pacto:1": HEAD "https://ghcr.io/v2/trianalab/pacto/manifests/1": denied: requested access to the resource is denied`, false},
+	{"connection refused", `Error: Get "https://localhost:5000/v2/": dial tcp [::1]:5000: connect: connection refused`, false},
+	{"dns failure", `Error: Get "https://reg.invalid/v2/": dial tcp: lookup reg.invalid: no such host`, false},
+	{"a tool is missing", `jq: command not found`, false},
+	{"the registry is broken", `Error: GET https://reg.example/v2/x/manifests/1: unexpected status code 500 Internal Server Error`, false},
+	{"the 60s timeout fired", ``, false},
+}
+
+func TestVerifyOCIReadsOnlyARegistry404AsAbsent(t *testing.T) {
+	root := repoRoot(t)
+	src := readFile(t, root, "release", "orchestrator", "verify-oci.sh")
+
+	// The caller must not swallow the exit. `exit` inside a command substitution
+	// only kills the subshell, so `set -e` on a bare assignment is the only thing
+	// carrying a fatal read out of digest().
+	if !strings.Contains(src, `remote="$(digest "$REF")"`) {
+		t.Error("verify-oci.sh no longer reads the remote digest as a bare `remote=\"$(digest \"$REF\")\"` assignment — a `|| true` there discards the fail-closed exit, because `exit` inside $(...) only ends the subshell")
+	}
+
+	m := regexp.MustCompile(`(?m)^NOT_FOUND_RE='([^']*)'$`).FindStringSubmatch(src)
+	if m == nil {
+		t.Fatal("verify-oci.sh no longer defines NOT_FOUND_RE — the table below has nothing to check, and this gate is vacuous")
+	}
+
+	for _, tc := range registryReadCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Run the real regex through the real engine: this is a shell script
+			// matching with `grep -qiE`, and Go's RE2 is a different engine.
+			err := exec.Command("bash", "-c", `printf '%s' "$1" | grep -qiE "$2"`, "_", tc.msg, m[1]).Run()
+			if matched := err == nil; matched != tc.absent {
+				verdict := map[bool]string{true: "absent", false: "a hard failure"}
+				t.Errorf("verify-oci.sh reads\n  %s\nas %s, but it is %s.\nNOT_FOUND_RE = %s", tc.msg, verdict[matched], verdict[tc.absent], m[1])
+			}
+		})
 	}
 }

--- a/tests/release/workflow_tooling_test.go
+++ b/tests/release/workflow_tooling_test.go
@@ -495,12 +495,19 @@ func ciFetchSurfaces(t *testing.T, root string) []string {
 // TestTheReleasePathNeverCompilesThirdPartyToolingFromSource — because a retry
 // that eventually gives up still leaves an irreversible half-publish behind.
 //
-// Two ceilings, stated so nobody trusts this further than it reaches. Continued
+// One ceiling, stated so nobody trusts this further than it reaches. Continued
 // lines are joined, so the unit is one shell command list, not one source line:
-// a RUN that retried one fetch and not a second would pass. And `go build`,
-// `go test` and `go run` download modules too; they are out of scope because
-// every CI job that runs them runs a retried `go mod download` first, which
-// leaves the cache warm.
+// a RUN that retried one fetch and not a second would pass.
+//
+// `go build`, `go run` and `go test` fetch modules too, and this gate never sees
+// them. That used to be written here as a second ceiling that excused itself —
+// "out of scope because every CI job that runs them runs a retried `go mod
+// download` first, which leaves the cache warm". It was not true. Four
+// release.yml jobs compiled Go with no retried fetch anywhere, three of them
+// after core-tag had already pushed the git tag, which is the same half-ship
+// window this whole rule exists to close. A ceiling that claims something nobody
+// checks is worse than no ceiling, so the claim is now its own gate:
+// TestEveryReleaseJobThatCompilesGoWarmsTheCacheFirst.
 func TestEveryGoNetworkFetchInCIRetries(t *testing.T) {
 	root := repoRoot(t)
 
@@ -549,6 +556,140 @@ func elide(s string) string {
 	return s
 }
 
+// goCompileRE is a Go command that compiles, and therefore downloads whatever
+// the module cache is missing — the same unretried round trips as `go mod
+// download`, only implicit, which is why they went unnoticed.
+//
+// `go mod download` and `go install` are deliberately absent: they are
+// TestEveryGoNetworkFetchInCIRetries' subject, and a job whose only Go command
+// is one of those has nothing left to warm.
+var goCompileRE = regexp.MustCompile(`\bgo (?:build|run|test|vet|generate)\b`)
+
+// reachableShell is every line of shell a workflow job can execute: its own
+// `run` bodies, the scripts those invoke transitively, the recipes of the make
+// targets they call, and the scripts those recipes invoke. It is the same walk
+// jobNeeds does for gated CLIs, kept generic because a gate that says "this job
+// compiles Go" has to be able to say where it saw it. Keyed by that origin.
+func reachableShell(t *testing.T, job wfJob, files map[string]string, rules map[string]makeRule) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	seen := map[string]bool{}
+	var walk func(name string)
+	walk = func(name string) {
+		if seen[name] {
+			return
+		}
+		seen[name] = true
+		path, ok := files[name]
+		if !ok {
+			return // not one of ours: a vendored helper, or a name that only appears in prose.
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		out[name] = string(b)
+		_, scripts := toolsIn(string(b))
+		for _, s := range slices.Sorted(maps.Keys(scripts)) {
+			walk(s)
+		}
+	}
+
+	shell := job.runs()
+	out["the job's own shell"] = shell
+	_, scripts := toolsIn(shell)
+	for _, s := range slices.Sorted(maps.Keys(scripts)) {
+		walk(s)
+	}
+	for _, l := range commandLines(shell) {
+		for _, m := range makeCallRE.FindAllStringSubmatch(l, -1) {
+			recipe := recipeClosure(rules, m[1], map[string]bool{})
+			out["make "+m[1]] = recipe
+			_, mScripts := toolsIn(recipe)
+			for _, s := range slices.Sorted(maps.Keys(mScripts)) {
+				walk(s)
+			}
+		}
+	}
+	return out
+}
+
+// goCacheState reads one job's reachable shell and reports where it first
+// compiles Go (origin "" if it never does) and whether anything it reaches warms
+// the module cache through a retry.
+func goCacheState(t *testing.T, job wfJob, files map[string]string, rules map[string]makeRule) (origin, cmd string, warmed bool) {
+	t.Helper()
+	reach := reachableShell(t, job, files, rules)
+	for _, src := range slices.Sorted(maps.Keys(reach)) {
+		for _, l := range commandLines(reach[src]) {
+			bare := quotedShellStringRE.ReplaceAllString(l, "")
+			if origin == "" && goCompileRE.MatchString(bare) {
+				origin, cmd = src, l
+			}
+			if fetches, retried := classifyGoFetch(l); fetches && retried {
+				warmed = true
+			}
+		}
+	}
+	return origin, cmd, warmed
+}
+
+// TestEveryReleaseJobThatCompilesGoWarmsTheCacheFirst closes the hole the gate
+// above used to wave away in a comment.
+//
+// setup-go restores a module cache keyed on go.sum, and while that cache hits,
+// a `go build` in a release job touches the network for nothing. On a miss —
+// evicted after seven days, or a go.sum that moved, which is exactly what a
+// release commit does — the same `go build` becomes one bare fetch per module
+// in the graph, none of them retried. The `release` job's build-cli.sh alone
+// resolves ~97.
+//
+// Three of the four jobs that were in this state run AFTER core-tag has pushed
+// the git tag. A dropped connection there does not fail a release; it
+// half-ships one — tags on GitHub, no binaries on the Release, no demo bundles,
+// no published Compose application. That is run 34613593980, and it is why the
+// fix is a gate and not a habit: the next release job someone adds will compile
+// Go, and nothing about `go build` looks like network access.
+//
+// The rule is uniform across release.yml rather than carved to the post-tag
+// jobs. A pre-tag failure is cheap, but "cheap enough to leave unretried" is an
+// exception whose boundary moves every time a job is reordered, and the fix
+// costs one idempotent step that is free on a cache hit.
+//
+// Ceilings: ordering is not modelled, so a script that compiled before its own
+// retried fetch would pass (none does — every warm step here is a job-level
+// step that runs before any compile); a Go command inside a Dockerfile is not
+// on this runner's network path and is covered by the Dockerfiles' own inline
+// retry loops; and a make target assembled from a matrix expression does not
+// resolve to a recipe, so its compiles are invisible.
+func TestEveryReleaseJobThatCompilesGoWarmsTheCacheFirst(t *testing.T) {
+	root := repoRoot(t)
+	files := gateScripts(t, root)
+	rules := makeRules(t, root)
+	jobs := workflowJobs(t, root, "release.yml")
+
+	compiling := 0
+	for _, name := range slices.Sorted(maps.Keys(jobs)) {
+		origin, cmd, warmed := goCacheState(t, jobs[name], files, rules)
+		if origin == "" {
+			continue
+		}
+		compiling++
+		if warmed {
+			continue
+		}
+		t.Errorf("release.yml job %q compiles Go (%s: %s) but never warms the module cache through a retry.\n"+
+			"Add `- name: Warm the module cache (retried)` running `bash release/scripts/retry.sh go mod download` after setup-go. "+
+			"On a cache miss that `go build` is one unretried fetch per module, and in a post-tag job one dropped connection half-ships the release.",
+			name, origin, elide(cmd))
+	}
+	// The four fixed here plus the ones that already had a fetch. A refactor that
+	// stopped resolving the closure would otherwise leave this green.
+	if compiling < 4 {
+		t.Errorf("only %d release.yml jobs found compiling Go — there are at least 4; the closure stopped resolving and this gate is now vacuous", compiling)
+	}
+}
+
 // TestTheRetryGateBitesOnABareFetch proves the classifier above can fail, and
 // fails on the exact three lines that broke on 2026-09-11 rather than on a
 // strawman. Without it, a regex that quietly stopped matching would leave the
@@ -578,6 +719,39 @@ func TestTheRetryGateBitesOnABareFetch(t *testing.T) {
 				t.Errorf("classifyGoFetch(%q) retried = %v, want %v", tc.cmd, retried, tc.retried)
 			}
 		})
+	}
+}
+
+// TestTheWarmCacheGateBitesWhenTheWarmStepIsDeleted proves that gate can fail,
+// on the exact state release.yml was in until this branch: the `release` job with
+// no retried fetch, still reaching build-cli.sh's `go build`. Without this, a
+// closure that quietly stopped resolving scripts would leave the gate green while
+// checking nothing.
+func TestTheWarmCacheGateBitesWhenTheWarmStepIsDeleted(t *testing.T) {
+	root := repoRoot(t)
+	files := gateScripts(t, root)
+	rules := makeRules(t, root)
+
+	job, ok := workflowJobs(t, root, "release.yml")["release"]
+	if !ok {
+		t.Fatal("release.yml has no release job — the binary publisher was renamed; move this proof with it")
+	}
+	stripped := wfJob{}
+	for _, s := range job.Steps {
+		if fetches, retried := classifyGoFetch(s.Run); fetches && retried {
+			continue
+		}
+		stripped.Steps = append(stripped.Steps, s)
+	}
+	origin, _, warmed := goCacheState(t, stripped, files, rules)
+	if warmed {
+		t.Fatal("stripping the warm step left a retried fetch behind — the proof below would be vacuous")
+	}
+	if origin == "" {
+		t.Error("the release job without its warm step is not reported as compiling Go — but it runs build-cli.sh, which runs `go build`. The closure stopped resolving, and the gate now passes every job for free.")
+	}
+	if origin != "" && origin != "build-cli.sh" {
+		t.Errorf("the release job's Go compile is attributed to %q — it should name build-cli.sh, the script that actually runs it", origin)
 	}
 }
 


### PR DESCRIPTION
Two ways the publish window could still half-ship a release, both closed with the gate that keeps them closed. Follows #365, which fixed the explicit fetches and left these behind.

## Five release jobs compiled Go with no retried fetch

`release`, `demo-bundles`, `demo-compose`, `docs` and `changesets`. #365 wrapped every `go mod download` and `go install` in `retry.sh`, but `go build` and `go run` download modules too, and nothing about them looks like network access.

setup-go's cache normally covers that. On a miss — evicted after seven days, or a `go.sum` that moved, which is exactly what a release commit does — `build-cli.sh`'s `go build` alone becomes ~97 bare fetches against proxy.golang.org, none retried. Four of the five jobs run **after** `core-tag` has pushed the git tag, so one dropped connection there does not fail a release, it half-ships one: tags on GitHub, no binaries on the Release, no demo bundles, no published Compose application. That is run 34613593980.

Each job now runs `retry.sh go mod download` after setup-go. It is idempotent and near-free on a cache hit. The rule is applied uniformly rather than carved to the post-tag jobs, because "cheap enough to leave unretried" is an exception whose boundary moves every time a job is reordered.

## The gate that claimed this was already true

`TestEveryGoNetworkFetchInCIRetries` carried a stated ceiling excusing implicit fetches: *"out of scope because every CI job that runs them runs a retried `go mod download` first, which leaves the cache warm."* That was untrue of five jobs. A ceiling that asserts something nobody checks is worse than no ceiling.

It is now `TestEveryReleaseJobThatCompilesGoWarmsTheCacheFirst`, which walks each release job's shell through the scripts it invokes and the make targets it calls, finds where it compiles, and requires a retried fetch. It found the fifth job — `docs`, via `gen_demo_transcripts.sh` — that the manual audit missed. `TestTheWarmCacheGateBitesWhenTheWarmStepIsDeleted` proves it fails when the warm step is removed.

## verify-oci.sh read the registry fail-open

`digest()` swallowed all stderr and the caller wrapped it in `|| true`. An expired token, a rate limit, a wedged registry or the 60-second timeout all came back empty — and empty prints `absent`, which is the one answer that unlocks the push. A transient read failure could publish over an occupied immutable tag, or let a resumed unit report itself verified against a registry that never answered.

It now distinguishes a registry 404 from a failure to reach the registry and exits 1 on the latter, the same rule and shape as `ledger.sh`'s `pull()`. The caller's `|| true` is gone: `exit` inside a command substitution only ends the subshell, so `set -e` on a bare assignment is the only thing that carries the failure out.

Stricter than `ledger.sh` in two places, both load-bearing:

- It matches the **last line** of stderr. crane's fallback warning carries the HEAD's `404 Not Found` even when the GET behind it fails with a 500, and scanning the whole buffer reads that pair as absent.
- It does **not** accept a bare `not found`. That phrase is equally how a machine says a *tool* is missing — `exec: "docker-credential-desktop": executable file not found in $PATH`, which oras prints when the credential helper is unreachable. An earlier draft of this change read that as a 404; caught by running the real `oras` path against ghcr.io on a PATH without the helper.

`TestVerifyOCIReadsOnlyARegistry404AsAbsent` checks the vocabulary against twelve messages captured from real clients against ghcr.io — five that must read as absent, seven that must not — through `grep -qiE` rather than Go's regexp engine, since the subject is a shell script.

## Verification

All four states re-verified live against ghcr.io on both the crane and oras paths: missing tag and never-existing repo return `absent`; an existing ref returns `conflict` unattributed and `identical` against its digest; connection refused, DNS failure and an unreachable credential helper all exit 1.

`go test ./tests/...` green, `make check-section` clean, `shellcheck release/orchestrator/verify-oci.sh` clean.

No changeset: this is release infrastructure, matching #361 and #362.
