### PR TITLE
chore(release): ship the operator go.sum fix as 5.4.1

### DIFF
--- a/.changeset/operator-gosum-standalone-build.md
+++ b/.changeset/operator-gosum-standalone-build.md
@@ -1,0 +1,12 @@
+---
+"@pacto/k8s-module": patch
+---
+
+Carry the checksums for the pinned engine core in the operator's `go.sum`.
+
+The published `v5.4.0` module requires `github.com/trianalab/pacto/v3 v3.3.0`
+while its `go.sum` only covers `v3.2.7`, so building the operator module on
+its own — outside the workspace, which is how a consumer or a fresh clone
+builds it — fails with `missing go.sum entry` for every `pacto/v3` package.
+The fix landed on main in #369; this release ships it, and moves the
+published pin to `v3.3.1`.


### PR DESCRIPTION
Adds the changeset that ships #369's fix as operator **5.4.1**. Merging this opens the Version PR; merging *that* cuts the release.

## Why this needs a release

#369 fixed `integrations/kubernetes/go.sum` on main, but `go.sum` travels *inside* the published module zip, so the artifact on the proxy is still broken:

```
github.com/trianalab/pacto/integrations/kubernetes/v5@v5.4.0
  go.mod requires: github.com/trianalab/pacto/v3 v3.3.0
  go.sum covers  : v3.2.7
  GOWORK=off GOFLAGS= go build ./...  -> missing go.sum entry  (x5 packages)
```

Library consumers are unaffected — only the main module's `go.sum` is consulted — but anyone building the operator from the tag or the module zip hits it. That only reaches them through a new release.

## What this produces

`@pacto/k8s-module: patch`. The four k8s units are a fixed group, so all four go to 5.4.1 and the core group stays at 3.3.1. Verified by running the real `npm run release:version` in a throwaway clone:

```
release-plan.json        core v3.3.1, kubernetes v5.4.1
release-transaction.json ready=true
                         changedUnits=[k8s-docs, k8s-module, operator-chart, operator-image]
```

`apply-release-plan.mjs` touches only `Chart.yaml`, the chart `README.md` and the manifest. Its new section 1a is a no-op here: main's `go.mod` already pins `v3.3.1` and the sums are present, which is exactly the post-#369 steady state.

Note the pin move itself already happened — main advanced to `v3.3.1` during the 3.3.1 core release even though the k8s group was not in that transaction. This release publishes it rather than performing it.

## Not in scope

The major-bump defect noted in #369 (a major core bump writes an unparseable `require` into the operator `go.mod`) is untouched. It cannot fire on a patch release.
