### PR TITLE
fix(release): close four gaps left by the 5.2.2 incident

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,9 +296,15 @@ jobs:
 
   release-dry-run:
     needs: changes
+    # Gated on `release` as well as `e2e`, because the dry run READS the pending
+    # changesets: verify-standalone.sh computes the next core version from them and
+    # build-release-plan.mjs turns them into the plan it rehearses. The `e2e` filter
+    # has no '.changeset/**' entry on purpose — a changeset cannot affect the kind or
+    # Compose legs — so gating this job on `e2e` alone made the one PR class that
+    # OPENS a release transaction the one class the dry run never rehearsed (#370).
     # Skip on the changesets Version PR: its changesets are already consumed, so the
     # dry-run's "pending bump" scenarios do not apply (feature-PR / main gate only).
-    if: (needs.changes.outputs.e2e == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && !startsWith(github.head_ref, 'changeset-release/')
+    if: (needs.changes.outputs.e2e == 'true' || needs.changes.outputs.release == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && !startsWith(github.head_ref, 'changeset-release/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/docs/maintainers/releases.md
+++ b/docs/maintainers/releases.md
@@ -216,3 +216,23 @@ follow, and they are permanent:
   3.2.1 / 5.2.1. Its ledger entries are permanent, so a recovery dispatch for
   that transaction id stays armed and still refuses to double-publish the four
   units that completed.
+
+## Abandoned transaction `3bf445d36fd2c3fc` (5.2.2)
+
+This one published **nothing** — no module tag, no operator image, no chart — and
+reported success. Run 32647472671 on `be20e3b3` (#319) is green in the Actions list.
+`detect` resolved correctly (`release=true`, the four Kubernetes units), `core-ready`
+succeeded, and then `ledger-init` and every publisher below it skipped.
+
+The cause was skip propagation through `needs`. A Kubernetes-only transaction has no
+core unit, so `core-tag` skips by design. `core-ready` carried `always()` and ran, but
+`always()` exempts only the job that declares it: the skip still reached everything
+downstream of `core-tag`, and `ledger-init` — which did not declare it — skipped with
+its `if:` satisfied and both of its `needs` green. A skipped job is not a failed job,
+so the run's conclusion stayed `success`. Fixed in #361 and #362.
+
+5.2.2 is therefore unlike 3.2.0 / 5.2.0: there is no tag, so nothing resolves through
+the module proxy either, and no artifact exists to be adopted or conflicted with. It
+was superseded by **5.2.3**, which published in full. Nothing needs recovering, and a
+recovery dispatch for this transaction id would rebuild from a commit whose versions
+have since been republished — do not send one.

--- a/docs/maintainers/releases.md
+++ b/docs/maintainers/releases.md
@@ -175,6 +175,31 @@ its tools, and distinguishes a genuine 404 from a registry it could not read at 
 Callers must assign its output to a variable before testing it: inside `[ "$(…)" ]`
 the exit status is discarded, so a failed read reads as an empty one.
 
+## A major bump needs the module path renamed first
+
+Go binds a module's version to its import path: a path ending `/vN` carries only
+`vN.y.z`, and an unsuffixed path only v0 and v1. Both Go modules here publish on a
+suffixed path — `github.com/trianalab/pacto/v3` and
+`github.com/trianalab/pacto/integrations/kubernetes/v5` — so the major in the path
+and the major in the version are the same number, always.
+
+A major changeset moves the version. It does not move the path, and it cannot: the
+rename touches the import path, every importer in the tree, `go.work`'s replace, the
+`coordinate` in `release/units/*/package.json` and the operator's own `module` line.
+That is a deliberate first commit of a major release, not something the version
+script should infer. Landing the changeset without it used to produce a require go
+refuses to parse:
+
+```
+go.mod:79:2: require github.com/trianalab/pacto/v3: version "v4.0.0" invalid: should be v3, not v4
+```
+
+`build-release-plan.mjs` now refuses to emit a plan whose version does not fit its
+path, and `apply-release-plan.mjs` refuses to write the require, so the release stops
+before the Version PR exists rather than mid-transaction. **Rename the path, merge
+that, then land the major changeset.** `tests/release/k8s_module_path_test.go` holds
+the Kubernetes half of the rename to every declared coordinate.
+
 ## Abandoned transaction `522e9507410f16fc` (3.2.0 / 5.2.0)
 
 This transaction published four units and then failed. v3.2.0 and v5.2.0 are

--- a/release/orchestrator/test-release-version.sh
+++ b/release/orchestrator/test-release-version.sh
@@ -44,24 +44,31 @@ else
   echo "  A: feature PR / post-release (unchanged committed transaction) publishes nothing"
 fi
 
-# --- B: run the REAL version command with a pending major core changeset. ---
-# Consume ONLY a controlled changeset: drop the repo's pending entries so the
-# bump is deterministic (config.json + README.md stay).
-find .changeset -name '*.md' ! -name 'README.md' -delete
-cat > .changeset/test-major.md <<'MD'
+# stage_changeset <dir> <bump> — replace the repo's pending changesets with one
+# controlled entry, so the bump is deterministic (config.json + README.md stay).
+stage_changeset() {
+  find "$1/.changeset" -name '*.md' ! -name 'README.md' -delete
+  cat > "$1/.changeset/test-bump.md" <<MD
 ---
-"@pacto/core": major
+"@pacto/core": $2
 ---
 
 Test: exercise the real release:version transaction path.
 MD
+}
+
+# --- B: run the REAL version command with a pending minor core changeset. ---
+# Minor, not major: a major bump is REFUSED until the module path is renamed to
+# match (case D below), and every invariant B checks — consumption, the fixed
+# group, the transaction, manifestSha — is bump-size independent.
+stage_changeset . minor
 npm run release:version >/dev/null 2>&1 || fail "npm run release:version errored"
 
 # changeset consumed
-[ -f .changeset/test-major.md ] && fail "changeset was not consumed"
-# versions bumped (core major: prev major +1 . 0 . 0)
+[ -f .changeset/test-bump.md ] && fail "changeset was not consumed"
+# versions bumped (core minor: prev major . prev minor +1 . 0)
 new_core="$(jq -r '.units.core.version' release/release-manifest.json)"
-want_core="$(( ${prev_core%%.*} + 1 )).0.0"
+want_core="${prev_core%%.*}.$(( $(echo "$prev_core" | cut -d. -f2) + 1 )).0"
 eq "$new_core" "$want_core" "core version bump"
 # k8s unchanged (core-only changeset)
 eq "$(jq -r '.units["k8s-module"].version' release/release-manifest.json)" "$prev_k8s" "k8s version unchanged"
@@ -85,20 +92,32 @@ echo "  B: real release:version -> ready transaction, detect release=true"
 # in an independent run (no clock/random; item 1 "second invocation byte-identical").
 cp release/release-transaction.json "$WORK/txn1.json"
 C2="$WORK/clone2"; git clone -q "$ROOT" "$C2"; ln -s "$ROOT/node_modules" "$C2/node_modules"
-(
-  cd "$C2"
-  find .changeset -name '*.md' ! -name 'README.md' -delete
-  cat > .changeset/test-major.md <<'MD'
----
-"@pacto/core": major
----
-
-Test: exercise the real release:version transaction path.
-MD
-  npm run release:version >/dev/null 2>&1
-)
+stage_changeset "$C2" minor
+( cd "$C2" && npm run release:version >/dev/null 2>&1 )
 diff -q "$WORK/txn1.json" "$C2/release/release-transaction.json" >/dev/null \
   || fail "transaction not deterministic across independent runs"
 echo "  C: same changesets -> byte-identical transaction across independent runs"
+
+# --- D: a major bump is REFUSED while the module path still carries the old major. ---
+# Go binds a module's version to its path (/vN carries only vN.y.z), and a major
+# changeset moves the version without moving the path — the rename is a separate,
+# deliberate commit. Emitting the plan anyway wrote `github.com/trianalab/pacto/v3
+# v4.0.0` into the operator's go.mod, a require go refuses to parse, discovered only
+# after the Version PR existed. release:version must fail loudly instead, naming the
+# rename. Run in a third clone so B and C's consumed state is untouched.
+C3="$WORK/clone3"; git clone -q "$ROOT" "$C3"; ln -s "$ROOT/node_modules" "$C3/node_modules"
+stage_changeset "$C3" major
+if ( cd "$C3" && npm run release:version ) > "$WORK/major.out" 2>&1; then
+  fail "a major core bump was accepted while the module path still carries the old major"
+fi
+grep -q 'refuses to emit' "$WORK/major.out" \
+  || fail "major bump failed for the wrong reason: $(tail -3 "$WORK/major.out")"
+grep -q 'Rename it to github.com/trianalab/pacto/v4' "$WORK/major.out" \
+  || fail "the refusal does not name the rename that unblocks it"
+# The refusal has to land BEFORE the operator go.mod is touched: a require go cannot
+# parse is worse than no bump at all.
+git -C "$C3" diff --quiet -- integrations/kubernetes/go.mod \
+  || fail "operator go.mod was modified by a refused major bump"
+echo "  D: major core bump refused, module-path rename named, operator go.mod untouched"
 
 echo "RELEASE-VERSION-TEST OK"

--- a/release/orchestrator/verify-k8s-standalone.sh
+++ b/release/orchestrator/verify-k8s-standalone.sh
@@ -8,10 +8,11 @@
 #
 # Non-invasive, mirrors verify-standalone.sh: local staging tags on the current
 # tree, a process-scoped git config (never the user's global) that rewrites the
-# public repo URL to this checkout, and a throwaway GOMODCACHE. The tags are
-# deleted on exit. No publish, no production coordinate.
+# public repo URL to this checkout, and a throwaway GOMODCACHE. The tags are put
+# back as they were found on exit. No publish, no production coordinate.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/release/scripts/staging-tags.sh"
 
 # The nested-module tag baseline for the /v5 path comes straight from the release
 # plan (build-release-plan.mjs derives it from the module PATH major, so a /v5
@@ -27,14 +28,16 @@ echo "consume ${MODULE}@v${K8S_VER} (tag ${K8S_TAG}); core pin ${CORE_PIN}"
 TMPGIT="$(mktemp)"; WORK="$(mktemp -d)"; MODCACHE="$(mktemp -d)"
 printf '[url "file://%s"]\n\tinsteadOf = https://github.com/trianalab/pacto\n' "$ROOT" > "$TMPGIT"
 
-git -C "$ROOT" tag -f "$K8S_TAG" HEAD >/dev/null 2>&1    # reproducible local staging tags
-git -C "$ROOT" tag -f "$CORE_PIN" HEAD >/dev/null 2>&1
+# Both names are REAL published tags between releases, so stage_tag records where
+# each one pointed and restore_staged_tags puts it back — deleting only what it
+# created. Trap first: the restore matters most when the check below fails.
 cleanup() {
-  git -C "$ROOT" tag -d "$K8S_TAG" >/dev/null 2>&1 || true
-  git -C "$ROOT" tag -d "$CORE_PIN" >/dev/null 2>&1 || true
+  restore_staged_tags
   rm -rf "$WORK" "$MODCACHE" "$TMPGIT" 2>/dev/null || true
 }
 trap cleanup EXIT
+stage_tag "$ROOT" "$K8S_TAG"    # reproducible local staging tags
+stage_tag "$ROOT" "$CORE_PIN"
 
 # A throwaway consumer module: nothing from the workspace reaches it.
 mkdir -p "$WORK/consumer"

--- a/release/scripts/apply-release-plan.mjs
+++ b/release/scripts/apply-release-plan.mjs
@@ -49,6 +49,21 @@ function assert(cond, msg) {
 // assertNoReplace declares the release-state invariant: a replace directive must
 // NOT survive into a published go.mod. This is enforcement, not removal — a stray
 // replace is a mistake to surface loudly, never something to silently rewrite.
+//
+// The pin has to name a version that CAN exist. Go's import-compat rule ties the
+// halves together — a `/vN` path carries only vN.y.z, an unsuffixed path only
+// v0/v1 — so `.../v3` at `v4.0.0` is not a require whose module is missing, it is
+// one go refuses to parse. A major core bump produced exactly that, because the
+// version advances and the module path does not; renaming the path is a separate,
+// deliberate step. build-release-plan.mjs now refuses to emit such a plan, so this
+// is unreachable through the release path and guards the hand-edited one.
+const majorOf = (v) => Number(/^v(\d+)\./.exec(v)?.[1] ?? NaN);
+const pathMajor = Number(/\/v(\d+)$/.exec(pin.module)?.[1] ?? 1);
+assert(pathMajor >= 2 ? majorOf(pin.version) === pathMajor : majorOf(pin.version) <= 1,
+  `release plan pins ${pin.module} at ${pin.version}, which that module path cannot carry ` +
+  `(a /v${pathMajor} path requires v${pathMajor}.y.z). Rename the module path to ` +
+  `/v${majorOf(pin.version)} before pinning this version — writing the require anyway ` +
+  'produces a go.mod go cannot parse.');
 {
   const rel = 'integrations/kubernetes/go.mod';
   const after = edit(rel, (s) =>
@@ -96,27 +111,12 @@ function assert(cond, msg) {
 // Skipped entirely when the entry is already present, which is every run between releases —
 // including ci.mk's artifact-drift idempotency check, which re-runs this script and demands
 // a byte-identical tree. Deterministic input, deterministic hash, so the re-run is a no-op.
-// Precondition: the pin has to name a module version that can EXIST. Go's import-compat
-// rule ties the two halves together — a `/vN` path carries only vN.y.z, and an unsuffixed
-// path only v0/v1 — so `.../v3` at v4.0.0 is not a version whose checksum is merely missing,
-// it is a coordinate no registry can serve. That combination is what a major core bump
-// currently produces, because the plan advances the version and leaves the module path
-// alone; the path rename is a separate, deliberate step. Skip rather than fail: the broken
-// require is section 1's to answer for, and failing here would only relabel it.
-const majorOf = (v) => Number(/^v(\d+)\./.exec(v)?.[1] ?? NaN);
-const pathMajor = Number(/\/v(\d+)$/.exec(pin.module)?.[1] ?? 1);
-const pinIsCoherent = pathMajor >= 2
-  ? majorOf(pin.version) === pathMajor
-  : majorOf(pin.version) <= 1;
+// Section 1 has already proved the pin names a version this module path can carry, so the
+// coordinate resolved below is one the proxy can actually be asked about.
 {
   const rel = 'integrations/kubernetes/go.sum';
   const before = readFileSync(R(rel), 'utf8');
-  if (!pinIsCoherent) {
-    console.warn(`apply-release-plan: WARNING — ${pin.module} cannot carry ${pin.version} ` +
-      `(a /v${pathMajor} path requires v${pathMajor}.y.z). Skipping the go.sum update: the ` +
-      `module path must be renamed to /v${majorOf(pin.version)} before this version can be pinned. ` +
-      `Note that section 1 has already written this require, and go cannot parse it.`);
-  } else if (!before.includes(`${pin.module} ${pin.version} h1:`)) {
+  if (!before.includes(`${pin.module} ${pin.version} h1:`)) {
     const opDir = R('integrations', 'kubernetes');
     // Section 1 already pinned the require, so go.mod is at its final state here.
     // `-mod=mod` below licenses go to rewrite it; nothing about resolving one

--- a/release/scripts/build-release-plan.mjs
+++ b/release/scripts/build-release-plan.mjs
@@ -14,6 +14,38 @@ import { createHash } from 'node:crypto';
 const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const unitsDir = join(root, 'release', 'units');
 
+// Go's import-compatibility rule binds a module's version to its path: a path
+// ending `/vN` carries only vN.y.z, and an unsuffixed path only v0 and v1. So
+// pathMajor is the ONLY major a coordinate can publish — 1 when unsuffixed.
+const pathMajorOf = (coordinate) => Number(coordinate.match(/\/v(\d+)$/)?.[1] ?? 1);
+
+// A major bump advances the unit version; it does NOT rename the module path,
+// which is a separate and deliberate first step of a major release (every import
+// in the tree moves with it). Emitting the plan regardless produced coordinates
+// that cannot exist — `github.com/trianalab/pacto/v3` at `v4.0.0` is not a
+// version whose artifact is merely missing, it is a require go refuses to parse:
+//
+//	go.mod:79:2: require github.com/trianalab/pacto/v3: version "v4.0.0" invalid:
+//	should be v3, not v4
+//
+// and apply-release-plan.mjs wrote exactly that into the operator's go.mod. Refuse
+// to emit the plan instead. The release stops here, before the Version PR exists,
+// with the missing step named — rather than mid-transaction with tags pushed.
+function assertVersionFitsPath(what, coordinate, version, pathFix) {
+  const pathMajor = pathMajorOf(coordinate);
+  const verMajor = Number(String(version).replace(/^v/, '').split('.')[0]);
+  const fits = pathMajor >= 2 ? verMajor === pathMajor : verMajor <= 1;
+  if (fits) return;
+  const carries = pathMajor >= 2 ? `v${pathMajor}.y.z` : 'v0.y.z and v1.y.z';
+  throw new Error(
+    `release plan refuses to emit: ${what} would publish ${coordinate} at v${String(version).replace(/^v/, '')}, ` +
+    `but that module path carries only ${carries}.\n` +
+    `A major bump does not rename the module path. Rename it to ` +
+    `${coordinate.replace(/\/v\d+$/, '')}/v${verMajor} first — the import path, every importer, ` +
+    `${pathFix} — then land the major changeset. See docs/maintainers/releases.md.`,
+  );
+}
+
 function readUnits() {
   const out = {};
   for (const id of readdirSync(unitsDir).sort()) {
@@ -33,10 +65,12 @@ function buildPlan(u) {
   // compatibility from the PATH major, not the un-bumped unit version — this
   // keeps the go.work dev build + apply-release-plan on a valid vN and lands
   // exactly on vN.0.0 when the major changeset applies.
-  const pathMajor = Number((u['core'].coordinate.match(/\/v(\d+)$/) || [, core.split('.')[0]])[1]);
+  const pathMajor = pathMajorOf(u['core'].coordinate);
   const coreMajor = Number(core.split('.')[0]);
   const pinVersion = pathMajor > coreMajor ? `v${pathMajor}.0.0` : `v${core}`;
   const compatMajor = Math.max(pathMajor, coreMajor);
+  assertVersionFitsPath('the core group', u['core'].coordinate, pinVersion,
+    'the /vN suffix in this coordinate, and go.work\'s replace');
   // The Kubernetes Go module path carries its OWN major (.../integrations/
   // kubernetes/vN). A Go module tag must live on the module path's major, so the
   // nested-module tag has to track the PATH major, not the un-bumped unit version
@@ -45,10 +79,12 @@ function buildPlan(u) {
   // baseline from the path major so a /v5 module never gets a v4 tag; it lands on
   // the real v5.x when the major changeset bumps the unit. The image, chart and
   // docs stay on the unit version (they are OCI/doc versions, not Go modules).
-  const k8sPathMajor = Number((u['k8s-module'].coordinate.match(/\/v(\d+)$/) || [, k8s.split('.')[0]])[1]);
+  const k8sPathMajor = pathMajorOf(u['k8s-module'].coordinate);
   const k8sMajor = Number(k8s.split('.')[0]);
   const k8sModuleVersion = k8sPathMajor > k8sMajor ? `${k8sPathMajor}.0.0` : k8s;
   const k8sModuleTag = `integrations/kubernetes/v${k8sModuleVersion}`;
+  assertVersionFitsPath('the kubernetes group', u['k8s-module'].coordinate, k8sModuleVersion,
+    'the directory suffix in the module tag, and the operator\'s own module line');
   // Fixed groups: core line and k8s line move as a unit.
   const plan = {
     schema: 'pacto-release-plan/v1',

--- a/release/scripts/docs_check.py
+++ b/release/scripts/docs_check.py
@@ -798,6 +798,11 @@ def check_unreleased_versions() -> None:
         if v not in post_mortem:
             problems.append(f"{v} is listed as unreleased but docs/maintainers/releases.md never explains it")
 
+    # Each record links to its OWN post-mortem -- they are separate transactions --
+    # so the anchors must resolve. Not checked here: mkdocs.yml sets
+    # validation.links.anchors=warn and check (c) builds --strict, so a heading that
+    # stops producing one of these anchors already fails the build.
+
     # The converse: a version the post-mortem calls abandoned must be disclosed.
     for v in re.findall(r"Abandoned transaction[^\n]*?\(([0-9./ ]+)\)", post_mortem):
         for ver in re.findall(r"\d+\.\d+\.\d+", v):
@@ -806,7 +811,7 @@ def check_unreleased_versions() -> None:
 
     ok = not problems
     record(ok, "(o) unreleased versions are disclosed on the Changelog",
-           f"{len(_UNRELEASED_VERSIONS)} tagged-but-unreleased versions disclosed"
+           f"{len(_UNRELEASED_VERSIONS)} abandoned versions disclosed, each linked to its post-mortem"
            if ok else " ; ".join(problems[:5]))
 
 

--- a/release/scripts/mkdocs_integration_hook.py
+++ b/release/scripts/mkdocs_integration_hook.py
@@ -28,6 +28,7 @@ import glob
 import json
 import os
 import re
+from collections import namedtuple
 
 import yaml
 from mkdocs.structure.files import File
@@ -69,28 +70,51 @@ def _pages(docs_dir: str):
 _FENCE = re.compile(r"^\s*(```|~~~)")
 _HEADING = re.compile(r"^#{1,6}\s")
 
-# Versions whose Changesets entry exists -- the version bump succeeded -- but
-# whose publishing transaction was abandoned, so no GitHub Release was ever cut.
-# The Changesets files below are the historical record and must not be rewritten
-# to hide them, so the assembled page says it instead. Keep in step with the
-# post-mortem on docs/maintainers/releases.md, which docs-check (o) enforces.
-_UNRELEASED_VERSIONS = ("3.2.0", "5.2.0")
-_SUPERSEDED_BY = ("3.2.1", "5.2.1")
+# Versions whose Changesets entry exists -- the version bump succeeded -- but whose
+# publishing transaction was abandoned, so the version was never released. The
+# Changesets files are the historical record and must not be rewritten to hide them,
+# so the assembled page says it instead. Keep in step with the post-mortems on
+# docs/maintainers/releases.md, which docs-check (o) enforces in both directions.
+#
+# One record per version, not one shared paragraph. They did not fail the same way:
+# 3.2.0 and 5.2.0 are tagged and resolve through the module proxy, while 5.2.2 was
+# never tagged at all, so prose saying "their tags resolve" and "neither has a GitHub
+# Release" is wrong for the third and cannot stretch to a fourth. Each record carries
+# its own supersedor and its own post-mortem anchor, because they are two transactions.
+_Ghost = namedtuple("_Ghost", "version superseded_by what_happened anchor")
+
+_PROXY_ONLY = (
+    "tagged and resolvable through the Go module proxy, but never given a GitHub "
+    "Release"
+)
+_ANCHOR_320_520 = "abandoned-transaction-522e9507410f16fc-320-520"
+
+_UNRELEASED = (
+    _Ghost("3.2.0", "3.2.1", _PROXY_ONLY, _ANCHOR_320_520),
+    _Ghost("5.2.0", "5.2.1", _PROXY_ONLY, _ANCHOR_320_520),
+    _Ghost(
+        "5.2.2",
+        "5.2.3",
+        "never published at all — no module tag, no operator image, no chart — "
+        "because every publisher skipped while the run still reported success",
+        "abandoned-transaction-3bf445d36fd2c3fc-522",
+    ),
+)
+
+_UNRELEASED_VERSIONS = tuple(g.version for g in _UNRELEASED)
 
 _UNRELEASED_NOTE = (
-    '!!! warning "{ghosts} have release notes below, but were never released"\n\n'
-    "    Their version bump succeeded and their tags resolve through the Go "
-    "module proxy, but the transaction that would have published them was "
-    "abandoned part-way through. Neither has a GitHub Release, and both "
-    "`pacto update` and the installer script's `--version` resolve releases "
-    "through the GitHub API — so neither version is installable by either "
-    "route. Use **{fixed}** instead: they supersede {ghosts} and contain "
-    "everything listed under them. The "
-    "[release ledger](maintainers/releases.md"
-    "#abandoned-transaction-522e9507410f16fc-320-520) has the post-mortem."
-).format(
-    ghosts=" and ".join(_UNRELEASED_VERSIONS),
-    fixed=" and ".join(_SUPERSEDED_BY),
+    '!!! warning "Some versions have release notes below, but were never released"\n\n'
+    "    A version bump can succeed and its publishing transaction still be abandoned "
+    "part-way through. `pacto update` and the installer script's `--version` both "
+    "resolve releases through the GitHub API, so none of the versions below is "
+    "installable by either route. Use the superseding version instead: it contains "
+    "everything listed under the version it replaces.\n\n"
+    + "".join(
+        "    - **{g.version}** — {g.what_happened}. Superseded by **{g.superseded_by}** "
+        "([post-mortem](maintainers/releases.md#{g.anchor})).\n".format(g=g)
+        for g in _UNRELEASED
+    )
 )
 
 _CHANGELOG_INTRO = (

--- a/release/scripts/staging-tags.sh
+++ b/release/scripts/staging-tags.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Local git tags staged on HEAD for the standalone-consumer checks — and put back
+# exactly as they were found. Source this; it defines two functions and runs nothing.
+#
+# Those checks resolve a Go module out of THIS checkout by pointing go at a tag, so
+# the tag has to name HEAD: the tree the release is about to publish, not the tree
+# the last release published. Between releases the names they stage —
+# `integrations/kubernetes/v5.4.1`, `v3.3.1` — are REAL published tags, and any
+# maintainer who has run `git fetch --tags` holds them locally, pointing at their
+# actual release commits. Staging therefore has to force-move a tag that already
+# exists, and both callers used to clean up by deleting it: a check that reads
+# nothing and publishes nothing was quietly destroying release history in the
+# maintainer's clone. (Never in CI, which clones fresh and throws the clone away —
+# which is why it went unnoticed.)
+#
+# So remember where each tag pointed and restore that ref on the way out, deleting
+# only the tags we created ourselves. `update-ref` restores the ref's exact object,
+# so an annotated tag comes back annotated. Callers must trap restore_staged_tags
+# on EXIT, not call it on the happy path — a check that fails mid-way is exactly
+# when the tags most need putting back.
+
+# _staged accumulates "<sha|-> <tag>" lines, oldest first. A plain string rather
+# than an array: this is sourced by scripts that may run under bash 3.2, where
+# expanding an empty array under `set -u` is an error.
+_staged_repo=""
+_staged=""
+
+# stage_tag <repo> <tag> — force <tag> onto HEAD, remembering where it pointed.
+stage_tag() {
+  local sha
+  _staged_repo="$1"
+  sha="$(git -C "$1" rev-parse -q --verify "refs/tags/$2" 2>/dev/null || true)"
+  _staged="${_staged}${sha:--} $2
+"
+  git -C "$1" tag -f "$2" HEAD >/dev/null 2>&1
+}
+
+# restore_staged_tags — restore every staged tag to the object it named, or delete
+# the ones that did not exist before. Idempotent, and safe to trap unconditionally.
+restore_staged_tags() {
+  [ -n "$_staged" ] || return 0
+  local sha tag
+  while read -r sha tag; do
+    [ -n "$tag" ] || continue
+    if [ "$sha" = "-" ]; then
+      git -C "$_staged_repo" update-ref -d "refs/tags/$tag" >/dev/null 2>&1 || true
+    else
+      git -C "$_staged_repo" update-ref "refs/tags/$tag" "$sha" >/dev/null 2>&1 || true
+    fi
+  done <<EOF
+$_staged
+EOF
+  _staged=""
+}

--- a/release/scripts/verify-standalone.sh
+++ b/release/scripts/verify-standalone.sh
@@ -6,6 +6,7 @@
 # git config (never the user's global) + a throwaway module cache. No network, no publish.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/release/scripts/staging-tags.sh"
 # NEXT core version = current @pacto/core version bumped by the strongest pending changeset.
 NEXT="$(node -e '
 const fs=require("fs"),path=require("path");
@@ -33,7 +34,11 @@ if [ "$NEXT" = "$(node -e 'console.log(require("'"$ROOT"'/release/units/pacto-co
   echo "note: no pending core bump — current core already published + proven standalone; skipping"
   exit 0
 fi
-git -C "$ROOT" tag -f "v${NEXT}" HEAD >/dev/null 2>&1   # reproducible local staging tag (deleted at end)
+# Everything below can fail — a build error, a proxy timeout, a ^C — and the only
+# tag deletion used to be the last line of the script, so any of those leaked the
+# staging tag into the maintainer's clone. Trap the restore before staging.
+trap restore_staged_tags EXIT
+stage_tag "$ROOT" "v${NEXT}"                            # reproducible local staging tag
 TMPGIT="$(mktemp)"; printf '[url "file://%s"]\n\tinsteadOf = https://github.com/trianalab/pacto\n' "$ROOT" > "$TMPGIT"
 WORK="$(mktemp -d)"; mkdir -p "$WORK/op"; tar -C "$ROOT/integrations/kubernetes" --exclude=bin --exclude=.github --exclude=node_modules -cf - . | tar -C "$WORK/op" -xf -
 perl -i -pe "s{github.com/trianalab/pacto/v3 v[0-9][0-9.]*}{github.com/trianalab/pacto/v3 v${NEXT}}" "$WORK/op/go.mod"
@@ -45,4 +50,3 @@ echo "go mod download (external, GOWORK=off)..."; bash "$ROOT"/release/scripts/r
 echo "go build ./... (standalone operator, no go.work, no replace)..."
 go build ./... && go build -o /dev/null ./cmd
 echo "STANDALONE-VERIFY OK: operator module builds against published core v${NEXT}, GOWORK=off, replace=0"
-git -C "$ROOT" tag -d "v${NEXT}" >/dev/null 2>&1 || true

--- a/tests/release/dry_run_gate_test.go
+++ b/tests/release/dry_run_gate_test.go
@@ -1,0 +1,143 @@
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// `make release-dry-run` READS the pending changesets: verify-standalone.sh
+// computes the next core version from them, and build-release-plan.mjs turns
+// them into the plan the whole rehearsal is built on. So a pull request that
+// adds nothing but a changeset changes the dry run's input, and must run it.
+//
+// It did not. ci.yml gated release-dry-run on the `e2e` path filter, which has
+// no '.changeset/**' entry — deliberately, because a changeset cannot affect
+// the kind or Compose legs that share that filter. The `release` filter does
+// list it, and its comment even names this job, but nothing consumed that
+// output here. The result: the one pull request class that OPENS a release
+// transaction was the one class the dry run never rehearsed. Observed on #370,
+// which adds a single .changeset/*.md and nothing else: `release-dry-run
+// skipping`, while release-version-test (gated on `release`) ran.
+//
+// Coverage was usually restored by accident — the code pull request that
+// motivated the changeset touches a watched path and rehearses nearly the same
+// tree — which is exactly why this went unnoticed. This gate does not depend on
+// that accident.
+func TestReleaseDryRunIsGatedOnAFilterWatchingChangesets(t *testing.T) {
+	root := repoRoot(t)
+
+	// Non-vacuity: if the dry run ever stops reading changesets, this gate is
+	// obsolete and should be deleted rather than left passing over nothing.
+	if !dryRunReadsChangesets(t, root) {
+		t.Fatal("no file under release/ reads .changeset any more — `make release-dry-run` no longer " +
+			"depends on pending changesets, so this gate proves nothing. Delete it.")
+	}
+
+	// Which path filters watch .changeset/**? Parsed from the live filter block,
+	// so moving the entry between filters keeps the gate honest.
+	watching := filtersWatchingChangesets(t, root)
+	if len(watching) == 0 {
+		t.Fatal("no path filter in ci.yml lists '.changeset/**' — a changeset-only pull request now " +
+			"triggers no path-filtered job at all")
+	}
+
+	var doc struct {
+		Jobs map[string]struct {
+			If string `yaml:"if"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal([]byte(readFile(t, root, ".github", "workflows", "ci.yml")), &doc); err != nil {
+		t.Fatalf("parse ci.yml: %v", err)
+	}
+	job, ok := doc.Jobs["release-dry-run"]
+	if !ok {
+		t.Fatal("ci.yml has no release-dry-run job")
+	}
+	for _, f := range watching {
+		if strings.Contains(job.If, "needs.changes.outputs."+f) {
+			return
+		}
+	}
+	t.Errorf("release-dry-run's `if:` consumes none of the filters that watch '.changeset/**' (%s), so a "+
+		"changeset-only pull request skips it — and that is the pull request that opens the release "+
+		"transaction the dry run exists to rehearse.\n  if: %s", strings.Join(watching, ", "), job.If)
+}
+
+// filtersWatchingChangesets returns the names of the dorny/paths-filter filters
+// whose path list includes a '.changeset/' pattern.
+func filtersWatchingChangesets(t *testing.T, root string) []string {
+	t.Helper()
+	var doc struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				With struct {
+					Filters string `yaml:"filters"`
+				} `yaml:"with"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal([]byte(readFile(t, root, ".github", "workflows", "ci.yml")), &doc); err != nil {
+		t.Fatalf("parse ci.yml: %v", err)
+	}
+	// The filters value is itself YAML: filter name -> list of path patterns.
+	for _, job := range doc.Jobs {
+		for _, step := range job.Steps {
+			if step.With.Filters == "" {
+				continue
+			}
+			var filters map[string][]string
+			if err := yaml.Unmarshal([]byte(step.With.Filters), &filters); err != nil {
+				t.Fatalf("parse paths-filter filters block: %v", err)
+			}
+			var out []string
+			for name, patterns := range filters {
+				for _, p := range patterns {
+					if strings.Contains(p, ".changeset/") {
+						out = append(out, name)
+						break
+					}
+				}
+			}
+			slices.Sort(out) // map iteration order is random; the failure message is not
+			return out
+		}
+	}
+	t.Fatal("ci.yml has no dorny/paths-filter step with a `filters:` block")
+	return nil
+}
+
+// changesetReadRE matches a real read of the changeset directory, not the word
+// "changeset" in prose: a path segment, which is how every reader spells it.
+var changesetReadRE = regexp.MustCompile(`\.changeset[/"']`)
+
+// dryRunReadsChangesets reports whether anything `make release-dry-run` runs
+// still reads the changeset directory.
+func dryRunReadsChangesets(t *testing.T, root string) bool {
+	t.Helper()
+	found := false
+	err := filepath.WalkDir(filepath.Join(root, "release"), func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || found {
+			return err
+		}
+		switch filepath.Ext(path) {
+		case ".sh", ".mjs", ".js":
+		default:
+			return nil
+		}
+		b, e := os.ReadFile(path)
+		if e == nil && changesetReadRE.Match(b) {
+			found = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk release/: %v", err)
+	}
+	return found
+}

--- a/tests/release/staging_tags_test.go
+++ b/tests/release/staging_tags_test.go
@@ -1,0 +1,167 @@
+package release
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The standalone-consumer checks resolve a Go module out of the working checkout
+// by pointing go at a tag, so the tag must name HEAD — the tree about to be
+// published, not the tree the last release published. The names they stage are
+// real published tags between releases (`v3.3.1`, `integrations/kubernetes/
+// v5.4.1`), and a maintainer who has fetched tags holds them locally pointing at
+// their actual release commits. Staging therefore force-moves them, and both
+// callers used to clean up by DELETING: a read-only check was destroying release
+// history in the maintainer's clone. CI never noticed, because CI clones fresh
+// and throws the clone away.
+//
+// release/scripts/staging-tags.sh exists to make the staging reversible. These
+// tests drive it against a real throwaway repository — the bug was in what git
+// ends up holding, so asserting on anything less would not have caught it.
+
+// gitRepo builds a throwaway repository with two commits and returns its path
+// plus the two commit shas, oldest first.
+func gitRepo(t *testing.T) (dir, first, head string) {
+	t.Helper()
+	dir = t.TempDir()
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	run("init", "-q", "-b", "main")
+	for _, msg := range []string{"one", "two"} {
+		if err := os.WriteFile(filepath.Join(dir, msg), []byte(msg), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		run("add", msg)
+		run("commit", "-q", "-m", msg)
+	}
+	return dir, run("rev-parse", "HEAD~1"), run("rev-parse", "HEAD")
+}
+
+// stagingScript runs a bash snippet with staging-tags.sh sourced, in `dir`.
+// wantFail asserts the snippet exits non-zero, which is how the EXIT trap is
+// exercised on the path that actually leaked tags.
+func stagingScript(t *testing.T, dir, body string, wantFail bool) {
+	t.Helper()
+	script := "set -euo pipefail\n. " + filepath.Join(repoRoot(t), "release", "scripts", "staging-tags.sh") + "\n" + body
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if wantFail && err == nil {
+		t.Fatalf("snippet was expected to fail but exited 0:\n%s", out)
+	}
+	if !wantFail && err != nil {
+		t.Fatalf("snippet failed: %v\n%s", err, out)
+	}
+}
+
+// tagSha resolves a tag ref, or "" when it does not exist.
+func tagSha(t *testing.T, dir, tag string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "-q", "--verify", "refs/tags/"+tag).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestStagingTagsRestoresAPreexistingTag(t *testing.T) {
+	dir, first, head := gitRepo(t)
+	const tag = "integrations/kubernetes/v5.4.1" // a real published name, slashes and all
+
+	if out, err := exec.Command("git", "-C", dir, "tag", tag, first).CombinedOutput(); err != nil {
+		t.Fatalf("seed tag: %v\n%s", err, out)
+	}
+	stagingScript(t, dir, `
+stage_tag "$PWD" `+tag+`
+[ "$(git rev-parse refs/tags/`+tag+`)" = "`+head+`" ] || { echo "stage_tag did not move the tag to HEAD"; exit 1; }
+restore_staged_tags
+`, false)
+
+	if got := tagSha(t, dir, tag); got != first {
+		t.Errorf("published tag %s not restored: points at %q, want the commit it named before staging (%q).\n"+
+			"A read-only standalone check must leave the maintainer's clone exactly as it found it.", tag, got, first)
+	}
+}
+
+func TestStagingTagsDeletesOnlyWhatItCreated(t *testing.T) {
+	dir, _, head := gitRepo(t)
+	const tag = "v9.9.9" // not published, not present: ours to create and remove
+
+	stagingScript(t, dir, `
+stage_tag "$PWD" `+tag+`
+[ "$(git rev-parse refs/tags/`+tag+`)" = "`+head+`" ] || { echo "stage_tag did not create the tag at HEAD"; exit 1; }
+restore_staged_tags
+`, false)
+
+	if got := tagSha(t, dir, tag); got != "" {
+		t.Errorf("staging tag %s survived the restore at %q — a tag we created must not leak into the clone", tag, got)
+	}
+}
+
+func TestStagingTagsRestoresWhenTheCheckFails(t *testing.T) {
+	dir, first, _ := gitRepo(t)
+	const existing, created = "v3.3.1", "v3.4.0"
+
+	if out, err := exec.Command("git", "-C", dir, "tag", existing, first).CombinedOutput(); err != nil {
+		t.Fatalf("seed tag: %v\n%s", err, out)
+	}
+	// The shape both callers use: trap the restore, stage, then fail part-way.
+	// verify-standalone.sh's only deletion used to be its last line, so every
+	// failure between staging and success leaked the tag.
+	stagingScript(t, dir, `
+trap restore_staged_tags EXIT
+stage_tag "$PWD" `+existing+`
+stage_tag "$PWD" `+created+`
+echo "pretend the standalone build failed here" >&2
+exit 1
+`, true)
+
+	if got := tagSha(t, dir, existing); got != first {
+		t.Errorf("after a failed check, %s points at %q, want %q — the EXIT trap did not restore it", existing, got, first)
+	}
+	if got := tagSha(t, dir, created); got != "" {
+		t.Errorf("after a failed check, staging tag %s survived at %q", created, got)
+	}
+}
+
+// The two callers must trap the restore rather than call it on the happy path;
+// a check that fails mid-way is exactly when the tags need putting back. And
+// neither may keep a bare `git tag -d` for a name it staged — that is the
+// original bug, and it reads as cleanup.
+func TestStandaloneChecksTrapTheRestore(t *testing.T) {
+	root := repoRoot(t)
+	for _, rel := range [][]string{
+		{"release", "scripts", "verify-standalone.sh"},
+		{"release", "orchestrator", "verify-k8s-standalone.sh"},
+	} {
+		name := filepath.Join(rel...)
+		body := readFile(t, root, rel...)
+		if !strings.Contains(body, "staging-tags.sh") {
+			t.Errorf("%s stages tags without release/scripts/staging-tags.sh, so nothing restores them", name)
+			continue
+		}
+		if !strings.Contains(body, "trap") || !strings.Contains(body, "restore_staged_tags") {
+			t.Errorf("%s does not trap restore_staged_tags on EXIT — a failure mid-check leaks the staging tags", name)
+		}
+		if strings.Contains(body, "tag -d") {
+			t.Errorf("%s still deletes a tag directly; the staged names are real published tags between "+
+				"releases, so deletion destroys them. Let restore_staged_tags decide.", name)
+		}
+		if strings.Contains(body, "tag -f") {
+			t.Errorf("%s force-moves a tag directly, bypassing the record stage_tag needs to restore it", name)
+		}
+	}
+}


### PR DESCRIPTION
Four loose ends from the 5.2.2 / 5.3.0 release incidents, each with a permanent
gate. They share a theme — the release machinery had gaps that only open on the
rarest PR shapes — so they land together.

## 1. The dry run skipped the one PR class that opens a release

`release-dry-run` was gated on the `e2e` paths filter, which has no
`.changeset/**` entry. That omission is correct for the filter's other three
consumers (`operator-build`, `ci-e2e-kind`, `ci-e2e-compose`) — a changeset
cannot affect a kind or Compose leg — but the dry run *reads* the pending
changesets: `verify-standalone.sh` computes the next core version from them, and
`build-release-plan.mjs` turns them into the plan it rehearses. So the one PR
class that opens a release transaction was the one class the rehearsal never saw.

Gate the job on `release` as well as `e2e`, rather than widening a filter three
heavy legs share. `tests/release/dry_run_gate_test.go` parses the live filter
block and the live job condition, walks `release/` for scripts that read
`.changeset`, and fails if the job is gated only on filters that ignore it. It
self-invalidates: if nothing under `release/` ever reads changesets again, the
test tells you to delete it.

The changesets Version PR is excluded — its changesets are already consumed, so
the dry run's pending-bump scenarios do not apply there.

## 2. A major bump wrote a go.mod Go cannot parse

Go binds a module's version to its import path: `/v3` carries only `v3.y.z`. A
major changeset moves the version and does not move the path, so
`release:version` happily produced

```
require github.com/trianalab/pacto/v3 v4.0.0
```

which fails to parse. `apply-release-plan.mjs` had a `console.warn` for this and
wrote the require anyway; the plan builder had no check at all. The same bug
existed twice — the core pin and the Kubernetes module tag both derive a version
without consulting the path major.

`build-release-plan.mjs` now refuses to emit such a plan, from a single
`assertVersionFitsPath` helper used by both derivations, with an error naming
everything the rename has to touch. `apply-release-plan.mjs`'s warning becomes a
hard assert, moved ahead of the write. The release stops before the Version PR
exists rather than mid-transaction.

`test-release-version.sh` gains case D, which stages a real major changeset,
runs the real `npm run release:version`, and asserts it refuses and leaves the
operator go.mod untouched. Cases B and C moved from `major` to `minor` so they
still exercise the happy path. `docs/maintainers/releases.md` documents the
rename as a deliberate first commit of a major release.

## 3. Two read-only checks were deleting real published tags

`verify-standalone.sh` and `verify-k8s-standalone.sh` stage local tags so a
standalone module graph resolves against the working tree. The names they stage
are real published tags between releases (`v3.3.1`,
`integrations/kubernetes/v5.4.1`), and a maintainer who has fetched tags holds
them pointing at their actual release commits. Both scripts cleaned up by
*deleting* — so a read-only check destroyed release history in the local clone.
`verify-standalone.sh` also had no trap, so any failure between staging and its
last line leaked the staging tag.

New `release/scripts/staging-tags.sh` records where each tag pointed and restores
it with `git update-ref` (which puts back the exact object, annotated tag or
commit), deleting only names it created. Both callers trap it on EXIT, before
staging. `tests/release/staging_tags_test.go` drives the helper against a real
throwaway repository — the bug was in what git ends up holding — including the
failure path, plus a static check that neither caller keeps a bare `tag -d` or
`tag -f`.

Verified against the working clone: `verify-k8s-standalone.sh` now completes with
all 165 local tags byte-identical.

## 4. The Changelog advertises 5.2.2, which published nothing

Transaction `3bf445d36fd2c3fc` published no module tag, no operator image and no
chart, and the run still reported success. 5.2.2 therefore has release notes on
pacto.run with nothing behind them and no warning above them.

The existing ghost admonition covered 3.2.0 and 5.2.0 in one shared paragraph
whose prose was specific to how *they* failed ("their tags resolve through the Go
module proxy", "neither has a GitHub Release") — neither sentence is true of
5.2.2. Replace it with one record per version, each carrying its own supersedor,
its own description and its own post-mortem anchor. A fourth ghost is now a tuple
entry rather than a rewrite.

The 5.2.2 post-mortem is separate from the 3.2.0/5.2.0 one because the
operational advice differs: those two have live tags and a ledger that keeps a
recovery dispatch armed, while 5.2.2 has nothing to adopt, nothing to conflict
with and nothing to recover.

docs-check `(o)` already enforces the disclosure in both directions and holds for
the new record; its success line said "tagged-but-unreleased", which 5.2.2 is not.

## Verification

- `make docs-check` — 16/16, including a deliberate anchor break to confirm the
  strict build catches a bad post-mortem link (`validation.links.anchors`).
- `go test ./tests/release/` — passes; both new tests confirmed red against the
  pre-fix state (the old `if:` condition; the old `tag -f` + `tag -d` sequence in
  a scratch repo).
- `release/orchestrator/test-release-version.sh` — A, B, C, D pass.
- `verify-k8s-standalone.sh` and `verify-standalone.sh` run against the working
  clone, tags unchanged.
- `make lint`, `make check-section`.